### PR TITLE
hotfix: entrypoint surfaces the real auth-login error (stop reporting every failure as 'token rejected')

### DIFF
--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -134,8 +134,11 @@ gh auth setup-git 2>/dev/null \
 #     but `auth login` also stores + verifies it, which is the real preflight.
 [ -n "${ALISSA_API_TOKEN:-}" ] \
   || die "no ALISSA_API_TOKEN — cannot reach tasks / session queue"
-alissa auth login --token "${ALISSA_API_TOKEN}" >/dev/null 2>&1 \
-  || die "ALISSA_API_TOKEN rejected (alissa auth login failed)"
+if ! command -v alissa >/dev/null 2>&1; then
+  die "alissa CLI missing from PATH (image-layer loss?) — cannot preflight ALISSA_API_TOKEN"
+fi
+LOGIN_ERR="$(alissa auth login --token "${ALISSA_API_TOKEN}" 2>&1 >/dev/null)" \
+  || die "alissa auth login failed: ${LOGIN_ERR:-<no output>}"
 log "alissa authenticated"
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
**Operator hotfix for tonight's crash-loop.** The revloop service is boot-looping on `FATAL: ALISSA_API_TOKEN rejected (alissa auth login failed)` while the API is verified up and the token verified valid — the muted `>/dev/null 2>&1` has already cost two multi-hour false diagnoses today (both times the actual fault was the `alissa` CLI binary missing, not the token).

Two-line change to the preflight (step 2c):
1. `command -v alissa` check first — if the CLI is gone (tonight's image-layer anomaly), say exactly that.
2. Capture the login command's stderr and carry it into the `die` message.

No behavior change on the happy path. The full failure-class triage (CLI re-bootstrap, transport backoff, genuine-reject fast-fail) stays with **TASK-616289237** — this is only the diagnostic unmute, so the next boot tells us what is actually failing.

After merge: rebuild/redeploy the Railway service and read the new FATAL line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLWAhxmurcUTEh392raZqc