### PR TITLE
docker: re-pin REVLOOP_VERSION 0.16.0 → 0.16.8

### DIFF
--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -33,7 +33,7 @@ FROM python:3.12-slim-bookworm
 # below 0.15.0, the first version shipping the `alissa-revloop-ui` console
 # script the entrypoint starts. Naming the two apart keeps the next release a
 # one-line edit.
-ARG REVLOOP_VERSION=0.16.0
+ARG REVLOOP_VERSION=0.16.6
 # Node major version (must be >= 18 for the alissa CLI and claude-code).
 ARG NODE_MAJOR=22
 


### PR DESCRIPTION
## What

One line: `ARG REVLOOP_VERSION` `0.16.0` → `0.16.6` (published on PyPI).

## Why now

The deployed Railway container runs 0.16.0 while six releases of merged fixes sit ungated behind this pin — and one of the 0.16.0 defects is **live right now**: studio PRs #318/#320 carry rounds whose reviewer sessions died in the 2026-07-29 19:52Z container crash, and 0.16.0's stale-round respawn defers silently forever behind a probe resolution pinned during the failure window (fixed in 0.16.3, `PROBE-CACHE-HEAL` #48, bounded in 0.16.4 #49). Fresh round-1 spawns need no probe, which is why the daemon still reviews new PRs while never respawning the dead rounds.

Ships with this bump: session reaper (0.16.2), probe fixes (0.16.3–0.16.5), close-out dangling-request withdrawal (0.16.5, #55), dry-run drift bounds (0.16.6, #56). The `>= 0.16.3` floor for `ALISSA_REVIEWER_LOGIN`/`ALISSA_REVIEWER_TOKEN_ENV` and the reap knobs is now satisfied — the identity-enforcement env vars can be set after this deploys.

## After merge

**Rebuild + redeploy** the Railway revloop service (the pin is baked at image build). On the next poll the healed probe finds the #318/#320 sessions gone → presumed dead → respawns the rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLWAhxmurcUTEh392raZqc