### PR TITLE
entrypoint: stop shadowing library config defaults (pass-through-when-unset)

### DIFF
--- a/.github/workflows/check-entrypoint.yaml
+++ b/.github/workflows/check-entrypoint.yaml
@@ -1,0 +1,36 @@
+name: Check Container Entrypoint Config Rendering
+on: [pull_request]
+
+# The env-driven entrypoint renders reviewloop.config.json with a
+# pass-through-when-unset contract (optional tuning keys are omitted so the
+# daemon library default applies; structural keys stay pinned). This check
+# exercises that renderer directly — see docker/claude/tests-entrypoint-config.sh.
+jobs:
+  entrypoint-config-check:
+    name: Entrypoint config renderer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+      - name: Install daemon package (for the library-default cross-check)
+        # Install the SAME PyPI release the image ships (REVIEWLOOP_VERSION pinned
+        # in the Dockerfile), not the repo source tree, so the cross-check
+        # validates the library the container actually runs and would catch a
+        # pin/default divergence (e.g. a README default that drifts from the pin).
+        run: |
+          python -m pip install --upgrade pip
+          version="$(grep -oP '^ARG REVIEWLOOP_VERSION=\K[0-9.]+' docker/claude/Dockerfile)"
+          echo "Installing alissa-tools-github-reviewloop==${version} (pinned in Dockerfile)"
+          python -m pip install "alissa-tools-github-reviewloop==${version}"
+      - name: Execute Entrypoint Config Tests
+        run: bash docker/claude/tests-entrypoint-config.sh

--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -93,8 +93,9 @@ RUN git config --system url."https://github.com/".insteadOf "git@github.com:" \
 
 # --- Entrypoint + optional firewall ------------------------------------------
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY reviewloop-config.sh /usr/local/bin/reviewloop-config.sh
 COPY init-firewall.sh /usr/local/bin/init-firewall.sh
-RUN chmod 0755 /usr/local/bin/entrypoint.sh /usr/local/bin/init-firewall.sh
+RUN chmod 0755 /usr/local/bin/entrypoint.sh /usr/local/bin/reviewloop-config.sh /usr/local/bin/init-firewall.sh
 
 USER alissa
 WORKDIR /home/alissa
@@ -178,8 +179,21 @@ ARG ALISSA_WORKSPACE="alissa-review"
 # alissa-code-git (read-only reviewers never commit).
 ARG ALISSA_REVIEW_SKILLS="alissa-code-workspace|alissa-code-review"
 # Daemon knobs (see the daemon README's settings table).
-ARG ALISSA_POLL_INTERVAL="60"
-ARG ALISSA_ROUND_CAP="3"
+#
+# ALISSA_POLL_INTERVAL / ALISSA_ROUND_CAP are PASS-THROUGH: their ARG default is
+# empty ON PURPOSE, so when the operator does not set them the entrypoint OMITS
+# the key from the generated config and the daemon library's own current default
+# applies (env var > library default). Baking a concrete value here would shadow
+# the library default — the exact defect this repo's #30 removed. The library
+# defaults at the pinned REVIEWLOOP_VERSION are poll_interval=60, round_cap=3;
+# they are documented in the README, not duplicated here.
+ARG ALISSA_POLL_INTERVAL=""
+ARG ALISSA_ROUND_CAP=""
+# STRUCTURAL container constants (not pass-through): agent_profile must name a
+# profile the baked agents.yaml ships (`claude`); on_missing_hub must be `add`
+# for the self-contained hub-ify-on-demand model (the library default `skip`
+# would review nothing on a fresh volume). Kept explicit and pinned by
+# tests-entrypoint-config.sh.
 ARG ALISSA_AGENT_PROFILE="claude"
 # Reviewer model pinned into the agents.yaml claude command at boot (the reviewer
 # is the quality gate, so it must not silently fall back to a smaller model on a

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -155,14 +155,33 @@ automatically; locally pass `--build-arg`):
 | `ALISSA_REVIEW_REPOS` | *(required if no manifest mounted)* | allowlist as one `\|`-separated string (see below) |
 | `ALISSA_WORKSPACE` | `alissa-review` | workspace name in the generated manifest |
 | `ALISSA_REVIEW_SKILLS` | `alissa-code-workspace\|alissa-code-review` | skills installed into every reviewer session (manifest `skills:`), `\|`-separated |
-| `ALISSA_POLL_INTERVAL` | `60` | seconds between polls (≥10) |
-| `ALISSA_ROUND_CAP` | `3` | CR9 round cap |
-| `ALISSA_AGENT_PROFILE` | `claude` | agent the worker launches |
+| `ALISSA_POLL_INTERVAL` | *daemon default* (currently 60) | seconds between polls (≥10); **pass-through** — unset ⇒ library default |
+| `ALISSA_ROUND_CAP` | *daemon default* (currently 3) | CR9 round cap; **pass-through** — unset ⇒ library default |
+| `ALISSA_AGENT_PROFILE` | `claude` | agent the worker launches (must name a profile in `agents.yaml`) |
 | `ALISSA_AGENT_MODEL` | `opus` | model pinned into the reviewer's claude command (see [Pinning the reviewer model](#pinning-the-reviewer-model)); `default` or empty omits the pin |
 | `ALISSA_ON_MISSING_HUB` | `add` | `add` hub-ifies on demand; `skip` to require a mounted workspace |
 | `ALISSA_WORKER_INTERVAL` | `2` | worker reconcile tick (seconds) |
 | `ALISSA_ENABLE_FIREWALL` | `0` | `1` raises the egress firewall (needs `--cap-add=NET_ADMIN`) |
 | `ALISSA_FIREWALL_EXTRA` | *(empty)* | extra firewall allowlist hosts, space-separated |
+
+#### Config precedence: env var > daemon library default
+
+The optional tuning knobs `ALISSA_POLL_INTERVAL` and `ALISSA_ROUND_CAP` are
+**pass-through**: their build `ARG` default is empty, and when they are unset the
+entrypoint **omits the key entirely** from the generated `reviewloop.config.json`
+so the daemon library applies its own current default. There is no hidden
+entrypoint fallback layer that would shadow it — set the env var to override,
+leave it unset to inherit the library default (which is why the "default" column
+above says *daemon default* rather than a baked number, and why upgrading the
+daemon can change these without a Dockerfile edit). The parenthetical values are
+the library defaults at the pinned `REVIEWLOOP_VERSION`, informational only.
+
+`ALISSA_AGENT_PROFILE` and `ALISSA_ON_MISSING_HUB` are **not** pass-through: they
+are container constants the image requires. `agent_profile` must name a profile
+that the baked [`agents.yaml`](./agents.yaml) ships (`claude`), and
+`on_missing_hub` must be `add` for the self-contained hub-ify-on-demand model —
+the library default `skip` would make a fresh volume review nothing. Both are
+still overridable via their env var.
 
 ### The repos allowlist string
 

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -16,6 +16,13 @@ set -euo pipefail
 log()  { printf '[entrypoint] %s\n' "$*" >&2; }
 die()  { printf '[entrypoint] FATAL: %s\n' "$*" >&2; exit 1; }
 
+# reviewloop.config.json renderer (pass-through-when-unset). Kept in a sibling
+# script so it can be unit-tested standalone (tests-entrypoint-config.sh). It
+# lives next to this file both in the image (/usr/local/bin) and in the repo.
+ENTRYPOINT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=reviewloop-config.sh
+. "${ENTRYPOINT_DIR}/reviewloop-config.sh"
+
 WORKSPACE_ROOT="${ALISSA_WORKSPACE_ROOT:-/workspace}"
 WORKSPACE_NAME="${ALISSA_WORKSPACE:-alissa-review}"
 RUNTIME_USER=alissa
@@ -213,20 +220,13 @@ if [ -n "$(repos_lines)" ]; then
     printf 'attributes: {}\n'
   } > "${MANIFEST}"
 
+  # The generated config PASSES THROUGH optional tuning keys: an unset
+  # ALISSA_POLL_INTERVAL / ALISSA_ROUND_CAP is omitted so the daemon library's
+  # own default applies (env var > library default, no shadowing entrypoint
+  # layer). Structural keys (on_missing_hub, agent_profile) are always emitted.
+  # See reviewloop-config.sh for the precedence contract and per-key rationale.
   repos_json="$(repos_lines | jq -R . | jq -s -c .)"
-  jq -n \
-    --argjson repos "${repos_json}" \
-    --argjson poll   "${ALISSA_POLL_INTERVAL:-60}" \
-    --argjson cap    "${ALISSA_ROUND_CAP:-3}" \
-    --arg     agent  "${ALISSA_AGENT_PROFILE:-claude}" \
-    --arg     hub    "${ALISSA_ON_MISSING_HUB:-add}" \
-    '{
-       repos: $repos,
-       poll_interval: $poll,
-       round_cap: $cap,
-       agent_profile: $agent,
-       on_missing_hub: $hub
-     }' > "${CONFIG}"
+  render_reviewloop_config "${repos_json}" > "${CONFIG}"
 else
   # MOUNTED MODE: no allowlist in the env — respect a mounted workspace as-is.
   [ -f "${MANIFEST}" ] \

--- a/docker/claude/reviewloop-config.sh
+++ b/docker/claude/reviewloop-config.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Render reviewloop.config.json from the environment.
+#
+# Precedence contract:  env var  >  daemon library default.  There is NO hidden
+# entrypoint layer in between for optional tuning knobs — the entrypoint used to
+# inject EVERY key with its own hardcoded fallback (e.g. `round_cap: 3`), which
+# SHADOWED the library's own default: a library that raised its default (say to
+# 10) could never take effect in the container, because the entrypoint always
+# wrote the old value unless the operator happened to set ALISSA_ROUND_CAP.
+#
+# So keys fall into two classes:
+#
+#   * PASS-THROUGH (optional tuning knobs) — emitted ONLY when the env var is
+#     set. When unset the key is omitted entirely and the daemon library applies
+#     its own current default. These are pure tuning values where the library is
+#     the authority: poll_interval, round_cap.
+#
+#   * STRUCTURAL (container constants) — always emitted with an explicit value
+#     the container requires, INDEPENDENT of the library default. Pass-through is
+#     unsafe here (see the per-key rationale below), so the value is byte-pinned
+#     and covered by tests-entrypoint-config.sh:
+#       - on_missing_hub = add     the container's whole model is self-contained
+#                                  hub-ify on demand; the library default is
+#                                  `skip`, which would make a fresh volume review
+#                                  nothing. (Bounded: `add` requires a non-empty
+#                                  repos allowlist, which env-driven mode always
+#                                  has.)
+#       - agent_profile  = claude  must name a profile that exists in the baked
+#                                  agents.yaml, which defines exactly `claude`;
+#                                  drifting to some future library default would
+#                                  select a profile the image does not ship.
+#
+# `repos` is required (env-driven mode only calls this with a non-empty
+# allowlist) and always emitted.
+#
+# Usage:  reviewloop-config.sh '<repos-json-array>'   # prints config JSON
+# Or source it and call render_reviewloop_config '<repos-json-array>'.
+# =============================================================================
+set -euo pipefail
+
+render_reviewloop_config() {
+  local repos_json="$1"
+  # --arg (string) + tonumber for the numeric pass-through keys: an unset/empty
+  # env var yields "" and the key is dropped, so the library default wins.
+  jq -n \
+    --argjson repos "${repos_json}" \
+    --arg     hub    "${ALISSA_ON_MISSING_HUB:-add}" \
+    --arg     agent  "${ALISSA_AGENT_PROFILE:-claude}" \
+    --arg     poll   "${ALISSA_POLL_INTERVAL:-}" \
+    --arg     cap    "${ALISSA_ROUND_CAP:-}" \
+    '{ repos: $repos, on_missing_hub: $hub, agent_profile: $agent }
+     + (if $poll == "" then {} else { poll_interval: ($poll | tonumber) } end)
+     + (if $cap  == "" then {} else { round_cap:     ($cap  | tonumber) } end)'
+}
+
+# Direct execution renders to stdout; sourcing just defines the function.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  render_reviewloop_config "${1:?usage: reviewloop-config.sh <repos-json-array>}"
+fi

--- a/docker/claude/tests-entrypoint-config.sh
+++ b/docker/claude/tests-entrypoint-config.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Tests for the entrypoint's reviewloop.config.json renderer (#30).
+#
+# Proves the pass-through-when-unset contract:
+#   * unset optional knobs  -> key OMITTED (library default applies)
+#   * set optional knobs    -> key present with the given value (override wins)
+#   * structural keys        -> always present with their pinned container value
+#
+# Pure shell + jq for the structural assertions (runs anywhere jq exists). A
+# final cross-check, run only when the daemon package is importable, boots the
+# omitted-key config through the real Config.build and asserts the effective
+# value equals the library default — the acceptance criterion's "effective
+# daemon config equals library defaults", verified against the actual library.
+#
+# Usage: bash docker/claude/tests-entrypoint-config.sh
+# =============================================================================
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=reviewloop-config.sh
+. "${HERE}/reviewloop-config.sh"
+
+REPOS='["fahera-mx/studio.alissa.app"]'
+fail=0
+pass() { printf '  ok   %s\n' "$1"; }
+bad()  { printf '  FAIL %s\n' "$1" >&2; fail=1; }
+
+# assert_key_absent <json> <key> <label>
+assert_key_absent() {
+  if printf '%s' "$1" | jq -e "has(\"$2\")" >/dev/null; then
+    bad "$3 (expected key '$2' absent, but present)"
+  else
+    pass "$3"
+  fi
+}
+# assert_eq <json> <jq-filter> <expected> <label>
+assert_eq() {
+  local got; got="$(printf '%s' "$1" | jq -c "$2")"
+  if [ "${got}" = "$3" ]; then pass "$4"; else bad "$4 (got ${got}, want $3)"; fi
+}
+
+echo "== pass-through: optional knobs omitted when env unset =="
+out="$(env -u ALISSA_POLL_INTERVAL -u ALISSA_ROUND_CAP \
+        bash -c '. "'"${HERE}"'/reviewloop-config.sh"; render_reviewloop_config '"'${REPOS}'"'')"
+assert_key_absent "${out}" poll_interval "poll_interval omitted when ALISSA_POLL_INTERVAL unset"
+assert_key_absent "${out}" round_cap     "round_cap omitted when ALISSA_ROUND_CAP unset"
+assert_eq "${out}" '.on_missing_hub' '"add"'    "on_missing_hub always emitted (structural: add)"
+assert_eq "${out}" '.agent_profile'  '"claude"' "agent_profile always emitted (structural: claude)"
+assert_eq "${out}" '.repos'          "${REPOS}" "repos emitted from allowlist"
+
+echo "== empty-string env is treated as unset (Dockerfile bakes empty ENV) =="
+out="$(ALISSA_ROUND_CAP="" ALISSA_POLL_INTERVAL="" render_reviewloop_config "${REPOS}")"
+assert_key_absent "${out}" round_cap     "round_cap omitted when ALISSA_ROUND_CAP is empty"
+assert_key_absent "${out}" poll_interval "poll_interval omitted when ALISSA_POLL_INTERVAL is empty"
+
+echo "== override: set env still wins, emitted as a JSON number =="
+out="$(ALISSA_ROUND_CAP=7 ALISSA_POLL_INTERVAL=90 render_reviewloop_config "${REPOS}")"
+assert_eq "${out}" '.round_cap'     '7'  "round_cap override present as number"
+assert_eq "${out}" '.poll_interval' '90' "poll_interval override present as number"
+
+echo "== override: structural keys still overridable =="
+out="$(ALISSA_ON_MISSING_HUB=skip ALISSA_AGENT_PROFILE=custom render_reviewloop_config "${REPOS}")"
+assert_eq "${out}" '.on_missing_hub' '"skip"'   "on_missing_hub override wins"
+assert_eq "${out}" '.agent_profile'  '"custom"' "agent_profile override wins"
+
+echo "== cross-check: omitted keys resolve to the LIBRARY default =="
+if python3 -c 'import alissa.tools.github.reviewloop.config' 2>/dev/null; then
+  out="$(env -u ALISSA_POLL_INTERVAL -u ALISSA_ROUND_CAP \
+          bash -c '. "'"${HERE}"'/reviewloop-config.sh"; render_reviewloop_config '"'${REPOS}'"'')"
+  # Pass the rendered JSON via an env var (not a pipe) so the heredoc can own
+  # stdin as the python program.
+  if CONFIG_JSON="${out}" python3 <<'PY'
+import json, os
+from alissa.tools.github.reviewloop.config import Config
+data = json.loads(os.environ["CONFIG_JSON"])
+built = Config.build(workspace_root=".", file_data=data)
+ref = Config(workspace_root=".")  # library defaults (dataclass fields)
+assert "round_cap" not in data and "poll_interval" not in data, data
+assert built.round_cap == ref.round_cap, (built.round_cap, ref.round_cap)
+assert built.poll_interval == ref.poll_interval, (built.poll_interval, ref.poll_interval)
+print(f"  ok   effective round_cap={built.round_cap} poll_interval={built.poll_interval} "
+      f"== library defaults")
+PY
+  then :; else fail=1; fi
+else
+  echo "  skip (reviewloop package not importable — structural checks above still ran)"
+fi
+
+echo
+[ "${fail}" = "0" ] && { echo "ALL PASS"; exit 0; } || { echo "FAILURES"; exit 1; }


### PR DESCRIPTION
## Summary

The env-driven container entrypoint injected **every** reviewloop config key with its own hardcoded fallback (`--argjson cap "${ALISSA_ROUND_CAP:-3}"`, …), which **shadowed the daemon library's own defaults**: a library that raised a default (e.g. `round_cap` → 10) could never take effect in a container unless the operator happened to set the matching env var. Library defaults were dead code in the container.

This implements the issue's preferred **pass-through-when-unset** model, with the precedence contract **env var > library default, no hidden entrypoint layer**.

## What changed

- **`docker/claude/reviewloop-config.sh`** (new) — the `reviewloop.config.json` renderer, extracted so it is unit-testable standalone.
  - **Pass-through** (optional tuning knobs): `poll_interval`, `round_cap` are emitted **only when their env var is set**. Unset ⇒ the key is omitted ⇒ the daemon library applies its own current default.
  - **Structural** (container constants, always emitted, argued exceptions): `on_missing_hub=add` and `agent_profile=claude`. Pass-through is unsafe for these — the library default `on_missing_hub=skip` would make a fresh volume review nothing, and `agent_profile` must name a profile the baked [`agents.yaml`](docker/claude/agents.yaml) ships (`claude`). Both stay explicit and pinned by tests, and remain overridable via their env var.
- **`docker/claude/entrypoint.sh`** — sources the renderer and calls it in place of the inline `jq` block.
- **`docker/claude/Dockerfile`** — empties the `ARG` defaults for the pass-through knobs (`ALISSA_POLL_INTERVAL`, `ALISSA_ROUND_CAP`) so an unset knob is genuinely unset (a baked concrete value would re-introduce the shadow); COPYs the new script. Structural ARGs (`add`, `claude`) kept.
- **`docker/claude/tests-entrypoint-config.sh`** (new) — asserts pass-through / override / structural behavior, and cross-checks that omitted keys resolve to the **real library default** through `Config.build` — dynamically, so it tracks the pinned release (`round_cap` → **3**, `poll_interval` → **60** at the pinned `REVIEWLOOP_VERSION` 0.8.0).
- **`.github/workflows/check-entrypoint.yaml`** (new) — runs the test in CI.
- **`docker/claude/README.md`** — documents the `env var > library default` precedence and drops the stale baked fallback values from the config table.

## Acceptance criteria

- [x] Boot with NO optional config env vars set → effective config equals library defaults (`round_cap` resolves to the pinned library default — **3** at `REVIEWLOOP_VERSION` 0.8.0 — without `ALISSA_ROUND_CAP`) — cross-checked dynamically against the pinned release in `tests-entrypoint-config.sh`.
- [x] Each env var still overrides when set — spot-tested (`round_cap`, `poll_interval`, and the structural keys).
- [x] Required inputs (repos allowlist) keep their fatal-if-missing behavior — untouched; change is OPTIONAL keys only.
- [x] `docker/claude/README` documents precedence and drops stale fallback-value claims.
- [x] Repo checks green — the entrypoint config test passes locally (12/12, incl. the dynamic library-default cross-check) and, after the round-1 rebase, `check-entrypoint.yaml` and the rest of CI now build the merge-ref and run on the PR; no Python package changes (unit/coverage/style/types unaffected).

## Out of scope (untouched)

Python package, version bumps, `agents.yaml`/model handling (#28), config semantics. The mirror issue in `alissa-github-develop-daemon` is not touched from this branch; the precedence contract and README language are kept consistent with it.

## Round-1 review fixes (request_changes → this update)

- **[blocker] stale/conflicting branch** — rebased onto `main`, keeping the newer `REVIEWLOOP_VERSION=0.8.0` pin (0.8.0 also defaults `round_cap=3`) and resolving the Dockerfile/README/entrypoint conflicts. The PR is now mergeable so GitHub can build the merge-ref and CI runs.
- **[major] wrong README round_cap default** — `README.md` config table corrected "currently 10" → **"currently 3"** to match the pinned 0.8.0 default and this PR's own `Dockerfile` comment (10 lands only in 0.11.0, out of scope). The same drift was corrected in this PR body and the commit message.
- **[minor] CI cross-check installed the source tree** — `check-entrypoint.yaml` now installs the pinned PyPI release `alissa-tools-github-reviewloop==${REVIEWLOOP_VERSION}` (parsed from the Dockerfile), so the library-default cross-check validates the library the image actually ships, not the repo source tree.
- **[nit] non-numeric override aborts with a raw jq error** — `[triage:ignore]`: not a regression (same failure class as the `--argjson` code it replaced) and the knobs are operator-set build-args, not untrusted input; a `die` would pull validation into the deliberately dependency-free, standalone-testable renderer. Reasoned on the thread; happy to file a follow-up.

---

Closes #30

**Alissa tasks** (canonical cross-actor record):
- Origin: `TASK-1799365990`
- Implementation: `TASK-664459042`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

