### PR TITLE
TASK-317994423: re-pin REVIEWLOOP_VERSION → 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Your two identities are independent and nothing keeps them in sync:
 
 | | identity | used for |
 | --- | --- | --- |
-| `gh` | `alissa-app` | the review queue, PR comments, round counting |
+| `gh` | `alissa-app` | the review queue, PR comments, the GitHub-side convergence signal |
 | `alissa` | Alissa by Fahera | tasks, session queue, verdicts |
 
 Because of that, a `reviewer_login` that disagrees with the token is **fatal at

--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -26,7 +26,7 @@
 FROM python:3.12-slim-bookworm
 
 # Version of the daemon to install from PyPI. Bump per release.
-ARG REVIEWLOOP_VERSION=0.5.0
+ARG REVIEWLOOP_VERSION=0.6.0
 # Node major version (must be >= 18 for the alissa CLI and claude-code).
 ARG NODE_MAJOR=22
 


### PR DESCRIPTION
Bumps the baked `ARG REVIEWLOOP_VERSION` default 0.5.0 → **0.6.0** (published on PyPI — envelope round-count + collision-proof session names). Also fixes a stale README note (round counting is the task's verdict envelopes now, not gh). Railway env override still wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)