### PR TITLE
TASK-817578483: containerize the review daemon (Docker + entrypoint)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ at startup if it isn't.
 alissa-reviewloop         # foreground; tip: run it in its own tmux session
 ```
 
+### In a container
+
+To run the whole loop unattended in Docker — the poller, an `alissa worker`, and
+the `claude` reviewer it spawns, bundled in one image — see
+[`docker/claude/`](./docker/claude/README.md).
+
 ### Settings
 
 Three layers, each winning over the one before: **defaults → config file → CLI**.

--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -1,0 +1,103 @@
+# syntax=docker/dockerfile:1
+# =============================================================================
+# Alissa — GitHub Review Daemon (claude reviewer runtime)
+#
+# This image is NOT just the poller. The daemon (`alissa-reviewloop`) is thin: it
+# watches GitHub and enqueues reviewer sessions via `alissa tmux queue add`. The
+# real review work is done by `alissa worker`, which drains that queue and spawns
+# `claude` reviewer agents inside worktree-hub directories. So the image bundles
+# all three tiers:
+#
+#   * python 3.12 + alissa-tools-github-reviewloop  (the poller, from PyPI)
+#   * node + the alissa CLI                          (worker, tmux queue, tasks)
+#   * claude-code                                    (the agent the worker spawns)
+#
+# Build context is this directory (docker/claude) — the image pulls the daemon
+# from PyPI, so no repo source is copied in.
+#
+#   docker build -t alissa-review-daemon docker/claude
+#
+# Run: see docker/claude/README.md and ../../README.md.
+# =============================================================================
+
+# Base is pinned to python 3.12 (matches the repo's .python-version); Node 22 is
+# layered on via NodeSource. The daemon needs python >= 3.11; the alissa CLI and
+# claude-code need Node >= 18 — both satisfied.
+FROM python:3.12-slim-bookworm
+
+# Version of the daemon to install from PyPI. Bump per release.
+ARG REVIEWLOOP_VERSION=0.2.0
+# Node major version (must be >= 18 for the alissa CLI and claude-code).
+ARG NODE_MAJOR=22
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# --- System dependencies ------------------------------------------------------
+# git   : reviewers operate over git worktree hubs
+# tmux  : the alissa worker manages tmux (ali-*) sessions
+# gh     : the daemon shells out to `gh api` for the review queue
+# tini   : PID 1 init — reaps the tmux/node/claude child fan-out
+# sudo   : only used by the optional firewall init (dropped priv otherwise)
+# iptables/ipset : only used by the optional firewall init
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates curl gnupg git tmux tini sudo \
+        iptables ipset procps jq less; \
+    # GitHub CLI apt repo
+    mkdir -p /etc/apt/keyrings; \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /etc/apt/keyrings/githubcli-archive-keyring.gpg; \
+    chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list; \
+    # Node.js via NodeSource
+    curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash -; \
+    apt-get install -y --no-install-recommends gh nodejs; \
+    rm -rf /var/lib/apt/lists/*
+
+# --- claude-code (the reviewer agent) ----------------------------------------
+RUN npm install -g @anthropic-ai/claude-code \
+    && npm cache clean --force
+
+# --- The review daemon (from PyPI) -------------------------------------------
+# Installs the `alissa-reviewloop` console script into /usr/local/bin.
+RUN pip install "alissa-tools-github-reviewloop==${REVIEWLOOP_VERSION}"
+
+# --- Non-root runtime user ----------------------------------------------------
+# Agents run unattended with three live tokens; don't run them as root. The
+# firewall init (optional) is the only thing that needs root, via a narrow
+# sudoers entry.
+RUN useradd --create-home --shell /bin/bash --uid 1000 alissa \
+    && echo 'alissa ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh' \
+        > /etc/sudoers.d/alissa-firewall \
+    && chmod 0440 /etc/sudoers.d/alissa-firewall \
+    && mkdir -p /workspace \
+    && chown alissa:alissa /workspace
+
+# --- Entrypoint + optional firewall ------------------------------------------
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY init-firewall.sh /usr/local/bin/init-firewall.sh
+RUN chmod 0755 /usr/local/bin/entrypoint.sh /usr/local/bin/init-firewall.sh
+
+USER alissa
+WORKDIR /home/alissa
+
+# The alissa CLI installer is npm-free: it drops a `node cli.mjs` launcher into
+# ~/.local/bin. Run it as the target user so it lands in the user's home.
+ENV PATH="/home/alissa/.local/bin:${PATH}"
+RUN curl -fsSL https://share.alissa.app/install | bash
+
+# Workspace root that the daemon and reviewers operate over. Mount a manifest
+# here, or let the entrypoint generate one from env (see README).
+ENV ALISSA_WORKSPACE_ROOT=/workspace \
+    ALISSA_WORKSPACE=alissa-review \
+    TMUX_TMPDIR=/home/alissa/.tmux
+RUN mkdir -p /home/alissa/.tmux
+WORKDIR /workspace
+
+# tini reaps the worker/tmux/claude child fan-out; entrypoint does the rest.
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -138,8 +138,14 @@ RUN git config --global user.name  "alissa-review-daemon" \
 # Workspace root that the daemon and reviewers operate over. Mount a manifest
 # here, or let the entrypoint generate one from the config below (see README).
 # These are fixed internal paths, not meant to be reconfigured.
+#
+# CLAUDE_CONFIG_DIR points claude's config — crucially its OAuth credential file
+# `.credentials.json` — at a folder ON the /workspace volume, so a one-time
+# `claude /login` survives restarts and auto-renews (a static CLAUDE_CODE_OAUTH_
+# TOKEN expires and 401s). If you relocate the volume, move this with it.
 ENV ALISSA_WORKSPACE_ROOT=/workspace \
-    TMUX_TMPDIR=/home/alissa/.tmux
+    TMUX_TMPDIR=/home/alissa/.tmux \
+    CLAUDE_CONFIG_DIR=/workspace/.claude-config
 RUN mkdir -p /home/alissa/.tmux
 WORKDIR /workspace
 

--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -109,6 +109,25 @@ RUN curl -fsSL https://share.alissa.app/install | bash
 # prompt. Mount your own over this path at runtime to override.
 COPY --chown=alissa:alissa agents.yaml /home/alissa/.config/alissa/agents.yaml
 
+# --- claude first-run gates: pre-seed so the TUI starts READY, no human ------
+# A brand-new user hits claude's first-run dialogs (welcome/onboarding, theme
+# picker, and the one-time --dangerously-skip-permissions "bypass mode" warning)
+# and the worker hangs forever: "agent UI not ready — a first-run/trust dialog
+# needs a human". These are the exact keys the working host carries, split across
+# the two files claude reads:
+#   ~/.claude.json          — user state: onboarding completed, warnings seen
+#   ~/.claude/settings.json — settings: skip the bypass-mode prompt, theme, TUI
+# skipDangerousModePermissionPrompt is the key the public docs omit; it is what
+# lets `claude --dangerously-skip-permissions` come up without a keypress.
+# Auth is still required and stays in the env (CLAUDE_CODE_OAUTH_TOKEN preferred
+# — an interactive TUI would prompt to approve a bare ANTHROPIC_API_KEY).
+RUN mkdir -p /home/alissa/.claude \
+    && CLAUDE_VER="$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" \
+    && printf '{\n  "hasCompletedOnboarding": true,\n  "hasSeenAutoModeEntryWarning": true,\n  "lastOnboardingVersion": "%s"\n}\n' "${CLAUDE_VER:-2.1.215}" \
+        > /home/alissa/.claude.json \
+    && printf '{\n  "skipDangerousModePermissionPrompt": true,\n  "theme": "dark",\n  "tui": "fullscreen"\n}\n' \
+        > /home/alissa/.claude/settings.json
+
 # A git identity so any git operation (e.g. the clone in hub-ify) has an author
 # and never drops into git's interactive "who are you" prompt. Reviewers are
 # read-only (CR6), so this is a safety default, not a committing identity.

--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -170,6 +170,13 @@ WORKDIR /workspace
 ARG ALISSA_REVIEW_REPOS=""
 # Workspace name recorded in the generated manifest.
 ARG ALISSA_WORKSPACE="alissa-review"
+# Skills installed into every reviewer session (manifest `skills:`), "|"-separated.
+# alissa-code-review is the review protocol the reviewer directive loads; the
+# workspace skill is for navigating the hubs. alissa-session/-skills-usage are
+# auto-installed by `alissa code`, so they need not be listed. Deliberately NOT
+# alissa-code-orchestration (reviewers must not spawn ali-* sessions) or
+# alissa-code-git (read-only reviewers never commit).
+ARG ALISSA_REVIEW_SKILLS="alissa-code-workspace|alissa-code-review"
 # Daemon knobs (see the daemon README's settings table).
 ARG ALISSA_POLL_INTERVAL="60"
 ARG ALISSA_ROUND_CAP="3"
@@ -183,6 +190,7 @@ ARG ALISSA_FIREWALL_EXTRA=""
 
 ENV ALISSA_REVIEW_REPOS=${ALISSA_REVIEW_REPOS} \
     ALISSA_WORKSPACE=${ALISSA_WORKSPACE} \
+    ALISSA_REVIEW_SKILLS=${ALISSA_REVIEW_SKILLS} \
     ALISSA_POLL_INTERVAL=${ALISSA_POLL_INTERVAL} \
     ALISSA_ROUND_CAP=${ALISSA_ROUND_CAP} \
     ALISSA_AGENT_PROFILE=${ALISSA_AGENT_PROFILE} \

--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -77,6 +77,20 @@ RUN useradd --create-home --shell /bin/bash --uid 1000 alissa \
     && mkdir -p /workspace \
     && chown alissa:alissa /workspace
 
+# --- git: force GitHub over HTTPS with the gh token (no SSH key in a container)
+# `alissa code workspace add` clones over SSH by default (git@github.com:…), and
+# the daemon's on_missing_hub:add path calls it WITHOUT --https — so there is no
+# flag to flip. Rewrite every GitHub SSH URL to HTTPS system-wide and wire gh in
+# as the credential helper (gh reads GH_TOKEN from the env). This makes the clone
+# authenticate for both the unprivileged daemon and any manual shell (root).
+# NB: --add on the second insteadOf — a plain `git config` replaces the single
+# value, so without it only the last rewrite survives (and git@github.com: is the
+# form the alissa CLI actually emits).
+RUN git config --system url."https://github.com/".insteadOf "git@github.com:" \
+    && git config --system --add url."https://github.com/".insteadOf "ssh://git@github.com/" \
+    && git config --system credential."https://github.com".helper "" \
+    && git config --system --add credential."https://github.com".helper "!gh auth git-credential"
+
 # --- Entrypoint + optional firewall ------------------------------------------
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY init-firewall.sh /usr/local/bin/init-firewall.sh

--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -92,12 +92,54 @@ ENV PATH="/home/alissa/.local/bin:${PATH}"
 RUN curl -fsSL https://share.alissa.app/install | bash
 
 # Workspace root that the daemon and reviewers operate over. Mount a manifest
-# here, or let the entrypoint generate one from env (see README).
+# here, or let the entrypoint generate one from the config below (see README).
+# These are fixed internal paths, not meant to be reconfigured.
 ENV ALISSA_WORKSPACE_ROOT=/workspace \
-    ALISSA_WORKSPACE=alissa-review \
     TMUX_TMPDIR=/home/alissa/.tmux
 RUN mkdir -p /home/alissa/.tmux
 WORKDIR /workspace
+
+# --- Build-time configuration (Railway-friendly) -----------------------------
+# Railway's Dockerfile builds only expose service variables that are declared as
+# ARG here — runtime ENV set in the dashboard does NOT reach a from-Dockerfile
+# build's config. So every non-secret knob is an ARG whose value is baked into
+# an ENV of the same name. A runtime `-e VAR=...` still overrides the baked
+# default, so both paths work.
+#
+# Kept LAST on purpose: changing any of these rebuilds only these tiny trailing
+# layers, never the apt/npm/pip layers above.
+#
+# NOT here (by design): GH_TOKEN, ALISSA_API_TOKEN, ANTHROPIC_API_KEY /
+# CLAUDE_CODE_OAUTH_TOKEN. Secrets baked via ARG leak into `docker history` and
+# every image layer — inject them as runtime env instead (Railway provides
+# service variables to the container at runtime).
+
+# Allowlist of repos to watch, as a single string separated by "|" (a single
+# repo needs no separator). "|" is used because repo slugs contain "/".
+#   e.g. "fahera-mx/studio.alissa.app|fahera-mx/blog.alissa.app"
+ARG ALISSA_REVIEW_REPOS=""
+# Workspace name recorded in the generated manifest.
+ARG ALISSA_WORKSPACE="alissa-review"
+# Daemon knobs (see the daemon README's settings table).
+ARG ALISSA_POLL_INTERVAL="60"
+ARG ALISSA_ROUND_CAP="3"
+ARG ALISSA_AGENT_PROFILE="claude"
+ARG ALISSA_ON_MISSING_HUB="add"
+# Worker reconcile tick, seconds.
+ARG ALISSA_WORKER_INTERVAL="2"
+# Optional egress firewall (needs --cap-add=NET_ADMIN at runtime).
+ARG ALISSA_ENABLE_FIREWALL="0"
+ARG ALISSA_FIREWALL_EXTRA=""
+
+ENV ALISSA_REVIEW_REPOS=${ALISSA_REVIEW_REPOS} \
+    ALISSA_WORKSPACE=${ALISSA_WORKSPACE} \
+    ALISSA_POLL_INTERVAL=${ALISSA_POLL_INTERVAL} \
+    ALISSA_ROUND_CAP=${ALISSA_ROUND_CAP} \
+    ALISSA_AGENT_PROFILE=${ALISSA_AGENT_PROFILE} \
+    ALISSA_ON_MISSING_HUB=${ALISSA_ON_MISSING_HUB} \
+    ALISSA_WORKER_INTERVAL=${ALISSA_WORKER_INTERVAL} \
+    ALISSA_ENABLE_FIREWALL=${ALISSA_ENABLE_FIREWALL} \
+    ALISSA_FIREWALL_EXTRA=${ALISSA_FIREWALL_EXTRA}
 
 # tini reaps the worker/tmux/claude child fan-out; entrypoint does the rest.
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -91,6 +91,18 @@ WORKDIR /home/alissa
 ENV PATH="/home/alissa/.local/bin:${PATH}"
 RUN curl -fsSL https://share.alissa.app/install | bash
 
+# Agent profile the worker uses to launch reviewers non-interactively. Without
+# this, worker-spawned claude sessions stop on the first-run trust/permission
+# prompt. Mount your own over this path at runtime to override.
+COPY --chown=alissa:alissa agents.yaml /home/alissa/.config/alissa/agents.yaml
+
+# A git identity so any git operation (e.g. the clone in hub-ify) has an author
+# and never drops into git's interactive "who are you" prompt. Reviewers are
+# read-only (CR6), so this is a safety default, not a committing identity.
+RUN git config --global user.name  "alissa-review-daemon" \
+    && git config --global user.email "support@alissa.app" \
+    && git config --global advice.detachedHead false
+
 # Workspace root that the daemon and reviewers operate over. Mount a manifest
 # here, or let the entrypoint generate one from the config below (see README).
 # These are fixed internal paths, not meant to be reconfigured.

--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -40,12 +40,12 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # tmux  : the alissa worker manages tmux (ali-*) sessions
 # gh     : the daemon shells out to `gh api` for the review queue
 # tini   : PID 1 init — reaps the tmux/node/claude child fan-out
-# sudo   : only used by the optional firewall init (dropped priv otherwise)
+# gosu   : drop root -> alissa after the entrypoint fixes the volume mount
 # iptables/ipset : only used by the optional firewall init
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        ca-certificates curl gnupg git tmux tini sudo \
+        ca-certificates curl gnupg git tmux tini gosu \
         iptables ipset procps jq less; \
     # GitHub CLI apt repo
     mkdir -p /etc/apt/keyrings; \
@@ -68,13 +68,12 @@ RUN npm install -g @anthropic-ai/claude-code \
 RUN pip install "alissa-tools-github-reviewloop==${REVIEWLOOP_VERSION}"
 
 # --- Non-root runtime user ----------------------------------------------------
-# Agents run unattended with three live tokens; don't run them as root. The
-# firewall init (optional) is the only thing that needs root, via a narrow
-# sudoers entry.
+# Agents run unattended with three live tokens, and claude refuses
+# --dangerously-skip-permissions as root, so the worker/daemon run as this user.
+# The container still STARTS as root (see the USER root before ENTRYPOINT): the
+# entrypoint fixes the /workspace mount ownership, then drops to `alissa` via
+# gosu. This is what makes a root-owned platform volume (e.g. Railway) writable.
 RUN useradd --create-home --shell /bin/bash --uid 1000 alissa \
-    && echo 'alissa ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh' \
-        > /etc/sudoers.d/alissa-firewall \
-    && chmod 0440 /etc/sudoers.d/alissa-firewall \
     && mkdir -p /workspace \
     && chown alissa:alissa /workspace
 
@@ -152,6 +151,11 @@ ENV ALISSA_REVIEW_REPOS=${ALISSA_REVIEW_REPOS} \
     ALISSA_WORKER_INTERVAL=${ALISSA_WORKER_INTERVAL} \
     ALISSA_ENABLE_FIREWALL=${ALISSA_ENABLE_FIREWALL} \
     ALISSA_FIREWALL_EXTRA=${ALISSA_FIREWALL_EXTRA}
+
+# Start as root so the entrypoint can chown a root-owned volume mount; it drops
+# to `alissa` (via gosu) before running anything else. All the build steps above
+# ran as `alissa`, so the CLI, agents.yaml and git config are already in place.
+USER root
 
 # tini reaps the worker/tmux/claude child fan-out; entrypoint does the rest.
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -1,0 +1,136 @@
+# Containerized review daemon (`docker/claude`)
+
+Runs the GitHub review loop unattended in a container: the `alissa-reviewloop`
+poller, an `alissa worker`, and the `claude` reviewer agent it spawns — all in
+one image.
+
+This is **not** a thin Python-daemon container. The daemon only watches GitHub
+and enqueues sessions; the worker is what drains the queue and spawns reviewers,
+so the image bundles all three tiers (see the top-of-file comment in
+[`Dockerfile`](./Dockerfile)).
+
+## Build
+
+```sh
+docker build -t alissa-review-daemon docker/claude
+# pin a specific daemon release:
+docker build --build-arg REVIEWLOOP_VERSION=0.2.0 -t alissa-review-daemon docker/claude
+```
+
+The image installs the daemon from PyPI, so the build context is just this
+directory — no repo source is copied in.
+
+## The three identities
+
+The loop depends on three independent identities. All are injected at runtime as
+env vars — **never bake them into the image**. The entrypoint preflights all
+three and fails fast if any is missing or rejected.
+
+| env var | identity | used for |
+| --- | --- | --- |
+| `GH_TOKEN` | `gh` (the `alissa-app` GitHub user) | review queue, round counting, PR comments |
+| `ALISSA_API_TOKEN` (`alissa_…`) | Alissa by Fahera | tasks, session queue, verdicts |
+| `ANTHROPIC_API_KEY` *or* `CLAUDE_CODE_OAUTH_TOKEN` | claude | the reviewer agent |
+
+A `reviewer_login` that disagrees with the `GH_TOKEN` is **fatal at the daemon's
+own startup** (every round would look like round 1 and respawn forever) — so keep
+the token and any configured login in sync.
+
+## Workspace: bootstrap-from-manifest
+
+Reviewers `cd` into `{root}/{repo}/main` worktree hubs. This image is
+self-contained: with `on_missing_hub: add` the daemon hub-ifies each repo itself
+on the first review request, so **you do not pre-clone anything**. The entrypoint
+only guarantees a manifest and a `reviewloop.config.json` exist under
+`ALISSA_WORKSPACE_ROOT` (default `/workspace`). Either can be mounted; otherwise
+both are generated from env.
+
+| env var | default | meaning |
+| --- | --- | --- |
+| `ALISSA_REVIEW_REPOS` | *(required if no manifest mounted)* | allowlist, e.g. `fahera-mx/studio.alissa.app fahera-mx/blog.alissa.app` (space- or comma-separated) |
+| `ALISSA_POLL_INTERVAL` | `60` | seconds between polls (≥10) |
+| `ALISSA_ROUND_CAP` | `3` | CR9 round cap |
+| `ALISSA_AGENT_PROFILE` | `claude` | agent the worker launches |
+| `ALISSA_ON_MISSING_HUB` | `add` | `add` hub-ifies on demand; `skip` to require a mounted workspace |
+| `ALISSA_WORKER_INTERVAL` | `2` | worker reconcile tick (seconds) |
+
+A non-empty allowlist is required whenever `on_missing_hub` is `add` — the daemon
+refuses to hub-ify unattended without one.
+
+## Run
+
+Start with a dry run against the first real pending request before letting it run
+unattended (mirrors the daemon's own "not verified live" caveat):
+
+```sh
+docker run --rm -it \
+  -e GH_TOKEN \
+  -e ALISSA_API_TOKEN \
+  -e ANTHROPIC_API_KEY \
+  -e ALISSA_REVIEW_REPOS="fahera-mx/studio.alissa.app" \
+  alissa-review-daemon --once --dry-run -v
+```
+
+Everything after the image name is passed straight to `alissa-reviewloop`, so
+`--once`, `--dry-run`, `-v` all work.
+
+Unattended, persisting the workspace (hubs + the spawn ledger) across restarts:
+
+```sh
+docker run -d --name alissa-review \
+  --restart unless-stopped \
+  -e GH_TOKEN \
+  -e ALISSA_API_TOKEN \
+  -e ANTHROPIC_API_KEY \
+  -e ALISSA_REVIEW_REPOS="fahera-mx/studio.alissa.app fahera-mx/blog.alissa.app" \
+  -v alissa-review-workspace:/workspace \
+  alissa-review-daemon -v
+```
+
+### Optional egress firewall
+
+For unattended runs, lock egress to the hosts the loop needs (GitHub, Anthropic,
+Alissa, the package registries). Needs `NET_ADMIN`:
+
+```sh
+docker run -d --name alissa-review \
+  --cap-add=NET_ADMIN \
+  -e ALISSA_ENABLE_FIREWALL=1 \
+  -e ALISSA_FIREWALL_EXTRA="ghe.example.com" \
+  ... \
+  alissa-review-daemon -v
+```
+
+See [`init-firewall.sh`](./init-firewall.sh) for the allowlist.
+
+## docker-compose
+
+```yaml
+services:
+  review-daemon:
+    build: ./docker/claude
+    restart: unless-stopped
+    environment:
+      GH_TOKEN: ${GH_TOKEN}
+      ALISSA_API_TOKEN: ${ALISSA_API_TOKEN}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      ALISSA_REVIEW_REPOS: "fahera-mx/studio.alissa.app"
+    volumes:
+      - alissa-review-workspace:/workspace
+    # For the egress firewall:
+    # cap_add: ["NET_ADMIN"]
+    # environment: { ALISSA_ENABLE_FIREWALL: "1" }
+volumes:
+  alissa-review-workspace:
+```
+
+## What the entrypoint does
+
+1. (optional) raise the egress firewall.
+2. Preflight `gh`, `alissa`, and `claude` — fail fast if any is missing/rejected.
+3. Ensure a manifest + `reviewloop.config.json` exist (mount or generate).
+4. Start `alissa worker --daemon`, wait until it reports running (the daemon only
+   *warns* if the worker is absent, so ordering matters).
+5. Run `alissa-reviewloop` in the foreground; stop the worker on `SIGTERM`/`SIGINT`.
+
+`tini` is PID 1 to reap the tmux/node/claude child fan-out.

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -43,7 +43,7 @@ onboarding automatically, so you only supply tokens:
 
 | env var | identity | required? | what the entrypoint does |
 | --- | --- | --- | --- |
-| `GH_TOKEN` | `gh` (the `alissa-app` GitHub user) | **yes** — fatal if missing | validates via `gh api user`, then `gh auth setup-git` so `git clone`/fetch of private repos authenticates |
+| `GH_TOKEN` | `gh` (the `alissa-app` GitHub user) | **yes** — fatal if missing | validates via `gh api user`; the image rewrites GitHub SSH URLs to HTTPS + wires gh as the git credential helper, so hub-ify's `git clone` authenticates with the token (no SSH key needed) |
 | `ALISSA_API_TOKEN` (`alissa_…`) | Alissa by Fahera | **yes** — fatal if missing | `alissa auth login --token` (stores + verifies) |
 | `ANTHROPIC_API_KEY` *or* `CLAUDE_CODE_OAUTH_TOKEN` | claude | no — warns, continues | read by claude at spawn; the baked [`agents.yaml`](./agents.yaml) launches it headless (`--dangerously-skip-permissions --permission-mode acceptEdits`) |
 

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -35,21 +35,30 @@ ENV. Set the three **secrets** (`GH_TOKEN`, `ALISSA_API_TOKEN`,
 `ANTHROPIC_API_KEY`) as service variables too; those are read at runtime and
 must NOT be baked in.
 
-## The three identities
+## The three identities (self-onboarding)
 
-The loop depends on three independent identities. All are injected at runtime as
-env vars — **never bake them into the image**. The entrypoint preflights all
-three and fails fast if any is missing or rejected.
+The loop depends on three independent identities. Provide all three as **runtime
+env** (secrets — never baked into the image); the entrypoint does the rest of the
+onboarding automatically, so you only supply tokens:
 
-| env var | identity | used for |
-| --- | --- | --- |
-| `GH_TOKEN` | `gh` (the `alissa-app` GitHub user) | review queue, round counting, PR comments |
-| `ALISSA_API_TOKEN` (`alissa_…`) | Alissa by Fahera | tasks, session queue, verdicts |
-| `ANTHROPIC_API_KEY` *or* `CLAUDE_CODE_OAUTH_TOKEN` | claude | the reviewer agent |
+| env var | identity | used for | what the entrypoint does |
+| --- | --- | --- | --- |
+| `GH_TOKEN` | `gh` (the `alissa-app` GitHub user) | review queue, round counting, PR comments | validates via `gh api user`, then `gh auth setup-git` so `git clone`/fetch of private repos authenticates |
+| `ALISSA_API_TOKEN` (`alissa_…`) | Alissa by Fahera | tasks, session queue, verdicts | `alissa auth login --token` (stores + verifies) |
+| `ANTHROPIC_API_KEY` *or* `CLAUDE_CODE_OAUTH_TOKEN` | claude | the reviewer agent | read by claude at spawn; the baked [`agents.yaml`](./agents.yaml) launches it headless (`--dangerously-skip-permissions --permission-mode acceptEdits`) |
+
+That is the whole setup: three tokens in, and the container self-configures gh's
+git credential helper, the alissa session, and the headless claude profile. No
+`gh auth login`, no `claude` first-run trust prompt, no manual git config.
 
 A `reviewer_login` that disagrees with the `GH_TOKEN` is **fatal at the daemon's
 own startup** (every round would look like round 1 and respawn forever) — so keep
 the token and any configured login in sync.
+
+The reviewer's claude launch command lives in [`agents.yaml`](./agents.yaml)
+(pin a model or change flags there, or mount your own over
+`/home/alissa/.config/alissa/agents.yaml`). The image runs as a non-root user
+because claude refuses `--dangerously-skip-permissions` as root.
 
 ## Configuration (build ARGs — Railway-friendly)
 
@@ -173,7 +182,9 @@ volumes:
 ## What the entrypoint does
 
 1. (optional) raise the egress firewall.
-2. Preflight `gh`, `alissa`, and `claude` — fail fast if any is missing/rejected.
+2. Preflight + onboard the three identities — fail fast if any is missing/rejected:
+   validate `gh` and run `gh auth setup-git`; `alissa auth login`; check the claude
+   credential (the baked `agents.yaml` handles headless launch).
 3. Ensure a manifest + `reviewloop.config.json` exist (mount or generate).
 4. Start `alissa worker --daemon`, wait until it reports running (the daemon only
    *warns* if the worker is absent, so ordering matters).

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -41,15 +41,24 @@ The loop depends on three independent identities. Provide all three as **runtime
 env** (secrets — never baked into the image); the entrypoint does the rest of the
 onboarding automatically, so you only supply tokens:
 
-| env var | identity | used for | what the entrypoint does |
+| env var | identity | required? | what the entrypoint does |
 | --- | --- | --- | --- |
-| `GH_TOKEN` | `gh` (the `alissa-app` GitHub user) | review queue, round counting, PR comments | validates via `gh api user`, then `gh auth setup-git` so `git clone`/fetch of private repos authenticates |
-| `ALISSA_API_TOKEN` (`alissa_…`) | Alissa by Fahera | tasks, session queue, verdicts | `alissa auth login --token` (stores + verifies) |
-| `ANTHROPIC_API_KEY` *or* `CLAUDE_CODE_OAUTH_TOKEN` | claude | the reviewer agent | read by claude at spawn; the baked [`agents.yaml`](./agents.yaml) launches it headless (`--dangerously-skip-permissions --permission-mode acceptEdits`) |
+| `GH_TOKEN` | `gh` (the `alissa-app` GitHub user) | **yes** — fatal if missing | validates via `gh api user`, then `gh auth setup-git` so `git clone`/fetch of private repos authenticates |
+| `ALISSA_API_TOKEN` (`alissa_…`) | Alissa by Fahera | **yes** — fatal if missing | `alissa auth login --token` (stores + verifies) |
+| `ANTHROPIC_API_KEY` *or* `CLAUDE_CODE_OAUTH_TOKEN` | claude | no — warns, continues | read by claude at spawn; the baked [`agents.yaml`](./agents.yaml) launches it headless (`--dangerously-skip-permissions --permission-mode acceptEdits`) |
 
-That is the whole setup: three tokens in, and the container self-configures gh's
-git credential helper, the alissa session, and the headless claude profile. No
-`gh auth login`, no `claude` first-run trust prompt, no manual git config.
+`GH_TOKEN` and `ALISSA_API_TOKEN` are hard requirements — the daemon can't poll
+GitHub or reach the task queue without them. The **claude credential is not**: the
+daemon never calls claude directly (only the worker-spawned reviewer does), and
+claude can authenticate by other means — a mounted `~/.claude` credential, a token
+from `claude setup-token` (persist it on the `/workspace` volume), or Bedrock/
+Vertex env. If none of those is present the entrypoint just warns, and a reviewer
+that genuinely has no credential fails on its own later.
+
+So the setup is: two tokens in (gh + alissa) plus a claude credential by any
+means, and the container self-configures gh's git credential helper, the alissa
+session, and the headless claude profile. No `gh auth login`, no `claude`
+first-run trust prompt, no manual git config.
 
 A `reviewer_login` that disagrees with the `GH_TOKEN` is **fatal at the daemon's
 own startup** (every round would look like round 1 and respawn forever) — so keep
@@ -202,9 +211,9 @@ volumes:
 ## What the entrypoint does
 
 1. (optional) raise the egress firewall.
-2. Preflight + onboard the three identities — fail fast if any is missing/rejected:
-   validate `gh` and run `gh auth setup-git`; `alissa auth login`; check the claude
-   credential (the baked `agents.yaml` handles headless launch).
+2. Preflight + onboard the identities: validate `gh` (fatal if missing) and run
+   `gh auth setup-git`; `alissa auth login` (fatal if missing); check the claude
+   credential (warn-only — the baked `agents.yaml` handles headless launch).
 3. Ensure a manifest + `reviewloop.config.json` exist (mount or generate).
 4. Start `alissa worker --daemon`, wait until it reports running (the daemon only
    *warns* if the worker is absent, so ordering matters).

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -160,11 +160,11 @@ Everything worth surviving a restart lives there:
 Nothing else needs a volume: the gh/alissa/claude auth is re-established from the
 env tokens on every boot, and tmux sockets are deliberately ephemeral.
 
-On Railway, set the volume's mount path to `/workspace`. A **named** Docker volume
-(what Railway uses) inherits the image's `alissa:alissa` (uid 1000) ownership
-automatically — verified writable. A **bind mount** (host directory) keeps the
-host's ownership instead, so make sure the host path is writable by uid 1000, or
-the entrypoint can't write the manifest.
+On Railway, set the volume's mount path to `/workspace`. Persistent platform
+volumes typically mount **root-owned**, so the container starts as root, the
+entrypoint `chown`s the mount to `alissa` (uid 1000), and then drops to that user
+(via `gosu`) for everything else — so a root-owned mount just works, no manual
+`chown` or init container needed. (claude still runs unprivileged, as it must.)
 
 ### Optional egress firewall
 
@@ -210,13 +210,15 @@ volumes:
 
 ## What the entrypoint does
 
-1. (optional) raise the egress firewall.
-2. Preflight + onboard the identities: validate `gh` (fatal if missing) and run
+0. As root: `chown` the `/workspace` mount to `alissa`, (optionally) raise the
+   egress firewall, then drop to `alissa` via `gosu`. Everything below runs
+   unprivileged.
+1. Preflight + onboard the identities: validate `gh` (fatal if missing) and run
    `gh auth setup-git`; `alissa auth login` (fatal if missing); check the claude
    credential (warn-only — the baked `agents.yaml` handles headless launch).
-3. Ensure a manifest + `reviewloop.config.json` exist (mount or generate).
-4. Start `alissa worker --daemon`, wait until it reports running (the daemon only
+2. Ensure a manifest + `reviewloop.config.json` exist (mount or generate).
+3. Start `alissa worker --daemon`, wait until it reports running (the daemon only
    *warns* if the worker is absent, so ordering matters).
-5. Run `alissa-reviewloop` in the foreground; stop the worker on `SIGTERM`/`SIGINT`.
+4. Run `alissa-reviewloop` in the foreground; stop the worker on `SIGTERM`/`SIGINT`.
 
 `tini` is PID 1 to reap the tmux/node/claude child fan-out.

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -65,12 +65,14 @@ credential has to be visible to that user. Two footguns:
   works with a Pro/Max subscription) in Railway. Prefer it over `ANTHROPIC_API_KEY`
   — in the interactive TUI the worker drives, a bare API key triggers claude's own
   "approve this key?" prompt, which hangs the same way.
-- **First-run dialogs are pre-seeded** into the image (`~/.claude.json` +
-  `~/.claude/settings.json` for `alissa`): `hasCompletedOnboarding`,
-  `hasSeenAutoModeEntryWarning`, `skipDangerousModePermissionPrompt`, and a theme.
-  Without these a fresh user hangs at claude's welcome / theme / bypass-mode
-  dialog and the worker logs *"agent UI not ready — a first-run/trust dialog needs
-  a human"* forever.
+- **First-run dialogs are pre-seeded.** The image bakes `~/.claude.json` +
+  `~/.claude/settings.json` for `alissa` (`hasCompletedOnboarding`,
+  `hasSeenAutoModeEntryWarning`, `skipDangerousModePermissionPrompt`, theme), and
+  the entrypoint additionally sets `projects["<hub>/main"].hasTrustDialogAccepted`
+  for every reviewer working directory. Without these a fresh user hangs at
+  claude's welcome / theme / bypass-mode / **"trust this folder?"** dialog and the
+  worker logs *"stuck — waiting at a prompt"* forever. The trust dialog in
+  particular is **not** suppressed by `--dangerously-skip-permissions`.
 
 So the setup is: two tokens in (gh + alissa) plus a claude credential by any
 means, and the container self-configures gh's git credential helper, the alissa

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -150,9 +150,15 @@ refuses to hub-ify unattended without one.
 Reviewers `cd` into `{root}/{repo}/main` worktree hubs. This image is
 self-contained: with `on_missing_hub: add` the daemon hub-ifies each repo itself
 on the first review request, so **you do not pre-clone anything**. The entrypoint
-only guarantees a manifest and a `reviewloop.config.json` exist under
-`ALISSA_WORKSPACE_ROOT` (`/workspace`, fixed). Either can be mounted; otherwise
-both are generated from the config above.
+guarantees a manifest and a `reviewloop.config.json` exist under
+`ALISSA_WORKSPACE_ROOT` (`/workspace`, fixed).
+
+**When `ALISSA_REVIEW_REPOS` is set it is authoritative**: the entrypoint
+regenerates both files from it on **every boot**, so changing the allowlist (or
+`ALISSA_POLL_INTERVAL`, `ALISSA_ROUND_CAP`, …) and redeploying just applies — the
+files persist on the volume, so a "generate only if absent" rule would otherwise
+pin them to the first boot's values forever. Leave `ALISSA_REVIEW_REPOS` **unset**
+to instead run against a workspace you've mounted at `/workspace` as-is.
 
 ## Run
 
@@ -189,7 +195,8 @@ docker run -d --name alissa-review \
 Mount your volume at **`/workspace`** (the value of `ALISSA_WORKSPACE_ROOT`).
 Everything worth surviving a restart lives there:
 
-- `alissa-workspace.yaml` + `reviewloop.config.json` (generated on first boot);
+- `alissa-workspace.yaml` + `reviewloop.config.json` (regenerated from
+  `ALISSA_REVIEW_REPOS` each boot when it's set, else whatever you mounted);
 - the cloned worktree hubs `<owner>/<repo>/main` — persisting them means a
   restart does **not** re-clone every repo;
 - `.claude-config/.credentials.json` — the persisted `claude /login` (see the

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -122,6 +122,7 @@ automatically; locally pass `--build-arg`):
 | --- | --- | --- |
 | `ALISSA_REVIEW_REPOS` | *(required if no manifest mounted)* | allowlist as one `\|`-separated string (see below) |
 | `ALISSA_WORKSPACE` | `alissa-review` | workspace name in the generated manifest |
+| `ALISSA_REVIEW_SKILLS` | `alissa-code-workspace\|alissa-code-review` | skills installed into every reviewer session (manifest `skills:`), `\|`-separated |
 | `ALISSA_POLL_INTERVAL` | `60` | seconds between polls (≥10) |
 | `ALISSA_ROUND_CAP` | `3` | CR9 round cap |
 | `ALISSA_AGENT_PROFILE` | `claude` | agent the worker launches |

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -137,6 +137,26 @@ docker run -d --name alissa-review \
   alissa-review-daemon -v
 ```
 
+### Persistence — mount the volume at `/workspace`
+
+Mount your volume at **`/workspace`** (the value of `ALISSA_WORKSPACE_ROOT`).
+Everything worth surviving a restart lives there:
+
+- `alissa-workspace.yaml` + `reviewloop.config.json` (generated on first boot);
+- the cloned worktree hubs `<owner>/<repo>/main` — persisting them means a
+  restart does **not** re-clone every repo;
+- `.reviewloop/state.db` — the spawn ledger (which round is in-flight, which
+  cap-outs were escalated). Losing it can double-spawn a reviewer or re-escalate.
+
+Nothing else needs a volume: the gh/alissa/claude auth is re-established from the
+env tokens on every boot, and tmux sockets are deliberately ephemeral.
+
+On Railway, set the volume's mount path to `/workspace`. A **named** Docker volume
+(what Railway uses) inherits the image's `alissa:alissa` (uid 1000) ownership
+automatically — verified writable. A **bind mount** (host directory) keeps the
+host's ownership instead, so make sure the host path is writable by uid 1000, or
+the entrypoint can't write the manifest.
+
 ### Optional egress firewall
 
 For unattended runs, lock egress to the hosts the loop needs (GitHub, Anthropic,

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -45,15 +45,32 @@ onboarding automatically, so you only supply tokens:
 | --- | --- | --- | --- |
 | `GH_TOKEN` | `gh` (the `alissa-app` GitHub user) | **yes** — fatal if missing | validates via `gh api user`; the image rewrites GitHub SSH URLs to HTTPS + wires gh as the git credential helper, so hub-ify's `git clone` authenticates with the token (no SSH key needed) |
 | `ALISSA_API_TOKEN` (`alissa_…`) | Alissa by Fahera | **yes** — fatal if missing | `alissa auth login --token` (stores + verifies) |
-| `ANTHROPIC_API_KEY` *or* `CLAUDE_CODE_OAUTH_TOKEN` | claude | no — warns, continues | read by claude at spawn; the baked [`agents.yaml`](./agents.yaml) launches it headless (`--dangerously-skip-permissions --permission-mode acceptEdits`) |
+| `CLAUDE_CODE_OAUTH_TOKEN` *(preferred)* or `ANTHROPIC_API_KEY` | claude | no — warns, continues | read by claude at spawn; the baked [`agents.yaml`](./agents.yaml) launches it headless, and the image pre-seeds claude's first-run config so the TUI comes up with no prompts |
 
 `GH_TOKEN` and `ALISSA_API_TOKEN` are hard requirements — the daemon can't poll
 GitHub or reach the task queue without them. The **claude credential is not**: the
 daemon never calls claude directly (only the worker-spawned reviewer does), and
-claude can authenticate by other means — a mounted `~/.claude` credential, a token
-from `claude setup-token` (persist it on the `/workspace` volume), or Bedrock/
-Vertex env. If none of those is present the entrypoint just warns, and a reviewer
+claude can authenticate by other means — a mounted `~/.claude` credential or
+Bedrock/Vertex env. If none is present the entrypoint just warns, and a reviewer
 that genuinely has no credential fails on its own later.
+
+### claude must auth as the `alissa` user (headless)
+
+The worker spawns each reviewer as the **`alissa`** user, so the claude
+credential has to be visible to that user. Two footguns:
+
+- **Do not `claude login` as `root`.** It writes `/root/.claude/…`, which the
+  `alissa` reviewer never reads. Set the credential in the **env** instead (it is
+  visible to every user): put `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`,
+  works with a Pro/Max subscription) in Railway. Prefer it over `ANTHROPIC_API_KEY`
+  — in the interactive TUI the worker drives, a bare API key triggers claude's own
+  "approve this key?" prompt, which hangs the same way.
+- **First-run dialogs are pre-seeded** into the image (`~/.claude.json` +
+  `~/.claude/settings.json` for `alissa`): `hasCompletedOnboarding`,
+  `hasSeenAutoModeEntryWarning`, `skipDangerousModePermissionPrompt`, and a theme.
+  Without these a fresh user hangs at claude's welcome / theme / bypass-mode
+  dialog and the worker logs *"agent UI not ready — a first-run/trust dialog needs
+  a human"* forever.
 
 So the setup is: two tokens in (gh + alissa) plus a claude credential by any
 means, and the container self-configures gh's git credential helper, the alissa

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -45,7 +45,7 @@ onboarding automatically, so you only supply tokens:
 | --- | --- | --- | --- |
 | `GH_TOKEN` | `gh` (the `alissa-app` GitHub user) | **yes** — fatal if missing | validates via `gh api user`; the image rewrites GitHub SSH URLs to HTTPS + wires gh as the git credential helper, so hub-ify's `git clone` authenticates with the token (no SSH key needed) |
 | `ALISSA_API_TOKEN` (`alissa_…`) | Alissa by Fahera | **yes** — fatal if missing | `alissa auth login --token` (stores + verifies) |
-| `CLAUDE_CODE_OAUTH_TOKEN` *(preferred)* or `ANTHROPIC_API_KEY` | claude | no — warns, continues | read by claude at spawn; the baked [`agents.yaml`](./agents.yaml) launches it headless, and the image pre-seeds claude's first-run config so the TUI comes up with no prompts |
+| a persisted `claude /login` *(recommended)*, or `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` in env | claude | no — warns, continues | credential persists on the volume via `CLAUDE_CONFIG_DIR`; the baked [`agents.yaml`](./agents.yaml) launches claude headless and the first-run config is pre-seeded (see below) |
 
 `GH_TOKEN` and `ALISSA_API_TOKEN` are hard requirements — the daemon can't poll
 GitHub or reach the task queue without them. The **claude credential is not**: the
@@ -54,30 +54,49 @@ claude can authenticate by other means — a mounted `~/.claude` credential or
 Bedrock/Vertex env. If none is present the entrypoint just warns, and a reviewer
 that genuinely has no credential fails on its own later.
 
-### claude must auth as the `alissa` user (headless)
+### claude auth: log in once, persisted on the volume (recommended)
 
-The worker spawns each reviewer as the **`alissa`** user, so the claude
-credential has to be visible to that user. Two footguns:
+The worker spawns each reviewer as the **`alissa`** user, so the credential has to
+be visible to that user *and* survive restarts. The durable answer is a one-time
+interactive `claude /login`: it stores a **refresh-token credential that
+auto-renews**, unlike a static `CLAUDE_CODE_OAUTH_TOKEN` (a `setup-token` is a
+fixed 1-year token that eventually returns `401 Invalid bearer token`).
 
-- **Do not `claude login` as `root`.** It writes `/root/.claude/…`, which the
-  `alissa` reviewer never reads. Set the credential in the **env** instead (it is
-  visible to every user): put `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`,
-  works with a Pro/Max subscription) in Railway. Prefer it over `ANTHROPIC_API_KEY`
-  — in the interactive TUI the worker drives, a bare API key triggers claude's own
-  "approve this key?" prompt, which hangs the same way.
-- **First-run dialogs are pre-seeded.** The image bakes `~/.claude.json` +
-  `~/.claude/settings.json` for `alissa` (`hasCompletedOnboarding`,
-  `hasSeenAutoModeEntryWarning`, `skipDangerousModePermissionPrompt`, theme), and
-  the entrypoint additionally sets `projects["<hub>/main"].hasTrustDialogAccepted`
-  for every reviewer working directory. Without these a fresh user hangs at
-  claude's welcome / theme / bypass-mode / **"trust this folder?"** dialog and the
-  worker logs *"stuck — waiting at a prompt"* forever. The trust dialog in
-  particular is **not** suppressed by `--dangerously-skip-permissions`.
+The image sets **`CLAUDE_CONFIG_DIR=/workspace/.claude-config`** (on the persistent
+volume), which relocates claude's `.credentials.json` there — so the login
+survives restarts and redeploys. Log in once, as `alissa`, inside the container:
 
-So the setup is: two tokens in (gh + alissa) plus a claude credential by any
-means, and the container self-configures gh's git credential helper, the alissa
-session, and the headless claude profile. No `gh auth login`, no `claude`
-first-run trust prompt, no manual git config.
+```sh
+gosu alissa bash -lc 'claude /login'      # follow the URL, paste the code back
+```
+
+That writes `/workspace/.claude-config/.credentials.json`; every reviewer (and
+every future container) reuses and auto-renews it. claude ≥ 2.1.211 coordinates
+renewal across parallel sessions, so concurrent reviewers won't corrupt it.
+
+Two footguns:
+
+- **Don't `claude /login` as `root`** — it writes `/root/.claude/…`, which the
+  `alissa` reviewer never reads. Always `gosu alissa`.
+- **A static token in the env wins over the file and will keep 401'ing.** If you
+  set `CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_API_KEY` and it's expired/invalid,
+  claude uses it instead of the good persisted login. Once you've done `/login`,
+  **remove those env vars** in Railway. (A valid env token still works if you
+  prefer it — but prefer `CLAUDE_CODE_OAUTH_TOKEN` over `ANTHROPIC_API_KEY`, since
+  a bare API key triggers claude's own "approve this key?" prompt in the TUI.)
+
+**First-run dialogs are pre-seeded** so the TUI never blocks: the image bakes the
+onboarding/settings flags (`hasCompletedOnboarding`, `hasSeenAutoModeEntryWarning`,
+`skipDangerousModePermissionPrompt`, theme) and the entrypoint sets
+`projects["<hub>/main"].hasTrustDialogAccepted` for every reviewer dir — into both
+`$HOME` and `$CLAUDE_CONFIG_DIR`. Without these a fresh user hangs at claude's
+welcome / theme / bypass-mode / **"trust this folder?"** dialog (`"stuck — waiting
+at a prompt"`); the trust dialog in particular is **not** suppressed by
+`--dangerously-skip-permissions`.
+
+So the setup is: two tokens in the env (gh + alissa), one `claude /login` on the
+volume, and the container self-configures git-over-HTTPS, the alissa session, and
+a headless claude. No `gh auth login`, no first-run prompts, no manual git config.
 
 A `reviewer_login` that disagrees with the `GH_TOKEN` is **fatal at the daemon's
 own startup** (every round would look like round 1 and respawn forever) — so keep
@@ -173,6 +192,8 @@ Everything worth surviving a restart lives there:
 - `alissa-workspace.yaml` + `reviewloop.config.json` (generated on first boot);
 - the cloned worktree hubs `<owner>/<repo>/main` — persisting them means a
   restart does **not** re-clone every repo;
+- `.claude-config/.credentials.json` — the persisted `claude /login` (see the
+  claude-auth section); this is why the login survives restarts;
 - `.reviewloop/state.db` — the spawn ledger. Its `escalations` (cap-out memory)
   are worth keeping so a restart doesn't re-escalate a capped PR.
 

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -150,7 +150,7 @@ docker run --rm -it \
 Everything after the image name is passed straight to `alissa-reviewloop`, so
 `--once`, `--dry-run`, `-v` all work.
 
-Unattended, persisting the workspace (hubs + the spawn ledger) across restarts:
+Unattended, persisting the workspace (the cloned hubs) across restarts:
 
 ```sh
 docker run -d --name alissa-review \
@@ -171,8 +171,15 @@ Everything worth surviving a restart lives there:
 - `alissa-workspace.yaml` + `reviewloop.config.json` (generated on first boot);
 - the cloned worktree hubs `<owner>/<repo>/main` — persisting them means a
   restart does **not** re-clone every repo;
-- `.reviewloop/state.db` — the spawn ledger (which round is in-flight, which
-  cap-outs were escalated). Losing it can double-spawn a reviewer or re-escalate.
+- `.reviewloop/state.db` — the spawn ledger. Its `escalations` (cap-out memory)
+  are worth keeping so a restart doesn't re-escalate a capped PR.
+
+The ledger's **in-flight `spawns` are cleared on every boot** by the entrypoint:
+the tmux server, its reviewer sessions, and the worker queue all live in the
+ephemeral home and are gone on restart, so a persisted "round N in-flight" would
+otherwise be stale and stall re-enqueue for 90 min. A fresh container has no
+reviewer running by definition, so clearing them is safe and the daemon
+re-enqueues any still-pending round on its first poll.
 
 Nothing else needs a volume: the gh/alissa/claude auth is re-established from the
 env tokens on every boot, and tmux sockets are deliberately ephemeral.

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -13,12 +13,27 @@ so the image bundles all three tiers (see the top-of-file comment in
 
 ```sh
 docker build -t alissa-review-daemon docker/claude
-# pin a specific daemon release:
-docker build --build-arg REVIEWLOOP_VERSION=0.2.0 -t alissa-review-daemon docker/claude
+
+# with configuration baked in (see the Configuration table):
+docker build \
+  --build-arg REVIEWLOOP_VERSION=0.2.0 \
+  --build-arg ALISSA_REVIEW_REPOS="fahera-mx/studio.alissa.app|fahera-mx/blog.alissa.app" \
+  --build-arg ALISSA_POLL_INTERVAL=90 \
+  --build-arg ALISSA_ROUND_CAP=3 \
+  -t alissa-review-daemon docker/claude
 ```
 
 The image installs the daemon from PyPI, so the build context is just this
 directory — no repo source is copied in.
+
+### On Railway
+
+Set the config values (`ALISSA_REVIEW_REPOS`, `ALISSA_POLL_INTERVAL`, …) as
+**service variables** — Railway passes any variable matching a declared `ARG`
+into the Dockerfile build, which is why these are ARGs and not plain runtime
+ENV. Set the three **secrets** (`GH_TOKEN`, `ALISSA_API_TOKEN`,
+`ANTHROPIC_API_KEY`) as service variables too; those are read at runtime and
+must NOT be baked in.
 
 ## The three identities
 
@@ -36,26 +51,52 @@ A `reviewer_login` that disagrees with the `GH_TOKEN` is **fatal at the daemon's
 own startup** (every round would look like round 1 and respawn forever) — so keep
 the token and any configured login in sync.
 
+## Configuration (build ARGs — Railway-friendly)
+
+Every non-secret knob is a build `ARG` baked into an `ENV` of the same name.
+This is deliberate: **Railway's Dockerfile builds only expose service variables
+that are declared as `ARG`** — runtime `ENV` set in the dashboard does not reach
+a from-Dockerfile build's config. A runtime `-e VAR=...` still overrides the
+baked default, so local `docker run -e ...` works too.
+
+Set them at build time (Railway populates matching service variables
+automatically; locally pass `--build-arg`):
+
+| ARG / env | default | meaning |
+| --- | --- | --- |
+| `ALISSA_REVIEW_REPOS` | *(required if no manifest mounted)* | allowlist as one `\|`-separated string (see below) |
+| `ALISSA_WORKSPACE` | `alissa-review` | workspace name in the generated manifest |
+| `ALISSA_POLL_INTERVAL` | `60` | seconds between polls (≥10) |
+| `ALISSA_ROUND_CAP` | `3` | CR9 round cap |
+| `ALISSA_AGENT_PROFILE` | `claude` | agent the worker launches |
+| `ALISSA_ON_MISSING_HUB` | `add` | `add` hub-ifies on demand; `skip` to require a mounted workspace |
+| `ALISSA_WORKER_INTERVAL` | `2` | worker reconcile tick (seconds) |
+| `ALISSA_ENABLE_FIREWALL` | `0` | `1` raises the egress firewall (needs `--cap-add=NET_ADMIN`) |
+| `ALISSA_FIREWALL_EXTRA` | *(empty)* | extra firewall allowlist hosts, space-separated |
+
+### The repos allowlist string
+
+`ALISSA_REVIEW_REPOS` is a single string, entries separated by **`|`**. `|` is
+used because repo slugs already contain `/` (so `/` can't be the delimiter, and
+`;`/`:` are noisier). A single repo needs no separator; whitespace around entries
+is stripped.
+
+```
+ALISSA_REVIEW_REPOS=fahera-mx/studio.alissa.app|fahera-mx/blog.alissa.app
+ALISSA_REVIEW_REPOS=fahera-mx/studio.alissa.app          # one repo
+```
+
+A non-empty allowlist is required whenever `on_missing_hub` is `add` — the daemon
+refuses to hub-ify unattended without one.
+
 ## Workspace: bootstrap-from-manifest
 
 Reviewers `cd` into `{root}/{repo}/main` worktree hubs. This image is
 self-contained: with `on_missing_hub: add` the daemon hub-ifies each repo itself
 on the first review request, so **you do not pre-clone anything**. The entrypoint
 only guarantees a manifest and a `reviewloop.config.json` exist under
-`ALISSA_WORKSPACE_ROOT` (default `/workspace`). Either can be mounted; otherwise
-both are generated from env.
-
-| env var | default | meaning |
-| --- | --- | --- |
-| `ALISSA_REVIEW_REPOS` | *(required if no manifest mounted)* | allowlist, e.g. `fahera-mx/studio.alissa.app fahera-mx/blog.alissa.app` (space- or comma-separated) |
-| `ALISSA_POLL_INTERVAL` | `60` | seconds between polls (≥10) |
-| `ALISSA_ROUND_CAP` | `3` | CR9 round cap |
-| `ALISSA_AGENT_PROFILE` | `claude` | agent the worker launches |
-| `ALISSA_ON_MISSING_HUB` | `add` | `add` hub-ifies on demand; `skip` to require a mounted workspace |
-| `ALISSA_WORKER_INTERVAL` | `2` | worker reconcile tick (seconds) |
-
-A non-empty allowlist is required whenever `on_missing_hub` is `add` — the daemon
-refuses to hub-ify unattended without one.
+`ALISSA_WORKSPACE_ROOT` (`/workspace`, fixed). Either can be mounted; otherwise
+both are generated from the config above.
 
 ## Run
 
@@ -82,7 +123,7 @@ docker run -d --name alissa-review \
   -e GH_TOKEN \
   -e ALISSA_API_TOKEN \
   -e ANTHROPIC_API_KEY \
-  -e ALISSA_REVIEW_REPOS="fahera-mx/studio.alissa.app fahera-mx/blog.alissa.app" \
+  -e ALISSA_REVIEW_REPOS="fahera-mx/studio.alissa.app|fahera-mx/blog.alissa.app" \
   -v alissa-review-workspace:/workspace \
   alissa-review-daemon -v
 ```
@@ -108,13 +149,18 @@ See [`init-firewall.sh`](./init-firewall.sh) for the allowlist.
 ```yaml
 services:
   review-daemon:
-    build: ./docker/claude
+    build:
+      context: ./docker/claude
+      # Non-secret config is baked at build time (matches the Railway/ARG model).
+      args:
+        ALISSA_REVIEW_REPOS: "fahera-mx/studio.alissa.app|fahera-mx/blog.alissa.app"
+        ALISSA_POLL_INTERVAL: "90"
     restart: unless-stopped
     environment:
+      # Secrets ride runtime env — never baked into the image.
       GH_TOKEN: ${GH_TOKEN}
       ALISSA_API_TOKEN: ${ALISSA_API_TOKEN}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
-      ALISSA_REVIEW_REPOS: "fahera-mx/studio.alissa.app"
     volumes:
       - alissa-review-workspace:/workspace
     # For the egress firewall:

--- a/docker/claude/agents.yaml
+++ b/docker/claude/agents.yaml
@@ -1,0 +1,20 @@
+# Agent profiles for the alissa worker (~/.config/alissa/agents.yaml).
+#
+# The worker launches a reviewer with the profile named by ALISSA_AGENT_PROFILE
+# (default: claude). Without this file the worker falls back to a bare `claude`,
+# which stops on its first-run trust / permission prompt and hangs the reviewer.
+#
+# `--dangerously-skip-permissions --permission-mode acceptEdits` is what makes
+# claude run unattended. It requires a non-root user (claude refuses that flag as
+# root) — the image runs as uid 1000, which satisfies it. Reviewer posture (CR6:
+# reviewers never write) is enforced by the round directive, not by this profile.
+#
+# To pin a model or tweak flags, override the command below (edit this file
+# before build, or mount your own agents.yaml over it at runtime).
+claude:
+  command: claude --dangerously-skip-permissions --permission-mode acceptEdits
+  mode: interactive
+  quietSeconds: 30
+  promptPatterns:
+    - "Do you want to"
+    - "❯ 1\\. Yes"

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -121,6 +121,17 @@ repos_lines() {
     | grep -v '^$'
 }
 
+# Skills installed into every reviewer session (manifest `skills:`). Same
+# "|"-separated convention. Defaults to the workspace + review skills; override
+# with ALISSA_REVIEW_SKILLS. alissa-session / alissa-skills-usage are installed
+# by `alissa code` automatically, so they need not be listed.
+skills_lines() {
+  printf '%s' "${ALISSA_REVIEW_SKILLS:-alissa-code-workspace|alissa-code-review}" \
+    | tr '|' '\n' \
+    | sed 's/[[:space:]]//g' \
+    | grep -v '^$'
+}
+
 CONFIG="${WORKSPACE_ROOT}/reviewloop.config.json"
 
 if [ -n "$(repos_lines)" ]; then
@@ -140,7 +151,10 @@ if [ -n "$(repos_lines)" ]; then
       printf '  - repo: %s\n' "${r}"
     done
     printf 'reviewers: []\n'
-    printf 'skills:\n  - alissa-code-workspace\n'
+    printf 'skills:\n'
+    skills_lines | while IFS= read -r s; do
+      printf '  - %s\n' "${s}"
+    done
     printf 'attributes: {}\n'
   } > "${MANIFEST}"
 

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -60,14 +60,18 @@ fi
 # -----------------------------------------------------------------------------
 
 # 2a. claude / Anthropic — the reviewer agent. NOT fatal: the daemon itself
-#     never calls claude (only the worker-spawned reviewer does), and claude may
-#     be authenticated by other means — a mounted ~/.claude credential, a token
-#     from `claude setup-token`, or Bedrock/Vertex env. So warn and continue; a
-#     reviewer with truly no credential fails loudly on its own later.
-if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
-  log "WARN: no ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN in env — relying on claude's own stored auth; reviewers will fail if none is configured"
+#     never calls claude (only the worker-spawned reviewer does). Auth can come
+#     from a persisted `claude /login` (the preferred, auto-renewing credential
+#     at $CLAUDE_CONFIG_DIR/.credentials.json on the volume), or from the env
+#     (CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY — note a static setup-token
+#     expires and 401s). Warn only if NONE of these is present.
+CLAUDE_CRED_FILE="${CLAUDE_CONFIG_DIR:-/home/${RUNTIME_USER}/.claude}/.credentials.json"
+if [ -s "${CLAUDE_CRED_FILE}" ]; then
+  log "claude credential present (persisted login: ${CLAUDE_CRED_FILE})"
+elif [ -n "${ANTHROPIC_API_KEY:-}" ] || [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+  log "claude credential present (from env)"
 else
-  log "claude credential present"
+  log "WARN: no persisted claude login and no ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN — run 'claude /login' once (see README); reviewers will 401 until then"
 fi
 
 # 2b. gh — the review queue, round counting, PR comments. gh reads GH_TOKEN /
@@ -157,37 +161,66 @@ if [ ! -f "${CONFIG}" ]; then
 fi
 
 # -----------------------------------------------------------------------------
-# 3a. Pre-trust the reviewer working directories.
+# 3a. Seed claude's first-run config so reviewers start headless.
 #
-# claude shows a per-directory "Is this a project you trust?" prompt the first
-# time it opens a folder, and --dangerously-skip-permissions does NOT suppress
-# it — so the reviewer TUI hangs there ("stuck — waiting at a prompt"). The
-# accept flag lives per-project in ~/.claude.json. Pre-set it for every hub
-# main/ the reviewer will cd into: each allowlisted repo (may not be cloned yet)
-# plus any hub already on disk. This runs before the worker, so the flag is in
-# place before any reviewer session starts.
+# A fresh user hangs on claude's first-run gates (welcome/theme, the one-time
+# --dangerously-skip-permissions warning, and a per-directory "trust this
+# folder?" prompt that the flag does NOT suppress). We pre-set the flags so the
+# TUI comes up ready. Auth is separate — the persisted `claude /login` credential
+# lives in $CLAUDE_CONFIG_DIR/.credentials.json and is never touched here.
+#
+# CLAUDE_CONFIG_DIR reliably relocates only .credentials.json; whether it also
+# moves the state/settings files is undocumented, so we seed BOTH $HOME and
+# $CLAUDE_CONFIG_DIR — whichever claude reads, the flags are there. Merges are
+# load-then-update, so a persisted login (oauthAccount etc.) is preserved.
 # -----------------------------------------------------------------------------
 python3 - "${WORKSPACE_ROOT}" <<'PY' || true
 import glob, json, os, sys
 root = sys.argv[1]
-cfg = os.path.expanduser("~/.claude.json")
-try:
-    data = json.load(open(cfg))
-except Exception:
-    data = {}
-projects = data.setdefault("projects", {})
+home = os.path.expanduser("~")
+ccdir = os.environ.get("CLAUDE_CONFIG_DIR", "").strip()
+
+# Reviewer working dirs to pre-trust: allowlisted repos (basename of owner/repo,
+# even before hub-ified) plus any hub main/ already on disk.
 paths = set()
-# Allowlisted repos (basename of owner/repo), even before they are hub-ified.
 for r in os.environ.get("ALISSA_REVIEW_REPOS", "").replace("|", "\n").split():
     r = r.strip()
     if "/" in r:
         paths.add(os.path.join(root, r.split("/")[-1], "main"))
-# Any hub main/ already present (covers --dir overrides and mounted workspaces).
 paths.update(glob.glob(os.path.join(root, "*", "main")))
-for p in sorted(paths):
-    projects.setdefault(p, {})["hasTrustDialogAccepted"] = True
-json.dump(data, open(cfg, "w"), indent=2)
-print(f"[entrypoint] pre-trusted {len(paths)} reviewer dir(s) in ~/.claude.json")
+
+def merge(path, apply):
+    try:
+        d = json.load(open(path))
+    except Exception:
+        d = {}
+    apply(d)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    json.dump(d, open(path, "w"), indent=2)
+
+def state(d):  # ~/.claude.json equivalent: onboarding + per-project trust
+    d["hasCompletedOnboarding"] = True
+    d["hasSeenAutoModeEntryWarning"] = True
+    d.setdefault("lastOnboardingVersion", "2.1.215")
+    pr = d.setdefault("projects", {})
+    for p in paths:
+        pr.setdefault(p, {})["hasTrustDialogAccepted"] = True
+
+def settings(d):  # settings.json: skip the bypass-mode prompt, theme, TUI
+    d["skipDangerousModePermissionPrompt"] = True
+    d.setdefault("theme", "dark")
+    d.setdefault("tui", "fullscreen")
+
+state_targets = [os.path.join(home, ".claude.json")]
+settings_targets = [os.path.join(home, ".claude", "settings.json")]
+if ccdir:
+    state_targets.append(os.path.join(ccdir, ".claude.json"))
+    settings_targets.append(os.path.join(ccdir, "settings.json"))
+for t in state_targets:
+    merge(t, state)
+for t in settings_targets:
+    merge(t, settings)
+print(f"[entrypoint] seeded claude first-run config; pre-trusted {len(paths)} reviewer dir(s)")
 PY
 
 # -----------------------------------------------------------------------------

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -157,6 +157,34 @@ if [ ! -f "${CONFIG}" ]; then
 fi
 
 # -----------------------------------------------------------------------------
+# 3b. Reset the stale in-flight ledger.
+#
+# The daemon's spawn ledger persists on the /workspace volume, but the tmux
+# server, its sessions, and the worker queue all live in the ephemeral home and
+# are gone on every (re)start. So after a redeploy the ledger still says round N
+# is "in-flight" for sessions that no longer exist, and the daemon waits the full
+# 90-min stall before re-enqueuing — nothing reviews in the meantime.
+#
+# A fresh container has no reviewer running by definition (tmux server is down),
+# so every `spawns` row is stale: clear them and the daemon re-enqueues on its
+# first poll. `escalations` is kept, so capped-out PRs are not re-escalated.
+STATE_DB="${WORKSPACE_ROOT}/.reviewloop/state.db"
+if [ -f "${STATE_DB}" ]; then
+  python3 - "${STATE_DB}" <<'PY' || true
+import sqlite3, sys
+db = sqlite3.connect(sys.argv[1])
+try:
+    n = db.execute("DELETE FROM spawns").rowcount
+    db.commit()
+    print(f"[entrypoint] cleared {n} stale in-flight spawn record(s) from the ledger")
+except sqlite3.OperationalError:
+    pass  # table not created yet — nothing to clear
+finally:
+    db.close()
+PY
+fi
+
+# -----------------------------------------------------------------------------
 # 4. Start the worker, wait until it reports running.
 # -----------------------------------------------------------------------------
 mkdir -p "${TMUX_TMPDIR:-/home/alissa/.tmux}"

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -2,11 +2,11 @@
 # =============================================================================
 # Container entrypoint for the Alissa GitHub review daemon.
 #
-#   1. (optional) raise the egress firewall
-#   2. preflight the THREE identities the loop depends on (gh / alissa / claude)
-#   3. bootstrap the worktree-hub workspace + reviewloop config from a manifest
-#   4. start `alissa worker` (backgrounded) and wait until it is up
-#   5. run `alissa-reviewloop` in the foreground, stopping the worker on exit
+#   0. as root: fix the volume-mount ownership (+ firewall), then drop to alissa
+#   1. preflight the identities the loop depends on (gh / alissa / claude)
+#   2. bootstrap the worktree-hub workspace + reviewloop config from a manifest
+#   3. start `alissa worker` (backgrounded) and wait until it is up
+#   4. run `alissa-reviewloop` in the foreground, stopping the worker on exit
 #
 # The daemon is a thin poller; the worker is what actually spawns reviewers, so
 # the worker MUST be running first — the daemon only warns if it isn't.
@@ -18,18 +18,40 @@ die()  { printf '[entrypoint] FATAL: %s\n' "$*" >&2; exit 1; }
 
 WORKSPACE_ROOT="${ALISSA_WORKSPACE_ROOT:-/workspace}"
 WORKSPACE_NAME="${ALISSA_WORKSPACE:-alissa-review}"
+RUNTIME_USER=alissa
 
 # -----------------------------------------------------------------------------
-# 1. Optional egress firewall (needs --cap-add=NET_ADMIN)
+# 0. Privilege bootstrap (runs only on the first pass, as root)
+#
+# The container starts as root purely so we can make a platform-provided volume
+# writable: a persistent volume (e.g. Railway) mounts at WORKSPACE_ROOT owned by
+# root, and the daemon runs as an unprivileged user, so without this it cannot
+# even write the generated manifest. We chown the mount, raise the optional
+# firewall (which needs root anyway), then re-exec this script as `alissa`.
+#
+# claude refuses --dangerously-skip-permissions as root, so everything past this
+# point MUST run unprivileged — that is exactly what the drop guarantees.
 # -----------------------------------------------------------------------------
-if [ "${ALISSA_ENABLE_FIREWALL:-0}" = "1" ]; then
-  log "raising egress firewall (ALISSA_ENABLE_FIREWALL=1)"
-  sudo /usr/local/bin/init-firewall.sh \
-    || die "firewall init failed — did you pass --cap-add=NET_ADMIN?"
+if [ "$(id -u)" = "0" ]; then
+  mkdir -p "${WORKSPACE_ROOT}" "${TMUX_TMPDIR:-/home/${RUNTIME_USER}/.tmux}"
+  # Fix ownership so the unprivileged user can write. -R because a restart may
+  # find files a previous root-mounted run left behind.
+  chown -R "${RUNTIME_USER}:${RUNTIME_USER}" \
+    "${WORKSPACE_ROOT}" "${TMUX_TMPDIR:-/home/${RUNTIME_USER}/.tmux}" 2>/dev/null || true
+  log "workspace mount ${WORKSPACE_ROOT} owned by ${RUNTIME_USER}"
+
+  if [ "${ALISSA_ENABLE_FIREWALL:-0}" = "1" ]; then
+    log "raising egress firewall (ALISSA_ENABLE_FIREWALL=1)"
+    /usr/local/bin/init-firewall.sh \
+      || die "firewall init failed — did you pass --cap-add=NET_ADMIN?"
+  fi
+
+  log "dropping to ${RUNTIME_USER}"
+  exec gosu "${RUNTIME_USER}" "$0" "$@"
 fi
 
 # -----------------------------------------------------------------------------
-# 2. Preflight the three identities
+# 1. Preflight the three identities
 #
 # The daemon warns that an identity MISMATCH between the gh token and
 # reviewer_login is fatal — but that check lives in the daemon itself. Here we

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -71,18 +71,27 @@ log "alissa authenticated"
 mkdir -p "${WORKSPACE_ROOT}"
 
 MANIFEST="${WORKSPACE_ROOT}/alissa-workspace.yaml"
+# ALISSA_REVIEW_REPOS: "|"-separated owner/repo allowlist ("|" because repo
+# slugs contain "/"); a single repo needs no separator. Whitespace around
+# entries is stripped. This helper prints one repo per line.
+repos_lines() {
+  printf '%s' "${ALISSA_REVIEW_REPOS:-}" \
+    | tr '|' '\n' \
+    | sed 's/[[:space:]]//g' \
+    | grep -v '^$'
+}
+
 if [ ! -f "${MANIFEST}" ]; then
-  # ALISSA_REVIEW_REPOS: whitespace/comma separated owner/repo allowlist.
   # Required to generate a manifest, and required by on_missing_hub:add anyway
   # (the daemon refuses "add" with an empty allowlist).
-  [ -n "${ALISSA_REVIEW_REPOS:-}" ] \
+  [ -n "$(repos_lines)" ] \
     || die "no alissa-workspace.yaml mounted and ALISSA_REVIEW_REPOS is empty — nothing to review"
   log "generating ${MANIFEST} from ALISSA_REVIEW_REPOS"
   {
     printf 'name: %s\n' "${WORKSPACE_NAME}"
     printf 'description: Containerized Alissa review daemon workspace\n'
     printf 'repos:\n'
-    for r in $(printf '%s' "${ALISSA_REVIEW_REPOS//,/ }" | tr ' ' '\n' | grep -v '^$'); do
+    repos_lines | while IFS= read -r r; do
       printf '  - repo: %s\n' "${r}"
     done
     printf 'reviewers: []\n'
@@ -95,12 +104,7 @@ CONFIG="${WORKSPACE_ROOT}/reviewloop.config.json"
 if [ ! -f "${CONFIG}" ]; then
   log "generating ${CONFIG} (on_missing_hub: add)"
   # Build the repos JSON array from the same allowlist.
-  repos_json="[]"
-  if [ -n "${ALISSA_REVIEW_REPOS:-}" ]; then
-    repos_json="$(printf '%s' "${ALISSA_REVIEW_REPOS//,/ }" \
-      | tr ' ' '\n' | grep -v '^$' \
-      | jq -R . | jq -s -c .)"
-  fi
+  repos_json="$(repos_lines | jq -R . | jq -s -c .)"
   jq -n \
     --argjson repos "${repos_json}" \
     --argjson poll   "${ALISSA_POLL_INTERVAL:-60}" \

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -121,12 +121,17 @@ repos_lines() {
     | grep -v '^$'
 }
 
-if [ ! -f "${MANIFEST}" ]; then
-  # Required to generate a manifest, and required by on_missing_hub:add anyway
-  # (the daemon refuses "add" with an empty allowlist).
-  [ -n "$(repos_lines)" ] \
-    || die "no alissa-workspace.yaml mounted and ALISSA_REVIEW_REPOS is empty — nothing to review"
-  log "generating ${MANIFEST} from ALISSA_REVIEW_REPOS"
+CONFIG="${WORKSPACE_ROOT}/reviewloop.config.json"
+
+if [ -n "$(repos_lines)" ]; then
+  # ENV-DRIVEN MODE: ALISSA_REVIEW_REPOS is authoritative, so (re)generate the
+  # manifest + config on EVERY boot. The files persist on the /workspace volume,
+  # so "generate only if absent" would pin them to the first boot's value and a
+  # later Railway env change would silently never apply. Regenerating is safe:
+  # the allowlist is the full set of repos the daemon may touch (on_missing_hub
+  # only hub-ifies repos already in it), and the cloned hub dirs on the volume
+  # are untouched by rewriting this text.
+  log "generating ${MANIFEST} + reviewloop.config.json from ALISSA_REVIEW_REPOS"
   {
     printf 'name: %s\n' "${WORKSPACE_NAME}"
     printf 'description: Containerized Alissa review daemon workspace\n'
@@ -138,12 +143,7 @@ if [ ! -f "${MANIFEST}" ]; then
     printf 'skills:\n  - alissa-code-workspace\n'
     printf 'attributes: {}\n'
   } > "${MANIFEST}"
-fi
 
-CONFIG="${WORKSPACE_ROOT}/reviewloop.config.json"
-if [ ! -f "${CONFIG}" ]; then
-  log "generating ${CONFIG} (on_missing_hub: add)"
-  # Build the repos JSON array from the same allowlist.
   repos_json="$(repos_lines | jq -R . | jq -s -c .)"
   jq -n \
     --argjson repos "${repos_json}" \
@@ -158,6 +158,11 @@ if [ ! -f "${CONFIG}" ]; then
        agent_profile: $agent,
        on_missing_hub: $hub
      }' > "${CONFIG}"
+else
+  # MOUNTED MODE: no allowlist in the env — respect a mounted workspace as-is.
+  [ -f "${MANIFEST}" ] \
+    || die "no alissa-workspace.yaml mounted and ALISSA_REVIEW_REPOS is empty — nothing to review"
+  log "using mounted workspace at ${WORKSPACE_ROOT} (ALISSA_REVIEW_REPOS unset)"
 fi
 
 # -----------------------------------------------------------------------------

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -52,6 +52,15 @@ GH_LOGIN="$(gh api user -q .login 2>/dev/null)" \
   || die "gh token rejected by GitHub (gh api user failed)"
 log "gh authenticated as: ${GH_LOGIN}"
 
+# The API token above is enough for `gh api` calls, but NOT for git itself:
+# hub-ifying a repo (on_missing_hub:add) does a `git clone`, which needs a git
+# credential helper. Wire gh in as that helper so https clones/fetches of
+# private repos authenticate with the same token. Non-fatal: an SSH-based or
+# public-only setup does not need it.
+gh auth setup-git 2>/dev/null \
+  && log "git credential helper configured (gh)" \
+  || log "WARN: gh auth setup-git failed — private-repo clone/fetch may not authenticate"
+
 # 2c. alissa — tasks, session queue, verdicts. The CLI reads ALISSA_API_TOKEN,
 #     but `auth login` also stores + verifies it, which is the real preflight.
 [ -n "${ALISSA_API_TOKEN:-}" ] \

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -157,6 +157,40 @@ if [ ! -f "${CONFIG}" ]; then
 fi
 
 # -----------------------------------------------------------------------------
+# 3a. Pre-trust the reviewer working directories.
+#
+# claude shows a per-directory "Is this a project you trust?" prompt the first
+# time it opens a folder, and --dangerously-skip-permissions does NOT suppress
+# it — so the reviewer TUI hangs there ("stuck — waiting at a prompt"). The
+# accept flag lives per-project in ~/.claude.json. Pre-set it for every hub
+# main/ the reviewer will cd into: each allowlisted repo (may not be cloned yet)
+# plus any hub already on disk. This runs before the worker, so the flag is in
+# place before any reviewer session starts.
+# -----------------------------------------------------------------------------
+python3 - "${WORKSPACE_ROOT}" <<'PY' || true
+import glob, json, os, sys
+root = sys.argv[1]
+cfg = os.path.expanduser("~/.claude.json")
+try:
+    data = json.load(open(cfg))
+except Exception:
+    data = {}
+projects = data.setdefault("projects", {})
+paths = set()
+# Allowlisted repos (basename of owner/repo), even before they are hub-ified.
+for r in os.environ.get("ALISSA_REVIEW_REPOS", "").replace("|", "\n").split():
+    r = r.strip()
+    if "/" in r:
+        paths.add(os.path.join(root, r.split("/")[-1], "main"))
+# Any hub main/ already present (covers --dir overrides and mounted workspaces).
+paths.update(glob.glob(os.path.join(root, "*", "main")))
+for p in sorted(paths):
+    projects.setdefault(p, {})["hasTrustDialogAccepted"] = True
+json.dump(data, open(cfg, "w"), indent=2)
+print(f"[entrypoint] pre-trusted {len(paths)} reviewer dir(s) in ~/.claude.json")
+PY
+
+# -----------------------------------------------------------------------------
 # 3b. Reset the stale in-flight ledger.
 #
 # The daemon's spawn ledger persists on the /workspace volume, but the tmux

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Container entrypoint for the Alissa GitHub review daemon.
+#
+#   1. (optional) raise the egress firewall
+#   2. preflight the THREE identities the loop depends on (gh / alissa / claude)
+#   3. bootstrap the worktree-hub workspace + reviewloop config from a manifest
+#   4. start `alissa worker` (backgrounded) and wait until it is up
+#   5. run `alissa-reviewloop` in the foreground, stopping the worker on exit
+#
+# The daemon is a thin poller; the worker is what actually spawns reviewers, so
+# the worker MUST be running first — the daemon only warns if it isn't.
+# =============================================================================
+set -euo pipefail
+
+log()  { printf '[entrypoint] %s\n' "$*" >&2; }
+die()  { printf '[entrypoint] FATAL: %s\n' "$*" >&2; exit 1; }
+
+WORKSPACE_ROOT="${ALISSA_WORKSPACE_ROOT:-/workspace}"
+WORKSPACE_NAME="${ALISSA_WORKSPACE:-alissa-review}"
+
+# -----------------------------------------------------------------------------
+# 1. Optional egress firewall (needs --cap-add=NET_ADMIN)
+# -----------------------------------------------------------------------------
+if [ "${ALISSA_ENABLE_FIREWALL:-0}" = "1" ]; then
+  log "raising egress firewall (ALISSA_ENABLE_FIREWALL=1)"
+  sudo /usr/local/bin/init-firewall.sh \
+    || die "firewall init failed — did you pass --cap-add=NET_ADMIN?"
+fi
+
+# -----------------------------------------------------------------------------
+# 2. Preflight the three identities
+#
+# The daemon warns that an identity MISMATCH between the gh token and
+# reviewer_login is fatal — but that check lives in the daemon itself. Here we
+# only guarantee all three are present and authenticated, then let the daemon
+# enforce the mismatch guard at its own startup.
+# -----------------------------------------------------------------------------
+
+# 2a. claude / Anthropic — the reviewer agent.
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+  die "no ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN — the claude reviewer agent cannot run"
+fi
+log "claude credential present"
+
+# 2b. gh — the review queue, round counting, PR comments. gh reads GH_TOKEN /
+#     GITHUB_TOKEN from the environment automatically.
+if [ -z "${GH_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
+  die "no GH_TOKEN (or GITHUB_TOKEN) — cannot watch the review queue"
+fi
+GH_LOGIN="$(gh api user -q .login 2>/dev/null)" \
+  || die "gh token rejected by GitHub (gh api user failed)"
+log "gh authenticated as: ${GH_LOGIN}"
+
+# 2c. alissa — tasks, session queue, verdicts. The CLI reads ALISSA_API_TOKEN,
+#     but `auth login` also stores + verifies it, which is the real preflight.
+[ -n "${ALISSA_API_TOKEN:-}" ] \
+  || die "no ALISSA_API_TOKEN — cannot reach tasks / session queue"
+alissa auth login --token "${ALISSA_API_TOKEN}" >/dev/null 2>&1 \
+  || die "ALISSA_API_TOKEN rejected (alissa auth login failed)"
+log "alissa authenticated"
+
+# -----------------------------------------------------------------------------
+# 3. Bootstrap the workspace (bootstrap-from-manifest model)
+#
+# Reviewers cd into {root}/{repo}/main worktree hubs. With on_missing_hub:add
+# the daemon hub-ifies each repo itself on first review request, so we do NOT
+# pre-clone anything — we only guarantee a manifest and a reviewloop config
+# exist. Either may be mounted; otherwise we generate them from env.
+# -----------------------------------------------------------------------------
+mkdir -p "${WORKSPACE_ROOT}"
+
+MANIFEST="${WORKSPACE_ROOT}/alissa-workspace.yaml"
+if [ ! -f "${MANIFEST}" ]; then
+  # ALISSA_REVIEW_REPOS: whitespace/comma separated owner/repo allowlist.
+  # Required to generate a manifest, and required by on_missing_hub:add anyway
+  # (the daemon refuses "add" with an empty allowlist).
+  [ -n "${ALISSA_REVIEW_REPOS:-}" ] \
+    || die "no alissa-workspace.yaml mounted and ALISSA_REVIEW_REPOS is empty — nothing to review"
+  log "generating ${MANIFEST} from ALISSA_REVIEW_REPOS"
+  {
+    printf 'name: %s\n' "${WORKSPACE_NAME}"
+    printf 'description: Containerized Alissa review daemon workspace\n'
+    printf 'repos:\n'
+    for r in $(printf '%s' "${ALISSA_REVIEW_REPOS//,/ }" | tr ' ' '\n' | grep -v '^$'); do
+      printf '  - repo: %s\n' "${r}"
+    done
+    printf 'reviewers: []\n'
+    printf 'skills:\n  - alissa-code-workspace\n'
+    printf 'attributes: {}\n'
+  } > "${MANIFEST}"
+fi
+
+CONFIG="${WORKSPACE_ROOT}/reviewloop.config.json"
+if [ ! -f "${CONFIG}" ]; then
+  log "generating ${CONFIG} (on_missing_hub: add)"
+  # Build the repos JSON array from the same allowlist.
+  repos_json="[]"
+  if [ -n "${ALISSA_REVIEW_REPOS:-}" ]; then
+    repos_json="$(printf '%s' "${ALISSA_REVIEW_REPOS//,/ }" \
+      | tr ' ' '\n' | grep -v '^$' \
+      | jq -R . | jq -s -c .)"
+  fi
+  jq -n \
+    --argjson repos "${repos_json}" \
+    --argjson poll   "${ALISSA_POLL_INTERVAL:-60}" \
+    --argjson cap    "${ALISSA_ROUND_CAP:-3}" \
+    --arg     agent  "${ALISSA_AGENT_PROFILE:-claude}" \
+    --arg     hub    "${ALISSA_ON_MISSING_HUB:-add}" \
+    '{
+       repos: $repos,
+       poll_interval: $poll,
+       round_cap: $cap,
+       agent_profile: $agent,
+       on_missing_hub: $hub
+     }' > "${CONFIG}"
+fi
+
+# -----------------------------------------------------------------------------
+# 4. Start the worker, wait until it reports running.
+# -----------------------------------------------------------------------------
+mkdir -p "${TMUX_TMPDIR:-/home/alissa/.tmux}"
+
+log "starting alissa worker (detached)"
+alissa worker start --daemon --interval "${ALISSA_WORKER_INTERVAL:-2}" \
+  || die "alissa worker failed to start"
+
+# Poll status until it is up (the daemon only warns if the worker is absent).
+worker_up=0
+for _ in $(seq 1 15); do
+  if alissa worker status 2>/dev/null | grep -qiv 'not running\|no worker' \
+     && alissa worker status 2>/dev/null | grep -qi 'running'; then
+    worker_up=1; break
+  fi
+  sleep 1
+done
+[ "${worker_up}" = "1" ] || die "alissa worker did not come up within 15s"
+log "alissa worker is running"
+
+# -----------------------------------------------------------------------------
+# 5. Run the daemon in the foreground; stop the worker on shutdown.
+# -----------------------------------------------------------------------------
+DAEMON_PID=""
+shutdown() {
+  log "shutting down"
+  [ -n "${DAEMON_PID}" ] && kill "${DAEMON_PID}" 2>/dev/null || true
+  alissa worker stop >/dev/null 2>&1 || true
+  wait "${DAEMON_PID}" 2>/dev/null || true
+  exit 0
+}
+trap shutdown TERM INT
+
+# Extra daemon flags (e.g. -v, --once, --dry-run) pass through as CMD args.
+log "starting alissa-reviewloop over ${WORKSPACE_ROOT}"
+alissa-reviewloop --workspace-root "${WORKSPACE_ROOT}" "$@" &
+DAEMON_PID=$!
+wait "${DAEMON_PID}"

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -37,11 +37,16 @@ fi
 # enforce the mismatch guard at its own startup.
 # -----------------------------------------------------------------------------
 
-# 2a. claude / Anthropic — the reviewer agent.
+# 2a. claude / Anthropic — the reviewer agent. NOT fatal: the daemon itself
+#     never calls claude (only the worker-spawned reviewer does), and claude may
+#     be authenticated by other means — a mounted ~/.claude credential, a token
+#     from `claude setup-token`, or Bedrock/Vertex env. So warn and continue; a
+#     reviewer with truly no credential fails loudly on its own later.
 if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
-  die "no ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN — the claude reviewer agent cannot run"
+  log "WARN: no ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN in env — relying on claude's own stored auth; reviewers will fail if none is configured"
+else
+  log "claude credential present"
 fi
-log "claude credential present"
 
 # 2b. gh — the review queue, round counting, PR comments. gh reads GH_TOKEN /
 #     GITHUB_TOKEN from the environment automatically.

--- a/docker/claude/init-firewall.sh
+++ b/docker/claude/init-firewall.sh
@@ -8,8 +8,9 @@
 # to the few hosts the loop actually needs limits the blast radius if a reviewed
 # PR tries to talk an agent into exfiltrating.
 #
-# Runs as root (via the narrow sudoers entry) and needs --cap-add=NET_ADMIN.
-# Gated behind ALISSA_ENABLE_FIREWALL=1 in the entrypoint — off by default.
+# Runs as root (the entrypoint invokes it during its root bootstrap, before it
+# drops to the unprivileged user) and needs --cap-add=NET_ADMIN. Gated behind
+# ALISSA_ENABLE_FIREWALL=1 — off by default.
 # =============================================================================
 set -euo pipefail
 

--- a/docker/claude/init-firewall.sh
+++ b/docker/claude/init-firewall.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Optional egress firewall — default-deny with a narrow allowlist.
+#
+# Adapted from the claude-code devcontainer firewall. This matters here because
+# the container runs `claude` reviewer agents UNATTENDED, holding three live
+# tokens, reacting to INBOUND pull requests from other accounts. Locking egress
+# to the few hosts the loop actually needs limits the blast radius if a reviewed
+# PR tries to talk an agent into exfiltrating.
+#
+# Runs as root (via the narrow sudoers entry) and needs --cap-add=NET_ADMIN.
+# Gated behind ALISSA_ENABLE_FIREWALL=1 in the entrypoint — off by default.
+# =============================================================================
+set -euo pipefail
+
+echo "[firewall] resetting rules"
+iptables -F || true
+iptables -X || true
+ipset destroy allowed-domains 2>/dev/null || true
+
+# Allow loopback and established/related return traffic.
+iptables -A INPUT  -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+iptables -A INPUT  -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# DNS must be allowed before we can resolve the allowlist.
+iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+
+ipset create allowed-domains hash:ip
+
+# The hosts the review loop actually talks to. Extend via ALISSA_FIREWALL_EXTRA
+# (space-separated hostnames) for private registries or self-hosted GitHub.
+DOMAINS=(
+  api.github.com
+  github.com
+  codeload.github.com
+  objects.githubusercontent.com
+  api.anthropic.com
+  share.alissa.app
+  skills.alissa.app
+  api.alissa.app
+  registry.npmjs.org
+  pypi.org
+  files.pythonhosted.org
+  deb.nodesource.com
+  cli.github.com
+  ${ALISSA_FIREWALL_EXTRA:-}
+)
+
+for domain in "${DOMAINS[@]}"; do
+  [ -n "${domain}" ] || continue
+  ips="$(getent ahostsv4 "${domain}" | awk '{print $1}' | sort -u || true)"
+  if [ -z "${ips}" ]; then
+    echo "[firewall] WARN: could not resolve ${domain}" >&2
+    continue
+  fi
+  for ip in ${ips}; do
+    ipset add allowed-domains "${ip}" 2>/dev/null || true
+  done
+  echo "[firewall] allowed ${domain}"
+done
+
+# Allow egress to the allowlist; drop everything else.
+iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
+iptables -P INPUT   DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT  DROP
+# Re-allow the essentials the policy would otherwise have dropped.
+iptables -A OUTPUT -o lo -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+
+echo "[firewall] egress locked to allowlist"


### PR DESCRIPTION
Registers and delivers **TASK-817578483** — run the GitHub review loop unattended in a container instead of on a dev host.

## What this is
The daemon (`alissa-reviewloop`) is a thin poller; the real reviewing is done by `alissa worker` draining a tmux queue and spawning `claude` reviewer agents inside worktree hubs. So this image bundles **all three tiers**, not just the PyPI package:

- python 3.12 + `alissa-tools-github-reviewloop` (the poller, from PyPI)
- node 22 + the alissa CLI (worker, tmux queue, tasks)
- claude-code (the agent the worker spawns)

## Files (`docker/claude/`)
- **`Dockerfile`** — `python:3.12-slim-bookworm` (matches the repo's pinned 3.12) + Node 22 via NodeSource. alissa CLI via the official npm-free installer (checksum-verified); daemon from PyPI (`REVIEWLOOP_VERSION` build arg, default 0.2.0). Runs non-root (uid 1000); `tini` as PID 1.
- **`entrypoint.sh`** — preflight the three identities → bootstrap manifest + `reviewloop.config.json` (`on_missing_hub: add`) → start `alissa worker --daemon`, wait until up → run the daemon foreground with graceful shutdown.
- **`init-firewall.sh`** — optional default-deny egress allowlist (gated by `ALISSA_ENABLE_FIREWALL=1`, needs `--cap-add=NET_ADMIN`).
- **`README.md`** — build/run, the three identities, workspace bootstrap, compose example.

## The three identities (injected at runtime, never baked)
| env | identity | for |
| --- | --- | --- |
| `GH_TOKEN` | gh (`alissa-app`) | review queue, round counting, PR comments |
| `ALISSA_API_TOKEN` | Alissa by Fahera | tasks, session queue, verdicts |
| `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` | claude | the reviewer agent |

## Workspace: bootstrap-from-manifest
Self-contained — with `on_missing_hub: add` the daemon hub-ifies each repo itself on first request, so nothing is pre-cloned. The entrypoint only guarantees a manifest + config exist (mounted, or generated from `ALISSA_REVIEW_REPOS`).

## Verification
**Done here:** image builds; python 3.12.13 / node 22 / gh 2.96 / claude-code 2.1.215 / alissa CLI / `alissa-reviewloop` all present and runnable; entrypoint preflight fails fast on each missing identity (claude → gh presence → gh validity) with exit 1.

**Left to verify live** (needs real tokens + a PR authored by another account — the daemon README's own live-verify caveat): the worker actually spawning a reviewer and a full round. Run `docker run ... --once --dry-run -v` against the first real request before letting it run unattended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)