### PR TITLE
TASK-1058266947: CI guard — fail revloop src PRs without a version bump (and bumps to a published version)

### DIFF
--- a/.github/workflows/check-version-bump.yaml
+++ b/.github/workflows/check-version-bump.yaml
@@ -1,0 +1,183 @@
+name: Check Version Bump for Source Changes
+on: [pull_request]
+
+# "Python Package Publish" runs on merge and uploads with `twine upload
+# --skip-existing`. That flag is what keeps a duplicate release from erroring —
+# but it also means a merged source change that forgot to bump the version is
+# published as NOTHING while the workflow reports success. main silently ends up
+# ahead of PyPI and every pinned consumer keeps running the old code. That is the
+# 2026-07-28 alissa-github-develop-daemon incident (its PRs #62 and #64).
+#
+# This check closes the gap on the pull_request side: touch the dist source, bump
+# the version; bump the version, make it one PyPI does not already have.
+#
+# SOURCE OF TRUTH: the plain-text `version` file, NOT the `version.py` beside it.
+# setup.py reads `version` to set the distribution version, and version.py is a
+# derived reader (Version.from_path() opens the same file at runtime, falling back
+# to 0.0.0). Editing version.py cannot change what gets published, so the guard
+# keys on `version` alone.
+
+# Least privilege: the changed-file set is computed from git history rather than
+# the pull-request API, so a read-only checkout is all this job ever needs (same
+# posture as the other check workflows).
+permissions:
+  contents: read
+
+env:
+  # PyPI JSON API root. Overridable so the guard can be dry-run against an
+  # unreachable host to exercise the network-error path.
+  PYPI_API_BASE: https://pypi.org/pypi
+
+jobs:
+  version-bump-check:
+    strategy:
+      matrix:
+        # The distribution name on PyPI is the directory name, so `path` doubles
+        # as the dist name. `version_file` is spelled out because the module path
+        # under src/main is not derivable from the dist name.
+        include:
+          - path: alissa-tools-github-revloop
+            version_file: alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version
+    name: Version Bump Check for ${{ matrix.path }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          # Full history: the diff below needs the merge base of the pull request.
+          fetch-depth: 0
+      - name: Compute Changed Files
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            echo "Base commit ${BASE_SHA} is missing from the local clone; fetching it."
+            git fetch --no-tags origin "${BASE_SHA}"
+          fi
+
+          # Diff against the merge base (equivalent to BASE...HEAD), which is the
+          # file set GitHub shows in the pull request's "Files changed" tab —
+          # unrelated commits that landed on main meanwhile are not attributed
+          # to this pull request.
+          merge_base="$(git merge-base "${BASE_SHA}" "${HEAD_SHA}")"
+          changed="${RUNNER_TEMP}/changed-files.txt"
+          git diff --name-only "${merge_base}" "${HEAD_SHA}" > "${changed}"
+
+          echo "changed_files=${changed}" >> "${GITHUB_OUTPUT}"
+          echo "Changed files in this pull request (${merge_base}..${HEAD_SHA}):"
+          sed 's/^/  /' "${changed}"
+      - name: Enforce Version Bump for Source Changes
+        id: guard
+        env:
+          CHANGED_FILES: ${{ steps.changes.outputs.changed_files }}
+          SRC_PREFIX: ${{ matrix.path }}/src/
+          VERSION_FILE: ${{ matrix.version_file }}
+        run: |
+          set -euo pipefail
+
+          src_changed=false
+          version_changed=false
+          while IFS= read -r file; do
+            if [ -z "${file}" ]; then
+              continue
+            fi
+            case "${file}" in
+              "${SRC_PREFIX}"*) src_changed=true ;;
+            esac
+            if [ "${file}" = "${VERSION_FILE}" ]; then
+              version_changed=true
+            fi
+          done < "${CHANGED_FILES}"
+
+          if [ "${src_changed}" = "false" ]; then
+            echo "src_changed=false" >> "${GITHUB_OUTPUT}"
+            echo "version_changed=false" >> "${GITHUB_OUTPUT}"
+            echo "::notice::No changes under ${SRC_PREFIX} — the version-bump rule does not apply to this pull request."
+            exit 0
+          fi
+          echo "src_changed=true" >> "${GITHUB_OUTPUT}"
+
+          if [ "${version_changed}" = "false" ]; then
+            current="$(head -n 1 "${VERSION_FILE}" 2>/dev/null | tr -d '[:space:]' || true)"
+            {
+              echo "RULE: a pull request that modifies ${SRC_PREFIX}** must also change ${VERSION_FILE}"
+              echo ""
+              echo "This pull request changes ${SRC_PREFIX}** but leaves ${VERSION_FILE} at ${current:-<unreadable>}."
+              echo ""
+              echo "Why that blocks the merge: on merge, \"Python Package Publish\" uploads with"
+              echo "\`twine upload --skip-existing\`. Re-uploading a version PyPI already has is skipped"
+              echo "silently, so the workflow reports SUCCESS while publishing nothing. main ends up"
+              echo "ahead of PyPI with no signal, and everything pinned to ${current:-that version} keeps"
+              echo "running the old code. That is the 2026-07-28 alissa-github-develop-daemon incident"
+              echo "(its PRs #62 and #64)."
+              echo ""
+              echo "Fix: bump ${VERSION_FILE} to the next unpublished version"
+              echo "(the version.py beside it is a derived reader — editing that file alone changes nothing),"
+              echo "or move the change out of ${SRC_PREFIX}** if this pull request must not release."
+            } | tee -a "${GITHUB_STEP_SUMMARY}"
+            echo "::error file=${VERSION_FILE}::Source under ${SRC_PREFIX} changed without bumping ${VERSION_FILE} — the merge-triggered publish would be a silent no-op (see the 2026-07-28 develop-daemon #62/#64 incident). Bump the version file."
+            exit 1
+          fi
+
+          echo "version_changed=true" >> "${GITHUB_OUTPUT}"
+          echo "::notice::${VERSION_FILE} is part of this pull request — the merge will publish a new release."
+      - name: Verify New Version Is Unpublished
+        if: steps.guard.outputs.version_changed == 'true'
+        env:
+          DIST_NAME: ${{ matrix.path }}
+          VERSION_FILE: ${{ matrix.version_file }}
+        run: |
+          set -euo pipefail
+
+          version="$(head -n 1 "${VERSION_FILE}" | tr -d '[:space:]')"
+          if [ -z "${version}" ]; then
+            echo "::error file=${VERSION_FILE}::${VERSION_FILE} is empty — it must hold the version this pull request publishes."
+            exit 1
+          fi
+          case "${version}" in
+            *[!A-Za-z0-9.+!_-]*)
+              echo "::error file=${VERSION_FILE}::Version '${version}' contains characters that cannot appear in a PEP 440 version."
+              exit 1
+              ;;
+          esac
+
+          url="${PYPI_API_BASE}/${DIST_NAME}/${version}/json"
+          echo "Asking PyPI whether ${DIST_NAME} ${version} already exists: ${url}"
+
+          # A confirmed 200 is the only outcome that fails this step. Anything the
+          # check cannot confirm — connection failure, timeout, 5xx, rate limit —
+          # warns and passes: a PyPI outage must never block a merge.
+          if http_code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 --retry 2 --retry-delay 3 "${url}")"; then
+            case "${http_code}" in
+              404)
+                echo "::notice::${DIST_NAME} ${version} is not on PyPI (HTTP 404) — this pull request can publish it."
+                ;;
+              200)
+                {
+                  echo "RULE: the version in ${VERSION_FILE} must not already exist on PyPI."
+                  echo ""
+                  echo "${DIST_NAME} ${version} is ALREADY published (${url} responded HTTP 200)."
+                  echo ""
+                  echo "Why that blocks the merge: on merge, \"Python Package Publish\" uploads with"
+                  echo "\`twine upload --skip-existing\`, which skips the duplicate and reports SUCCESS"
+                  echo "while publishing nothing. main ends up ahead of PyPI with no signal — the"
+                  echo "2026-07-28 alissa-github-develop-daemon incident (its PRs #62 and #64)."
+                  echo ""
+                  echo "Fix: bump ${VERSION_FILE} to a version PyPI does not have yet."
+                } | tee -a "${GITHUB_STEP_SUMMARY}"
+                echo "::error file=${VERSION_FILE}::${DIST_NAME} ${version} is already on PyPI — merging would make the publish a silent no-op (see the 2026-07-28 develop-daemon #62/#64 incident). Bump ${VERSION_FILE} again."
+                exit 1
+                ;;
+              *)
+                echo "::warning::PyPI answered HTTP ${http_code} for ${url}; could not confirm whether ${DIST_NAME} ${version} is already published. Passing — a PyPI outage must not block a merge."
+                ;;
+            esac
+          else
+            rc=$?
+            echo "::warning::Could not reach PyPI (curl exited ${rc}) at ${url}; could not confirm whether ${DIST_NAME} ${version} is already published. Passing — a PyPI outage must not block a merge."
+          fi

--- a/.github/workflows/check-version-bump.yaml
+++ b/.github/workflows/check-version-bump.yaml
@@ -8,8 +8,21 @@ on: [pull_request]
 # ahead of PyPI and every pinned consumer keeps running the old code. That is the
 # 2026-07-28 alissa-github-develop-daemon incident (its PRs #62 and #64).
 #
-# This check closes the gap on the pull_request side: touch the dist source, bump
-# the version; bump the version, make it one PyPI does not already have.
+# This check closes the gap on the pull_request side: touch anything that gets
+# published, bump the version; bump the version, make it one PyPI does not already
+# have.
+#
+# SCOPE: the guarded prefix is the whole distribution directory — the same subtree
+# package-publish.yaml triggers on — minus src/test/. The property being enforced
+# is "if merging this pull request runs a publish, it must publish something", so
+# the guard has to cover every path that starts a publish AND changes the artifact:
+# requirements.txt (install_requires), setup.py (name, entry_points,
+# python_requires), README.md (long_description) and MANIFEST.in (sdist contents),
+# not just src/. src/test/ is exempt in the other direction: nothing under it is
+# packaged (setup.py packages src/main only, MANIFEST.in adds requirements.txt and
+# version), so a test-only change yields a byte-identical wheel and must not cost a
+# release number. Repo-level paths — README.md, docker/, .github/, the *.sh check
+# scripts — are outside the dist directory and never require a bump.
 #
 # SOURCE OF TRUTH: the plain-text `version` file, NOT the `version.py` beside it.
 # setup.py reads `version` to set the distribution version, and version.py is a
@@ -64,50 +77,61 @@ jobs:
           # file set GitHub shows in the pull request's "Files changed" tab —
           # unrelated commits that landed on main meanwhile are not attributed
           # to this pull request.
+          #
+          # --no-renames: with rename detection on, a file moved OUT of the dist
+          # directory is reported only at its destination, so the wheel changes
+          # while the guard never sees a dist path. Without it, both sides of a
+          # rename appear and the set is exactly "paths this pull request touches".
           merge_base="$(git merge-base "${BASE_SHA}" "${HEAD_SHA}")"
           changed="${RUNNER_TEMP}/changed-files.txt"
-          git diff --name-only "${merge_base}" "${HEAD_SHA}" > "${changed}"
+          git diff --no-renames --name-only "${merge_base}" "${HEAD_SHA}" > "${changed}"
 
           echo "changed_files=${changed}" >> "${GITHUB_OUTPUT}"
           echo "Changed files in this pull request (${merge_base}..${HEAD_SHA}):"
           sed 's/^/  /' "${changed}"
-      - name: Enforce Version Bump for Source Changes
+      - name: Enforce Version Bump for Published Changes
         id: guard
         env:
           CHANGED_FILES: ${{ steps.changes.outputs.changed_files }}
-          SRC_PREFIX: ${{ matrix.path }}/src/
+          # The whole dist directory (what package-publish.yaml triggers on)…
+          DIST_PREFIX: ${{ matrix.path }}/
+          # …except the tests, which are not packaged. See the SCOPE note above.
+          TEST_PREFIX: ${{ matrix.path }}/src/test/
           VERSION_FILE: ${{ matrix.version_file }}
         run: |
           set -euo pipefail
 
-          src_changed=false
+          dist_changed=false
           version_changed=false
           while IFS= read -r file; do
             if [ -z "${file}" ]; then
               continue
             fi
             case "${file}" in
-              "${SRC_PREFIX}"*) src_changed=true ;;
+              "${TEST_PREFIX}"*) ;;
+              "${DIST_PREFIX}"*) dist_changed=true ;;
             esac
             if [ "${file}" = "${VERSION_FILE}" ]; then
               version_changed=true
             fi
           done < "${CHANGED_FILES}"
 
-          if [ "${src_changed}" = "false" ]; then
-            echo "src_changed=false" >> "${GITHUB_OUTPUT}"
+          if [ "${dist_changed}" = "false" ]; then
+            echo "dist_changed=false" >> "${GITHUB_OUTPUT}"
             echo "version_changed=false" >> "${GITHUB_OUTPUT}"
-            echo "::notice::No changes under ${SRC_PREFIX} — the version-bump rule does not apply to this pull request."
+            echo "::notice::No published files changed under ${DIST_PREFIX} (${TEST_PREFIX} is exempt — nothing under it is packaged) — the version-bump rule does not apply to this pull request."
             exit 0
           fi
-          echo "src_changed=true" >> "${GITHUB_OUTPUT}"
+          echo "dist_changed=true" >> "${GITHUB_OUTPUT}"
 
           if [ "${version_changed}" = "false" ]; then
             current="$(head -n 1 "${VERSION_FILE}" 2>/dev/null | tr -d '[:space:]' || true)"
             {
-              echo "RULE: a pull request that modifies ${SRC_PREFIX}** must also change ${VERSION_FILE}"
+              echo "RULE: a pull request that modifies ${DIST_PREFIX}** must also change ${VERSION_FILE}"
+              echo "      (${TEST_PREFIX}** is exempt — nothing under it is packaged)"
               echo ""
-              echo "This pull request changes ${SRC_PREFIX}** but leaves ${VERSION_FILE} at ${current:-<unreadable>}."
+              echo "This pull request changes published files under ${DIST_PREFIX}** but leaves"
+              echo "${VERSION_FILE} at ${current:-<unreadable>}."
               echo ""
               echo "Why that blocks the merge: on merge, \"Python Package Publish\" uploads with"
               echo "\`twine upload --skip-existing\`. Re-uploading a version PyPI already has is skipped"
@@ -118,9 +142,9 @@ jobs:
               echo ""
               echo "Fix: bump ${VERSION_FILE} to the next unpublished version"
               echo "(the version.py beside it is a derived reader — editing that file alone changes nothing),"
-              echo "or move the change out of ${SRC_PREFIX}** if this pull request must not release."
+              echo "or move the change out of ${DIST_PREFIX}** if this pull request must not release."
             } | tee -a "${GITHUB_STEP_SUMMARY}"
-            echo "::error file=${VERSION_FILE}::Source under ${SRC_PREFIX} changed without bumping ${VERSION_FILE} — the merge-triggered publish would be a silent no-op (see the 2026-07-28 develop-daemon #62/#64 incident). Bump the version file."
+            echo "::error file=${VERSION_FILE}::Published files under ${DIST_PREFIX} changed without bumping ${VERSION_FILE} — the merge-triggered publish would be a silent no-op (see the 2026-07-28 develop-daemon #62/#64 incident). Bump the version file."
             exit 1
           fi
 
@@ -134,8 +158,33 @@ jobs:
         run: |
           set -euo pipefail
 
+          # A pull request can DELETE the version file, which reaches this step as
+          # version_changed=true. Say so in the same shape as every other failure
+          # here rather than dying on a bare `head: cannot open …`.
+          if [ ! -f "${VERSION_FILE}" ]; then
+            {
+              echo "RULE: ${VERSION_FILE} must exist and hold the version this pull request publishes."
+              echo ""
+              echo "This pull request deletes (or moves away) ${VERSION_FILE}. setup.py opens that"
+              echo "exact path to set the distribution version, so the merge-triggered publish would"
+              echo "fail to build — and the version.py beside it would fall back to 0.0.0."
+              echo ""
+              echo "Fix: restore ${VERSION_FILE} holding the version this pull request publishes."
+            } | tee -a "${GITHUB_STEP_SUMMARY}"
+            echo "::error file=${VERSION_FILE}::${VERSION_FILE} is missing — setup.py reads it to set the published version. Restore it."
+            exit 1
+          fi
+
           version="$(head -n 1 "${VERSION_FILE}" | tr -d '[:space:]')"
           if [ -z "${version}" ]; then
+            {
+              echo "RULE: ${VERSION_FILE} must exist and hold the version this pull request publishes."
+              echo ""
+              echo "The file is empty. setup.py reads it to set the distribution version, so the"
+              echo "merge-triggered publish would fail to build."
+              echo ""
+              echo "Fix: write the version this pull request publishes into ${VERSION_FILE}."
+            } | tee -a "${GITHUB_STEP_SUMMARY}"
             echo "::error file=${VERSION_FILE}::${VERSION_FILE} is empty — it must hold the version this pull request publishes."
             exit 1
           fi


### PR DESCRIPTION
Closes #40

- Origin task: **TASK-1625720421**
- Implementation task: **TASK-1058266947**

## What this adds

`.github/workflows/check-version-bump.yaml` — a `pull_request` check (`Check Version Bump for Source Changes`) that closes the silent-no-op publish gap on the PR side:

1. Computes the PR's changed files from git (`merge-base(base.sha, head.sha)..head.sha`, `--no-renames` so both sides of a move appear). No pull-request API call, so the job keeps `permissions: contents: read` like the other check workflows.
2. **Fails** if anything *published* under `alissa-tools-github-revloop/**` changed and `alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version` did not. `src/test/**` is exempt (nothing under it is packaged); repo-level paths — `README.md`, `docker/`, `.github/`, the `*.sh` check scripts — are outside the dist directory and never require a bump.
3. When the version file *did* change, **fails** if that version already exists on PyPI (`GET https://pypi.org/pypi/alissa-tools-github-revloop/<version>/json` → 200). 404 passes.
4. Anything the check cannot confirm — connection failure, timeout, 5xx, rate limit — emits a `::warning::` and **passes**. A PyPI outage never blocks a merge.
5. PRs that touch nothing published (docs, `docker/`, workflows — including this one — and test-only changes) skip both rules with a `::notice::`.
6. A deleted or empty version file fails with the same RULE + step-summary + annotation shape as every other failure, rather than a bare `head: cannot open`.

### Scope: the guarded subtree is the publish trigger, not `src/**`

Round 1 raised a `[major]` that this PR takes: the property worth enforcing is **"if merging this PR runs a publish, it must publish something."** `package-publish.yaml` triggers on all of `alissa-tools-github-revloop/**`, and `requirements.txt` (`install_requires`), `setup.py` (dist name, `entry_points`, `python_requires`), `README.md` (`long_description`) and `MANIFEST.in` (sdist contents) each change the artifact *and* start a publish — but a `src/**`-only prefix exempted all four, reaching exactly the failure this workflow exists to prevent.

**This is a deliberate, recorded deviation from the issue's literal `src/**`.** Every repo-level path the issue's acceptance criteria call out as unaffected — docs, `docker/`, workflows, the check scripts — stays exempt, and this PR still passes its own check. The only files that move from exempt to guarded are the four inside the distribution directory, and for each of them "unaffected" would be wrong on the issue's own terms. In the other direction, `src/test/**` is now exempt: it is not packaged, so a test-only change yields a byte-identical wheel and must not cost a release number.

Failure messages name the rule, the version-file path, the `twine upload --skip-existing` → "reports SUCCESS while publishing nothing" consequence, and the 2026-07-28 `alissa-github-develop-daemon` #62/#64 incident. They go to the job log, to `$GITHUB_STEP_SUMMARY`, and to a `::error file=<version file>::` annotation.

## Source-of-truth decision: `version`, not `version.py`

**The guard keys on the plain-text `version` file alone.** `version.py` is a *derived reader*, not a second source of truth:

- `setup.py` opens `src/main/alissa/tools/github/revloop/version` and passes its contents as `setup(version=...)` — that string is what lands on PyPI.
- `version.py`'s `Version.from_path()` opens the same file at import time (falling back to `0.0.0` if it is missing); it holds no version literal of its own.
- `MANIFEST.in` ships `version`, and `check-wheel.yaml` asserts the installed `version.value != '0.0.0'` — i.e. it asserts the *file* was packaged.

So editing `version.py` cannot change what gets published, and requiring it to change would be a false gate. Keying on `version` alone is correct. (`__init__.py` also carries a stale `__version__ = "0.1.0"` literal that nothing reads — untouched here, out of this PR's `.github/workflows/**` scope, and worth a separate cleanup.)

## Dry-run demonstrations

Executed against the **shipped** workflow file: a harness parses `check-version-bump.yaml`, extracts the two guard steps' actual `run:` blocks, and runs them under a GitHub-Actions-shaped environment (`RUNNER_TEMP` / `GITHUB_OUTPUT` / `GITHUB_STEP_SUMMARY`, the step `env:` maps with `${{ matrix.* }}` and `${{ steps.*.outputs.* }}` resolved, workflow-level `env`, and the `if:` condition evaluated). Only the "Compute Changed Files" step is stubbed with a fixture file list; everything after it is the real code path. PyPI calls are real (`0.15.0` is published → 200; `0.16.0` is not → 404).

| # | Case | Changed files | `version` | Result |
|---|------|---------------|-----------|--------|
| 1 | src without bump | `…/revloop/loop.py` | 0.15.0 | **FAIL** ✅ |
| 2 | src with new version | `…/loop.py`, `…/version` | 0.16.0 | PASS ✅ |
| 3 | **this PR itself** | `.github/workflows/check-version-bump.yaml` | 0.15.0 | PASS (skipped) ✅ |
| 4 | repo docs / docker only | `README.md`, `docker/claude/Dockerfile` | 0.15.0 | PASS (skipped) ✅ |
| 5 | bump to a published version | `…/loop.py`, `…/version` | 0.15.0 | **FAIL** ✅ |
| 6 | PyPI unreachable | `…/loop.py`, `…/version` | 0.16.0 | PASS + warning ✅ |
| 7 | test-only change, no bump | `…/src/test/…/test_directives.py` | 0.15.0 | PASS (exempt) ✅ |
| 8 | dist `requirements.txt`, no bump | `alissa-tools-github-revloop/requirements.txt` | 0.15.0 | **FAIL** ✅ |
| 9 | dist `setup.py` + dist `README.md`, no bump | `…/setup.py`, `…/README.md` | 0.15.0 | **FAIL** ✅ |
| 10 | dist `MANIFEST.in` with new version | `…/MANIFEST.in`, `…/version` | 0.16.0 | PASS ✅ |
| 11 | src file moved *out* of the dist tree, no bump | `…/loop.py`, `docs/loop.py` | 0.15.0 | **FAIL** ✅ |
| 12 | version file deleted | `…/loop.py`, `…/version` | *(deleted)* | **FAIL** ✅ |
| 13 | version file emptied | `…/loop.py`, `…/version` | *(empty)* | **FAIL** ✅ |

`13/13 cases matched expectations`

Cases 7–13 are the round-1 review's findings; case 7 **inverted** in round 2 (a test-only change no longer requires a release).

<details>
<summary>Case 1 — src change without a version bump (FAIL)</summary>

```
changed files: ['alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/loop.py']
version file : 0.15.0
--- Enforce Version Bump for Published Changes (exit 1) ---
RULE: a pull request that modifies alissa-tools-github-revloop/** must also change alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version
      (alissa-tools-github-revloop/src/test/** is exempt — nothing under it is packaged)

This pull request changes published files under alissa-tools-github-revloop/** but leaves
alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version at 0.15.0.

Why that blocks the merge: on merge, "Python Package Publish" uploads with
`twine upload --skip-existing`. Re-uploading a version PyPI already has is skipped
silently, so the workflow reports SUCCESS while publishing nothing. main ends up
ahead of PyPI with no signal, and everything pinned to 0.15.0 keeps
running the old code. That is the 2026-07-28 alissa-github-develop-daemon incident
(its PRs #62 and #64).

Fix: bump alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version to the next unpublished version
(the version.py beside it is a derived reader — editing that file alone changes nothing),
or move the change out of alissa-tools-github-revloop/** if this pull request must not release.
::error file=alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version::Published files under alissa-tools-github-revloop/ changed without bumping alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version — the merge-triggered publish would be a silent no-op (see the 2026-07-28 develop-daemon #62/#64 incident). Bump the version file.
```
</details>

<details>
<summary>Cases 8 &amp; 9 — dist metadata without a bump (FAIL) — the round-1 [major]</summary>

```
changed files: ['alissa-tools-github-revloop/requirements.txt']
version file : 0.15.0
--- Enforce Version Bump for Published Changes (exit 1) ---
RULE: a pull request that modifies alissa-tools-github-revloop/** must also change alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version
      (alissa-tools-github-revloop/src/test/** is exempt — nothing under it is packaged)

This pull request changes published files under alissa-tools-github-revloop/** but leaves
alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version at 0.15.0.

Why that blocks the merge: on merge, "Python Package Publish" uploads with
`twine upload --skip-existing`. Re-uploading a version PyPI already has is skipped
silently, so the workflow reports SUCCESS while publishing nothing. main ends up
ahead of PyPI with no signal, and everything pinned to 0.15.0 keeps
running the old code. That is the 2026-07-28 alissa-github-develop-daemon incident
(its PRs #62 and #64).

Fix: bump alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version to the next unpublished version
(the version.py beside it is a derived reader — editing that file alone changes nothing),
or move the change out of alissa-tools-github-revloop/** if this pull request must not release.
::error file=alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version::Published files under alissa-tools-github-revloop/ changed without bumping alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version — the merge-triggered publish would be a silent no-op (see the 2026-07-28 develop-daemon #62/#64 incident). Bump the version file.
changed files: ['alissa-tools-github-revloop/setup.py', 'alissa-tools-github-revloop/README.md']
version file : 0.15.0
--- Enforce Version Bump for Published Changes (exit 1) ---
RULE: a pull request that modifies alissa-tools-github-revloop/** must also change alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version
      (alissa-tools-github-revloop/src/test/** is exempt — nothing under it is packaged)

This pull request changes published files under alissa-tools-github-revloop/** but leaves
alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version at 0.15.0.

Why that blocks the merge: on merge, "Python Package Publish" uploads with
`twine upload --skip-existing`. Re-uploading a version PyPI already has is skipped
silently, so the workflow reports SUCCESS while publishing nothing. main ends up
ahead of PyPI with no signal, and everything pinned to 0.15.0 keeps
running the old code. That is the 2026-07-28 alissa-github-develop-daemon incident
(its PRs #62 and #64).

Fix: bump alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version to the next unpublished version
(the version.py beside it is a derived reader — editing that file alone changes nothing),
or move the change out of alissa-tools-github-revloop/** if this pull request must not release.
::error file=alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version::Published files under alissa-tools-github-revloop/ changed without bumping alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version — the merge-triggered publish would be a silent no-op (see the 2026-07-28 develop-daemon #62/#64 incident). Bump the version file.
```
</details>

<details>
<summary>Cases 4 &amp; 7 — repo docs / test-only (PASS, rule does not apply)</summary>

```
changed files: ['README.md', 'docker/claude/Dockerfile']
version file : 0.15.0
--- Enforce Version Bump for Published Changes (exit 0) ---
::notice::No published files changed under alissa-tools-github-revloop/ (alissa-tools-github-revloop/src/test/ is exempt — nothing under it is packaged) — the version-bump rule does not apply to this pull request.
[step skipped by `if:`] Verify New Version Is Unpublished
changed files: ['alissa-tools-github-revloop/src/test/test_alissa/test_tools/test_github/test_revloop/test_directives.py']
version file : 0.15.0
--- Enforce Version Bump for Published Changes (exit 0) ---
::notice::No published files changed under alissa-tools-github-revloop/ (alissa-tools-github-revloop/src/test/ is exempt — nothing under it is packaged) — the version-bump rule does not apply to this pull request.
[step skipped by `if:`] Verify New Version Is Unpublished
```
</details>

<details>
<summary>Case 5 — bump to a version already on PyPI (FAIL)</summary>

```
changed files: ['alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/loop.py', 'alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version']
version file : 0.15.0
--- Enforce Version Bump for Published Changes (exit 0) ---
::notice::alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version is part of this pull request — the merge will publish a new release.
--- Verify New Version Is Unpublished (exit 1) ---
Asking PyPI whether alissa-tools-github-revloop 0.15.0 already exists: https://pypi.org/pypi/alissa-tools-github-revloop/0.15.0/json
RULE: the version in alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version must not already exist on PyPI.

alissa-tools-github-revloop 0.15.0 is ALREADY published (https://pypi.org/pypi/alissa-tools-github-revloop/0.15.0/json responded HTTP 200).

Why that blocks the merge: on merge, "Python Package Publish" uploads with
`twine upload --skip-existing`, which skips the duplicate and reports SUCCESS
while publishing nothing. main ends up ahead of PyPI with no signal — the
2026-07-28 alissa-github-develop-daemon incident (its PRs #62 and #64).

Fix: bump alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version to a version PyPI does not have yet.
::error file=alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version::alissa-tools-github-revloop 0.15.0 is already on PyPI — merging would make the publish a silent no-op (see the 2026-07-28 develop-daemon #62/#64 incident). Bump alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version again.
```
</details>

<details>
<summary>Case 6 — PyPI unreachable (PASS with a warning)</summary>

```
changed files: ['alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/loop.py', 'alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version']
version file : 0.16.0
--- Enforce Version Bump for Published Changes (exit 0) ---
::notice::alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version is part of this pull request — the merge will publish a new release.
--- Verify New Version Is Unpublished (exit 0) ---
Asking PyPI whether alissa-tools-github-revloop 0.16.0 already exists: https://pypi.invalid.localhost.example/pypi/alissa-tools-github-revloop/0.16.0/json
::warning::Could not reach PyPI (curl exited 6) at https://pypi.invalid.localhost.example/pypi/alissa-tools-github-revloop/0.16.0/json; could not confirm whether alissa-tools-github-revloop 0.16.0 is already published. Passing — a PyPI outage must not block a merge.
curl: (6) Could not resolve host: pypi.invalid.localhost.example
curl: (6) Could not resolve host: pypi.invalid.localhost.example
curl: (6) Could not resolve host: pypi.invalid.localhost.example
```
</details>

<details>
<summary>Cases 12 &amp; 13 — version file deleted / emptied (FAIL with the RULE shape)</summary>

```
changed files: ['alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/loop.py', 'alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version']
version file : <deleted>
--- Enforce Version Bump for Published Changes (exit 0) ---
::notice::alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version is part of this pull request — the merge will publish a new release.
--- Verify New Version Is Unpublished (exit 1) ---
RULE: alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version must exist and hold the version this pull request publishes.

This pull request deletes (or moves away) alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version. setup.py opens that
exact path to set the distribution version, so the merge-triggered publish would
fail to build — and the version.py beside it would fall back to 0.0.0.

Fix: restore alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version holding the version this pull request publishes.
::error file=alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version::alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version is missing — setup.py reads it to set the published version. Restore it.
changed files: ['alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/loop.py', 'alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version']
version file : 
--- Enforce Version Bump for Published Changes (exit 0) ---
::notice::alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version is part of this pull request — the merge will publish a new release.
--- Verify New Version Is Unpublished (exit 1) ---
RULE: alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version must exist and hold the version this pull request publishes.

The file is empty. setup.py reads it to set the distribution version, so the
merge-triggered publish would fail to build.

Fix: write the version this pull request publishes into alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version.
::error file=alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version::alissa-tools-github-revloop/src/main/alissa/tools/github/revloop/version is empty — it must hold the version this pull request publishes.

13/13 cases matched expectations
```
</details>

## Verification

- **The check ran for real on this PR and passed in 6s** ([run 30372698439](https://github.com/fahera-mx/alissa-github-review-daemon/actions/runs/30372698439), head `629df04`) — case 3 confirmed on GitHub Actions, not just in the harness:
  ```
  Changed files in this pull request (6348b5a..629df04):
    .github/workflows/check-version-bump.yaml
  ::notice::No published files changed under alissa-tools-github-revloop/ (alissa-tools-github-revloop/src/test/ is exempt — nothing under it is packaged) — the version-bump rule does not apply to this pull request.
  ```
  The job's `GITHUB_TOKEN` permissions resolved to `Contents: read` / `Metadata: read` only. (Round 1 ran the same way on `9335e42`: [run 30371283769](https://github.com/fahera-mx/alissa-github-review-daemon/actions/runs/30371283769).)
- `actionlint 1.7.7` clean on all six workflow files (`rc=0`).
- Repo check scripts green on this branch (unchanged Python, run for completeness): `tests-unit.sh` **295 passed**, `tests-coverage.sh` **88%**, `check-style.sh` clean, `check-types.sh` **"Success: no issues found in 28 source files"**.
- No version bump in this PR — it touches `.github/workflows/**` only, which is exactly what the new rule exempts (case 3 above).

## Round 1 → round 2

Reviewer `alissa-app` returned `request_changes` on 1 major, 2 minors, 2 nits. Triage replies are on each thread; all four code findings are taken:

| Finding | Triage | Change |
|---|---|---|
| `[major]` guarded prefix narrower than the publish trigger | `pursue` | `SRC_PREFIX` → `DIST_PREFIX: alissa-tools-github-revloop/` (cases 8–10) |
| `[minor]` `src/test/**` should not force a release | `pursue` | `TEST_PREFIX` exemption ordered before the dist match (case 7) |
| `[minor]` required-status-check / up-to-date branch protection | `answer` | Repo-admin, outside `Autonomous-Scope`; tracked as **TASK-568945951** |
| `[nit]` rename detection hides a file moved out of the dist tree | `pursue` | `git diff --no-renames` (case 11) |
| `[nit]` deleted/empty version file fails opaquely | `pursue` | RULE + summary + `::error file=` shape for both (cases 12–13) |
| `[nit]` no monotonicity check | `later` | Outside issue #40's rule and not the silent-no-op mode; tracked as **TASK-1492477** |

## Remaining judgement calls

- **Scope stays inside `.github/workflows/**`** per the issue's `Autonomous-Scope`, so the rule is documented in the workflow's header comment rather than in the README.
- **`PYPI_API_BASE` is a workflow-level env var** rather than a hardcoded URL, so the network-error branch is exercisable (case 6). It defaults to `https://pypi.org/pypi`.
- **This guard cannot see `main` move underneath an open PR** (a `pull_request` job only re-runs on `synchronize`), so two PRs bumping to the same version both pass. Closing that needs "require branches to be up to date" — TASK-568945951.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
