### PR TITLE
entrypoint: sync worktree hubs at boot (fixes the empty-hub hub-ify loop)

### DIFF
--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -272,8 +272,13 @@ volumes:
    `gh auth setup-git`; `alissa auth login` (fatal if missing); check the claude
    credential (warn-only — the baked `agents.yaml` handles headless launch).
 2. Ensure a manifest + `reviewloop.config.json` exist (mount or generate).
-3. Start `alissa worker --daemon`, wait until it reports running (the daemon only
+3. **`alissa code workspace sync`** — materialize the worktree hubs the manifest
+   declares (create missing/half-built ones, fetch existing). Without this the
+   daemon's on-demand `alissa code workspace add` no-ops on a repo already listed
+   in the manifest, leaving an empty folder and looping forever hub-ifying a hub
+   that never completes.
+4. Start `alissa worker --daemon`, wait until it reports running (the daemon only
    *warns* if the worker is absent, so ordering matters).
-4. Run `alissa-reviewloop` in the foreground; stop the worker on `SIGTERM`/`SIGINT`.
+5. Run `alissa-reviewloop` in the foreground; stop the worker on `SIGTERM`/`SIGINT`.
 
 `tini` is PID 1 to reap the tmux/node/claude child fan-out.

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -271,6 +271,24 @@ PY
 fi
 
 # -----------------------------------------------------------------------------
+# 3c. Materialize the worktree hubs the manifest declares.
+#
+# The manifest lists every allowlisted repo, but the hub directories
+# (bare clone + main/ worktree) don't exist until something creates them. The
+# daemon's on_missing_hub:add uses `alissa code workspace add`, which is
+# idempotent BY MANIFEST ENTRY -- for a repo already listed it no-ops, leaving an
+# empty folder and no main/, and the daemon then loops forever hub-ifying a hub
+# that never completes. `workspace sync` is the reconcile operation: it creates
+# the missing/half-built hubs (and fetches existing ones) to match the manifest.
+# Run it here (auth is wired, the manifest exists) so every hub is real before
+# the daemon polls -- exactly the manual `sync` an operator would otherwise run.
+if [ -f "${MANIFEST}" ]; then
+  log "syncing worktree hubs to the manifest (alissa code workspace sync)"
+  ( cd "${WORKSPACE_ROOT}" && alissa code workspace sync ) \
+    || log "WARN: workspace sync did not fully complete — the daemon will retry per-repo, but check for clone/auth errors above"
+fi
+
+# -----------------------------------------------------------------------------
 # 4. Start the worker, wait until it reports running.
 # -----------------------------------------------------------------------------
 mkdir -p "${TMUX_TMPDIR:-/home/alissa/.tmux}"


### PR DESCRIPTION
Fixes the daemon freezing on a newly-allowlisted repo (seen live on `alissa-github-develop-daemon#2`).

## Root cause (confirmed live)
The manifest lists every allowlisted repo, but a hub dir is just a placeholder folder until something clones into it. The daemon's `on_missing_hub: add` uses `alissa code workspace add`, which is **idempotent by manifest entry** — for a repo already listed it **no-ops**, leaving an empty folder with no `main/` worktree. So `hub.is_dir()` stays False and the daemon re-hub-ifies **every poll, forever** — and the failure is a `SKIPPED` decision logged at **DEBUG**, so it's invisible at INFO level.

Operator confirmed: the folder existed empty; `alissa code workspace sync` created `main/` and the review ran. (Private vs public was a red herring — `studio.alissa.app` is private too and works because its hub already existed on the volume.)

## Fix
The entrypoint now runs **`alissa code workspace sync`** after the manifest is generated + gh auth is wired, before the daemon starts. `sync` is the *reconcile* op — it creates missing/half-built hubs to match the manifest — so every hub is real before the first poll. Non-fatal on partial failure (warns; the daemon still retries per-repo). This automates the manual `sync` an operator would otherwise run for each new repo.

## Note
Entrypoint-only (no package change / version bump). A deeper daemon fix — make `on_missing_hub` self-heal by falling back to `sync` when `add` leaves an incomplete hub — is a good follow-up for the non-container / mid-run case, but the boot-sync covers the container: every (re)start (incl. every Railway redeploy after an env change) materializes all hubs.

⚠️ Branch lacks a TASK id — the Alissa MCP server was disconnected when this was authored; I'll attach a task once it reconnects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)