### PR TITLE
TASK-2030617909: default REVIEWLOOP_VERSION → 0.4.0

### DIFF
--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -26,7 +26,7 @@
 FROM python:3.12-slim-bookworm
 
 # Version of the daemon to install from PyPI. Bump per release.
-ARG REVIEWLOOP_VERSION=0.2.0
+ARG REVIEWLOOP_VERSION=0.4.0
 # Node major version (must be >= 18 for the alissa CLI and claude-code).
 ARG NODE_MAJOR=22
 


### PR DESCRIPTION
One-line bump of the baked `ARG REVIEWLOOP_VERSION` default from 0.2.0 to **0.4.0** (published on PyPI, with `alissa-pr-review` + the reviewer closing-discipline directives). Builds with no explicit build-arg now install the current package; Railway env override still wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)