### PR TITLE
docker: pin REVLOOP_VERSION default to 0.16.14 (current release)

### DIFF
--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -33,7 +33,7 @@ FROM python:3.12-slim-bookworm
 # below 0.15.0, the first version shipping the `alissa-revloop-ui` console
 # script the entrypoint starts. Naming the two apart keeps the next release a
 # one-line edit.
-ARG REVLOOP_VERSION=0.16.12
+ARG REVLOOP_VERSION=0.16.14
 # Node major version (must be >= 18 for the alissa CLI and claude-code).
 ARG NODE_MAJOR=22
 

--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -33,7 +33,7 @@ FROM python:3.12-slim-bookworm
 # below 0.15.0, the first version shipping the `alissa-revloop-ui` console
 # script the entrypoint starts. Naming the two apart keeps the next release a
 # one-line edit.
-ARG REVLOOP_VERSION=0.16.8
+ARG REVLOOP_VERSION=0.16.12
 # Node major version (must be >= 18 for the alissa CLI and claude-code).
 ARG NODE_MAJOR=22
 

--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -33,7 +33,7 @@ FROM python:3.12-slim-bookworm
 # below 0.15.0, the first version shipping the `alissa-revloop-ui` console
 # script the entrypoint starts. Naming the two apart keeps the next release a
 # one-line edit.
-ARG REVLOOP_VERSION=0.16.6
+ARG REVLOOP_VERSION=0.16.8
 # Node major version (must be >= 18 for the alissa CLI and claude-code).
 ARG NODE_MAJOR=22
 


### PR DESCRIPTION
Aligns the Dockerfile default with the current release: **0.16.12** — PyPI latest and exactly main's version file. Since the original #60 re-pin (0.16.6), the crash-resilience release (0.16.9, #63), its stranded follow-up re-land (0.16.10, #67), and 0.16.11/0.16.12 have all published.

The deployed Railway service builds with the `REVLOOP_VERSION` build-arg variable, which overrides this default — after merging, set that variable to `0.16.12` and rebuild so production picks up the poll-loop firewall and friends. This default exists so a build *without* the variable doesn't regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLWAhxmurcUTEh392raZqc