### PR TITLE
Container: pin the reviewer model via ALISSA_AGENT_MODEL (default opus)

### DIFF
--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -181,6 +181,11 @@ ARG ALISSA_REVIEW_SKILLS="alissa-code-workspace|alissa-code-review"
 ARG ALISSA_POLL_INTERVAL="60"
 ARG ALISSA_ROUND_CAP="3"
 ARG ALISSA_AGENT_PROFILE="claude"
+# Reviewer model pinned into the agents.yaml claude command at boot (the reviewer
+# is the quality gate, so it must not silently fall back to a smaller model on a
+# usage-throttled account). Alias (`opus`/`sonnet`) or full id (`claude-opus-4-8`);
+# `default` or empty omits the --model flag. See the entrypoint (step 2d) + README.
+ARG ALISSA_AGENT_MODEL="opus"
 ARG ALISSA_ON_MISSING_HUB="add"
 # Worker reconcile tick, seconds.
 ARG ALISSA_WORKER_INTERVAL="2"
@@ -194,6 +199,7 @@ ENV ALISSA_REVIEW_REPOS=${ALISSA_REVIEW_REPOS} \
     ALISSA_POLL_INTERVAL=${ALISSA_POLL_INTERVAL} \
     ALISSA_ROUND_CAP=${ALISSA_ROUND_CAP} \
     ALISSA_AGENT_PROFILE=${ALISSA_AGENT_PROFILE} \
+    ALISSA_AGENT_MODEL=${ALISSA_AGENT_MODEL} \
     ALISSA_ON_MISSING_HUB=${ALISSA_ON_MISSING_HUB} \
     ALISSA_WORKER_INTERVAL=${ALISSA_WORKER_INTERVAL} \
     ALISSA_ENABLE_FIREWALL=${ALISSA_ENABLE_FIREWALL} \

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -102,10 +102,42 @@ A `reviewer_login` that disagrees with the `GH_TOKEN` is **fatal at the daemon's
 own startup** (every round would look like round 1 and respawn forever) — so keep
 the token and any configured login in sync.
 
-The reviewer's claude launch command lives in [`agents.yaml`](./agents.yaml)
-(pin a model or change flags there, or mount your own over
-`/home/alissa/.config/alissa/agents.yaml`). The image runs as a non-root user
+The reviewer's claude launch command lives in [`agents.yaml`](./agents.yaml). To
+pin the model, set `ALISSA_AGENT_MODEL` (see [Pinning the reviewer model](#pinning-the-reviewer-model))
+rather than editing the file; to change flags, mount your own file over
+`/home/alissa/.config/alissa/agents.yaml`. The image runs as a non-root user
 because claude refuses `--dangerously-skip-permissions` as root.
+
+### Pinning the reviewer model
+
+The reviewer is the pipeline's **quality gate**: if its recall degrades nothing
+downstream notices. The baked [`agents.yaml`](./agents.yaml) pins no model, so a
+reviewer inherits whatever the persisted `claude /login` account defaults to —
+and on plan-based accounts that default can **silently fall back to a smaller
+model** once a usage threshold is hit. `ALISSA_AGENT_MODEL` makes the model an
+explicit boot-time decision instead of a rebuild-time one.
+
+At container boot the entrypoint appends `--model "$ALISSA_AGENT_MODEL"` to the
+claude profile's `command:` and logs the effective command (grep the startup log
+for `effective reviewer command:`).
+
+| `ALISSA_AGENT_MODEL` | reviewer `command:` becomes |
+| --- | --- |
+| *(unset)* → default `opus` | `claude … --model opus` |
+| `claude-opus-4-8` (any alias or full id) | `claude … --model claude-opus-4-8` |
+| `default` *or* empty | `claude …` (no `--model` — restores account default) |
+
+The value passes through **verbatim** — both aliases (`opus`, `sonnet`) and full
+ids (`claude-opus-4-8`) are valid; there is no allowlist.
+
+**Precedence.** The entrypoint only rewrites the **baked default** profile, which
+it recognizes by an `alissa-managed:` marker comment. A custom `agents.yaml`
+mounted over `/home/alissa/.config/alissa/agents.yaml` carries no such marker, so
+it is used **verbatim** and `ALISSA_AGENT_MODEL` is ignored for it — the mounted
+command (including any `--model` you set there) always wins. This is unchanged for
+every other field: flags, `mode`, `quietSeconds`, and `promptPatterns` are
+untouched, and reviewer posture (CR6: reviewers never write) stays enforced by the
+round directive, independent of the model.
 
 ## Configuration (build ARGs — Railway-friendly)
 
@@ -126,6 +158,7 @@ automatically; locally pass `--build-arg`):
 | `ALISSA_POLL_INTERVAL` | `60` | seconds between polls (≥10) |
 | `ALISSA_ROUND_CAP` | `3` | CR9 round cap |
 | `ALISSA_AGENT_PROFILE` | `claude` | agent the worker launches |
+| `ALISSA_AGENT_MODEL` | `opus` | model pinned into the reviewer's claude command (see [Pinning the reviewer model](#pinning-the-reviewer-model)); `default` or empty omits the pin |
 | `ALISSA_ON_MISSING_HUB` | `add` | `add` hub-ifies on demand; `skip` to require a mounted workspace |
 | `ALISSA_WORKER_INTERVAL` | `2` | worker reconcile tick (seconds) |
 | `ALISSA_ENABLE_FIREWALL` | `0` | `1` raises the egress firewall (needs `--cap-add=NET_ADMIN`) |

--- a/docker/claude/agents.yaml
+++ b/docker/claude/agents.yaml
@@ -9,8 +9,16 @@
 # root) — the image runs as uid 1000, which satisfies it. Reviewer posture (CR6:
 # reviewers never write) is enforced by the round directive, not by this profile.
 #
-# To pin a model or tweak flags, override the command below (edit this file
-# before build, or mount your own agents.yaml over it at runtime).
+# To pin the reviewer model, set the ALISSA_AGENT_MODEL env var (default: opus) —
+# the entrypoint rewrites the `command:` below with `--model "$ALISSA_AGENT_MODEL"`
+# at container boot (set it to `default` or empty to omit the flag and inherit the
+# account default). To change flags instead, mount your own agents.yaml over this
+# path at runtime; a mounted file lacks the `alissa-managed:` marker below and is
+# used verbatim, so ALISSA_AGENT_MODEL does not touch it (your command wins).
+#
+# alissa-managed: the entrypoint regenerates the `command:` line of this default
+# profile at boot from ALISSA_AGENT_MODEL — do not remove this marker line, it is
+# what distinguishes the baked default from a runtime-mounted custom agents.yaml.
 claude:
   command: claude --dangerously-skip-permissions --permission-mode acceptEdits
   mode: interactive

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -101,6 +101,61 @@ alissa auth login --token "${ALISSA_API_TOKEN}" >/dev/null 2>&1 \
 log "alissa authenticated"
 
 # -----------------------------------------------------------------------------
+# 2d. Resolve the reviewer model into the baked agents.yaml.
+#
+# The reviewer is the pipeline's quality gate, but the baked claude profile pins
+# no model — so it inherits the persisted /login account's default, which can
+# silently fall back to a smaller model when a plan hits its usage threshold. We
+# pin it explicitly at boot: ALISSA_AGENT_MODEL (default `opus`) is appended to
+# the profile's `command:` as `--model <value>`. The value passes through
+# verbatim — aliases (`opus`, `sonnet`) and full ids (`claude-opus-4-8`) are both
+# valid, no allowlist. `default` or an empty value omits the flag entirely,
+# restoring the account-default behavior.
+#
+# Precedence: we only rewrite the BAKED default (identified by its `alissa-managed:`
+# marker). A custom agents.yaml mounted over this path carries no marker, so it is
+# left verbatim and ALISSA_AGENT_MODEL is ignored for it — the mounted command
+# always wins. The baked file lives in the ephemeral home (not on the volume), so
+# it is pristine on every boot and this rewrite is idempotent.
+# -----------------------------------------------------------------------------
+AGENTS_YAML="${HOME}/.config/alissa/agents.yaml"
+# Default `opus` only when UNSET (use `-`, not `:-`): an explicitly empty value is
+# a valid opt-out and must NOT be re-defaulted back to opus.
+AGENT_MODEL="${ALISSA_AGENT_MODEL-opus}"
+if [ ! -f "${AGENTS_YAML}" ]; then
+  log "WARN: ${AGENTS_YAML} not found — skipping model pin (worker will fall back to a bare claude)"
+elif ! grep -q 'alissa-managed:' "${AGENTS_YAML}"; then
+  log "custom agents.yaml in effect (no alissa-managed marker) — using it verbatim, ALISSA_AGENT_MODEL ignored"
+else
+  BASE_CMD="claude --dangerously-skip-permissions --permission-mode acceptEdits"
+  if [ -z "${AGENT_MODEL}" ] || [ "${AGENT_MODEL}" = "default" ]; then
+    CLAUDE_CMD="${BASE_CMD}"
+    log "reviewer model: account default (ALISSA_AGENT_MODEL='${AGENT_MODEL}') — no --model flag"
+  else
+    CLAUDE_CMD="${BASE_CMD} --model ${AGENT_MODEL}"
+    log "reviewer model: ${AGENT_MODEL} (ALISSA_AGENT_MODEL)"
+  fi
+  # Rewrite the profile's `command:` line. python (not sed) so an arbitrary
+  # passed-through model value can't collide with a substitution metacharacter.
+  python3 - "${AGENTS_YAML}" "${CLAUDE_CMD}" <<'PY' || die "failed to render agents.yaml"
+import re, sys
+path, cmd = sys.argv[1], sys.argv[2]
+out, seen = [], False
+for ln in open(path).read().splitlines(keepends=True):
+    m = re.match(r'^(\s*)command:\s', ln)
+    if m and not seen:
+        out.append(f"{m.group(1)}command: {cmd}\n")
+        seen = True
+    else:
+        out.append(ln)
+if not seen:
+    sys.exit("no `command:` line found in agents.yaml")
+open(path, "w").writelines(out)
+PY
+  log "effective reviewer command: ${CLAUDE_CMD}"
+fi
+
+# -----------------------------------------------------------------------------
 # 3. Bootstrap the workspace (bootstrap-from-manifest model)
 #
 # Reviewers cd into {root}/{repo}/main worktree hubs. With on_missing_hub:add


### PR DESCRIPTION
## Summary

Makes the reviewer's claude model a **boot-time env var** instead of a rebuild-time edit of `agents.yaml`. The baked profile pinned no `--model`, so reviewers inherited the persisted `/login` account default — which on plan-based accounts can silently fall back to a smaller model under usage throttling. The reviewer is the pipeline's quality gate, so that degrades review recall unnoticed.

`docker/claude/` tier only — **no Python package changes, no reviewloop version bump**.

## Change

- **`ALISSA_AGENT_MODEL`, default `opus`.** At boot the entrypoint (new step `2d`) rewrites the baked claude profile's `command:` with `--model <value>` and logs the effective command (`effective reviewer command: …`).
- **Opt-out:** `ALISSA_AGENT_MODEL=default` (or empty) omits the `--model` flag, restoring account-default behavior. Any other value passes through **verbatim** — aliases (`opus`/`sonnet`) and full ids (`claude-opus-4-8`) both valid, no allowlist.
- **Precedence:** only the baked default (identified by an `alissa-managed:` marker comment) is rewritten. A runtime-mounted custom `agents.yaml` carries no marker and is used **verbatim** — the mounted command always wins.
- **No behavior change elsewhere:** flags, `mode`, `quietSeconds`, `promptPatterns` untouched; CR6 reviewer posture stays enforced by the round directive.
- Dockerfile: `ALISSA_AGENT_MODEL` added as an ARG→ENV (Railway-friendly, default `opus`). README: runtime-variables table row + a "Pinning the reviewer model" section (default, accepted values, opt-out, precedence, silent-fallback rationale). `agents.yaml`: stale "edit this file before build" comment now points at the env var.

## Acceptance (verified locally against the extracted entrypoint block)

| `ALISSA_AGENT_MODEL` | resulting `command:` |
| --- | --- |
| *(unset)* | `claude … --model opus` ✅ |
| `claude-opus-4-8` | `claude … --model claude-opus-4-8` ✅ |
| `default` / empty | `claude …` (no `--model`) ✅ |
| mounted custom (no marker) | left verbatim, ignored ✅ |

`bash -n` clean; baked + rewritten `agents.yaml` both parse (PyYAML) with all other profile fields intact. No entrypoint test file added — the repo has no existing entrypoint tests (its CI covers only the Python package, unchanged here).

Mirrors fahera-mx/alissa-github-develop-daemon#28 (variable name / default / opt-out kept byte-consistent); the devloop repo is not touched from this branch.

Closes #26

---

**Task refs**
- Origin task: TASK-1843563761
- Implementation task: TASK-1721233512