### PR TITLE
TASK-919382604: back-port the devloop CI hardenings (guarded wheel check, least privilege)

### DIFF
--- a/.github/workflows/check-style.yaml
+++ b/.github/workflows/check-style.yaml
@@ -1,6 +1,11 @@
 name: Check Python Style
 on: [pull_request]
 
+# Least privilege: these jobs only read the checkout (back-ported from the
+# devloop repo, review finding on its PR #11).
+permissions:
+  contents: read
+
 jobs:
   python-style-check:
     strategy:

--- a/.github/workflows/check-tests.yaml
+++ b/.github/workflows/check-tests.yaml
@@ -1,6 +1,11 @@
 name: Check Unit-Tests and Simple Coverage Report
 on: [pull_request]
 
+# Least privilege: these jobs only read the checkout (back-ported from the
+# devloop repo, review finding on its PR #11).
+permissions:
+  contents: read
+
 jobs:
   python-unit-testing:
     strategy:

--- a/.github/workflows/check-types.yaml
+++ b/.github/workflows/check-types.yaml
@@ -1,8 +1,13 @@
 name: Check Python Types
 on: [pull_request]
 
+# Least privilege: these jobs only read the checkout (back-ported from the
+# devloop repo, review finding on its PR #11).
+permissions:
+  contents: read
+
 jobs:
-  python-unit-testing:
+  python-types-check:
     strategy:
       matrix:
         path:

--- a/.github/workflows/check-wheel.yaml
+++ b/.github/workflows/check-wheel.yaml
@@ -1,6 +1,11 @@
 name: Check Creation of Wheel Package
 on: [pull_request]
 
+# Least privilege: these jobs only read the checkout (back-ported from the
+# devloop repo, review finding on its PR #11).
+permissions:
+  contents: read
+
 jobs:
   python-wheel-check:
     strategy:
@@ -28,5 +33,5 @@ jobs:
         run: python -m pip install ${{ matrix.path }}/dist/*.whl
       - name: Execute Simple Command to Verify Installation
         run: |
-          python -c "from alissa.tools.github.reviewloop.version import version; print(version)"
+          python -c "from alissa.tools.github.reviewloop.version import version; assert version.value != '0.0.0', version; print(version)"
           alissa-reviewloop --help

--- a/.github/workflows/package-publish.yaml
+++ b/.github/workflows/package-publish.yaml
@@ -1,9 +1,11 @@
 name: Python Package Publish
 
 # Publishing is irreversible: a version number, once on PyPI, can never be
-# reused even if the release is deleted. The version file is therefore the
-# release trigger -- merging a PR that does not bump it publishes nothing,
-# and twine's --skip-existing keeps a re-run from failing the workflow.
+# reused even if the release is deleted. ANY merged PR touching the dist
+# subtree (or this file) runs the full build and upload; what prevents a
+# duplicate release is twine's --skip-existing on the upload, which lets
+# PyPI reject versions it already has. To release, bump the version file and
+# merge; to merge without releasing, touch nothing under the dist subtree.
 
 on:
   pull_request:
@@ -14,6 +16,12 @@ on:
       - closed
     branches:
       - main
+
+# Least privilege: PyPI auth is TWINE_* env secrets, not the GitHub token, so
+# this job never needs write scope (back-ported from the devloop repo, review
+# finding on its PR #11).
+permissions:
+  contents: read
 
 jobs:
   python-publish:
@@ -46,5 +54,4 @@ jobs:
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-          GH_BRANCH: ${{ github.ref }}
         run: twine upload --verbose --skip-existing ${{ matrix.path }}/dist/*


### PR DESCRIPTION
Closes #17

Back-ports the CI hardenings this repo's own review loop prescribed for the devloop repo (its PR #11); reference implementation: `fahera-mx/alissa-github-develop-daemon` `.github/workflows/` @ `6b5a0d4`. Workflows only — no source, tests, or docker changes (a parallel branch owns the reviewloop source files).

## Changes

- **check-wheel.yaml** — the verify step can now fail: `assert version.value != '0.0.0', version`. Previously `version.py`'s bare-except fallback made a wheel missing its `version` data file pass green.
- **All five workflows** — `permissions: contents: read` (least privilege; PyPI auth is `TWINE_*` secrets, never the GitHub token).
- **check-types.yaml** — job id `python-unit-testing` → `python-types-check`.
- **package-publish.yaml** — dropped the unused `GH_BRANCH` env; corrected the header comment (the paths filter on the dist subtree is the trigger; `--skip-existing` is what prevents duplicate releases).

## Verification (local)

- All five workflow files parse as YAML (`yaml.safe_load`).
- The four check scripts the workflows execute run green: `check-style.sh`, `check-types.sh`, `tests-unit.sh`, `tests-coverage.sh` (Python 3.12 venv, `requirements-develop.txt`, editable install).
- **Mutation-verified** the wheel guard: built the wheel, installed it, baseline verify step passes (`0.7.0`); deleted the packaged `version` data file from site-packages → the guarded step now fails with `AssertionError: Version(name='alissa-tools-github-reviewloop', value='0.0.0')` (the unguarded step printed `0.0.0` and passed).

---
Alissa-Task: TASK-919382604 (downstream of TASK-841250126)

🤖 Generated with [Claude Code](https://claude.com/claude-code)