### PR TITLE
TASK-430061608: re-pin REVIEWLOOP_VERSION → 0.8.0 (session sweep to the deployed container)

### DIFF
--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -26,7 +26,7 @@
 FROM python:3.12-slim-bookworm
 
 # Version of the daemon to install from PyPI. Bump per release.
-ARG REVIEWLOOP_VERSION=0.6.0
+ARG REVIEWLOOP_VERSION=0.8.0
 # Node major version (must be >= 18 for the alissa CLI and claude-code).
 ARG NODE_MAJOR=22
 


### PR DESCRIPTION
Re-pins the reviewer container to reviewloop **0.8.0** so the deployed daemon picks up the fixes that merged to main in PR #19. One-line change to `docker/claude/Dockerfile` (`ARG REVIEWLOOP_VERSION` 0.6.0 → 0.8.0), same release pattern as the prior re-pin PRs. Verified `alissa-tools-github-reviewloop==0.8.0` is published on PyPI (latest) before pinning.

Supersedes draft PR #14 (which pinned 0.7.0 and should be closed, not merged).

## Release content since 0.7.0

- **Search-independent session sweep** — the daemon now enumerates and reaps idle `review-*` sessions directly instead of relying on search, fixing the live session-accumulation in the deployed container.
- **Interrupt-safe `run_forever` sleep** — the loop sleep now wakes promptly on interrupt instead of blocking shutdown for the full interval.

## Operator follow-through

1. Rebuild and redeploy the reviewer container from this Dockerfile.
2. Observe the sweep reaping the accumulated idle `review-*` sessions after the redeployed daemon's first cycles.

## Verification

All four repo scripts green locally: `tests-unit.sh` (111 passed), `tests-coverage.sh`, `check-style.sh`, `check-types.sh`. Nothing outside the Dockerfile pin changed (entrypoint hub-sync is PR #15, separate branch).

Closes #20

Alissa-Task: TASK-430061608

🤖 Generated with [Claude Code](https://claude.com/claude-code)
