### PR TITLE
TASK-895710961: re-pin REVIEWLOOP_VERSION → 0.5.0

### DIFF
--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -26,7 +26,7 @@
 FROM python:3.12-slim-bookworm
 
 # Version of the daemon to install from PyPI. Bump per release.
-ARG REVIEWLOOP_VERSION=0.4.0
+ARG REVIEWLOOP_VERSION=0.5.0
 # Node major version (must be >= 18 for the alissa CLI and claude-code).
 ARG NODE_MAJOR=22
 


### PR DESCRIPTION
Follow-up to the reap PR (#9). Bumps the baked `ARG REVIEWLOOP_VERSION` default 0.4.0 → **0.5.0** — the version with the reviewer self-kill + daemon session-reap backstop, now **published on PyPI**. Builds with no explicit build-arg install the current package; Railway env override still wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)