### PR TITLE
TASK-1898024596: re-pin REVIEWLOOP_VERSION → 0.7.0

### DIFF
--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -26,7 +26,7 @@
 FROM python:3.12-slim-bookworm
 
 # Version of the daemon to install from PyPI. Bump per release.
-ARG REVIEWLOOP_VERSION=0.6.0
+ARG REVIEWLOOP_VERSION=0.7.0
 # Node major version (must be >= 18 for the alissa CLI and claude-code).
 ARG NODE_MAJOR=22
 


### PR DESCRIPTION
Bumps the baked `ARG REVIEWLOOP_VERSION` default 0.6.0 → **0.7.0** — now **published on PyPI** (convergence head-binding fix that unfreezes studio#227, on top of round-count + reaping). Safe to merge now.

After merge: bump your Railway `REVIEWLOOP_VERSION` to `0.7.0` and redeploy → everything from this session goes live, and #227 gets a round-2 review on the next poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)