### PR TITLE
TASK-479723890: bridge-executor role — run `alissa bridge start` as a second service from the revloop image (issue #73)

### DIFF
--- a/.github/workflows/check-entrypoint.yaml
+++ b/.github/workflows/check-entrypoint.yaml
@@ -13,7 +13,10 @@ on: [pull_request]
 #     docker/claude/tests-entrypoint-identity.sh;
 #   * the `alissa auth login` failure triage (missing CLI -> re-bootstrap,
 #     unreachable API / unwritable config -> capped backoff, genuine 401 ->
-#     fast FATAL), same way — docker/claude/tests-entrypoint-auth.sh.
+#     fast FATAL), same way — docker/claude/tests-entrypoint-auth.sh;
+#   * the bridge-executor role (CONTAINER_ROLE / ALISSA_BRIDGE_* gate, executor
+#     identity, and the guarantee that neither role starts the other's
+#     supervisor) — docker/claude/tests-entrypoint-executor.sh.
 jobs:
   entrypoint-config-check:
     name: Entrypoint config renderer + console wiring
@@ -68,6 +71,16 @@ jobs:
         # #62 exists for; only the genuine rejection may exit.
         timeout-minutes: 5
         run: bash docker/claude/tests-entrypoint-auth.sh
+      - name: Execute Entrypoint Bridge-Executor Role Tests
+        # Boots the entrypoint nine times across both roles. The load-bearing
+        # assertions are negative: an unarmed executor starts nothing, an armed
+        # one starts neither the worker nor alissa-revloop, and the daemon role
+        # never starts a bridge however the ALISSA_BRIDGE_* env is set — the
+        # two services must not share a process chain (issue #73). One case
+        # holds a config dir unwritable to prove the volume class still backs
+        # off instead of crash-looping, hence the timeout headroom.
+        timeout-minutes: 6
+        run: bash docker/claude/tests-entrypoint-executor.sh
       - name: Execute Entrypoint Console Wiring Tests
         # Boots the entrypoint four times (console off / enabled-without-passcode
         # / enabled / sidecar killed under it). No docker needed: the CLIs the

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ To run the whole loop unattended in Docker — the poller, an `alissa worker`, a
 the `claude` reviewer it spawns, bundled in one image — see
 [`docker/claude/`](./docker/claude/README.md).
 
+That image also serves a second, separate role: `CONTAINER_ROLE=executor` runs
+`alissa bridge start` (an Alissa Studio queue executor) instead of the review
+loop, deployed as its own service so hours-long queue jobs never share a restart
+domain with the daemon. See
+[Bridge executor role](./docker/claude/README.md#bridge-executor-role-a-second-service-from-this-same-image).
+
 ### Settings
 
 Three layers, each winning over the one before: **defaults → config file → CLI**.
@@ -748,12 +754,15 @@ bash check-style.sh alissa-tools-github-revloop
 bash check-types.sh alissa-tools-github-revloop
 ```
 
-The container entrypoint has its own two shell suites (no docker needed — the
-CLIs it shells out to are stubbed):
+The container entrypoint has its own shell suites (no docker needed — the CLIs it
+shells out to are stubbed, and the entrypoint under test is the real one):
 
 ```sh
-bash docker/claude/tests-entrypoint-config.sh   # config renderer pass-through
-bash docker/claude/tests-entrypoint-ui.sh       # reviewer-console wiring
+bash docker/claude/tests-entrypoint-config.sh    # config renderer pass-through
+bash docker/claude/tests-entrypoint-identity.sh  # reviewer-identity preflight
+bash docker/claude/tests-entrypoint-auth.sh      # alissa auth failure triage
+bash docker/claude/tests-entrypoint-executor.sh  # bridge-executor role + gates
+bash docker/claude/tests-entrypoint-ui.sh        # reviewer-console wiring
 ```
 
 282 tests cover the decision state machine, the config layering, the

--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -12,6 +12,13 @@
 #   * node + the alissa CLI                          (worker, tmux queue, tasks)
 #   * claude-code                                    (the agent the worker spawns)
 #
+# ONE IMAGE, TWO ROLES (issue #73). `CONTAINER_ROLE=executor` boots the same
+# image as an Alissa Studio queue EXECUTOR (`alissa bridge start`) instead of the
+# review daemon — deployed as a SECOND service, never as a sidecar of the first.
+# Nothing below changes for it: the executor uses the same CLI, the same claude,
+# the same agents.yaml and the same entrypoint, which simply takes a different
+# branch. See "Bridge executor role" in README.md.
+#
 # Build context is this directory (docker/claude) — the image pulls the daemon
 # from PyPI, so no repo source is copied in.
 #
@@ -182,6 +189,22 @@ WORKDIR /workspace
 #     so it pairs with the passcode it is useless without.
 #   * ALISSA_UI_SECURE_COOKIE — TLS-posture flag read by the sidecar itself.
 # EXPOSE below documents the console port; the console is disabled by default.
+#
+# AND deliberately not here (runtime-only): every bridge-executor knob —
+# CONTAINER_ROLE, ALISSA_BRIDGE_EXECUTOR, ALISSA_BRIDGE_EXECUTOR_ID,
+# ALISSA_BRIDGE_LABEL, ALISSA_BRIDGE_MAX_CONCURRENT, ALISSA_BRIDGE_POLL_SECONDS,
+# ALISSA_BRIDGE_HANDOFF. Same reasoning as the console flags, plus one that is
+# specific to the role:
+#   * CONTAINER_ROLE is what makes ONE image serve TWO services. Baking a default
+#     other than `daemon` would make the artifact role-specific — the opposite of
+#     the "same image, no second Dockerfile" decision this role exists under.
+#   * ALISSA_BRIDGE_EXECUTOR is the arming gate, and an ARG default is a value
+#     every deploy inherits. It stays unset so the image ships DISARMED and the
+#     entrypoint's own `${…:-0}` is the only default there is.
+#   * the id / label / concurrency / interval / handoff knobs only mean anything
+#     on a service that already set the two above, and the entrypoint supplies
+#     their defaults (`revloop-executor`, `claude`, and CLI pass-through for the
+#     rest), so an ARG here would just be a second place for them to drift.
 
 # Allowlist of repos to watch, as a single string separated by "|" (a single
 # repo needs no separator). "|" is used because repo slugs contain "/".

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -554,7 +554,8 @@ What it must **not** carry:
 
 ### Persistence, and what happens when the volume is not there
 
-Two things have to outlive a redeploy, and both live on the `/workspace` volume:
+Two things have to outlive a redeploy, and both live on the `/workspace` volume —
+plus a third that lands there as a consequence, and that you should know about:
 
 * **the executor identity** — `${ALISSA_CONFIG_DIR}/bridge-executor.json`, the id
   plus the fingerprint Studio displays. In this role `ALISSA_CONFIG_DIR` defaults
@@ -566,9 +567,34 @@ Two things have to outlive a redeploy, and both live on the `/workspace` volume:
   if a deploy moved it off; a queue job is long and unattended, and re-logging in
   is manual.
 
+* **the Alissa API token — a consequence, not a goal.** `alissa auth login` (the
+  same preflight the daemon role runs) writes the *verified* `ALISSA_API_TOKEN`
+  in cleartext to `${ALISSA_CONFIG_DIR}/config.json` with default permissions.
+  Relocating that directory onto the volume therefore moves that secret from the
+  ephemeral home to persistent storage. Nothing about the executor needs it
+  persisted — it is the price of persisting the identity file that sits beside
+  it — but the volume now holds a live credential, so give it the same handling
+  you would give any credential store: no snapshots into shared buckets, no
+  attaching it to a second service to "have a look", and rotate the token if the
+  volume is ever exposed. This is the same class of exposure as
+  [Exactly what a job spec can name](#exactly-what-a-job-spec-can-name) above,
+  one layer down: that section is about what a job can *read from the process*,
+  this is about what sits *on the disk*.
+
 The resolved `agents.yaml` is copied into the executor's config dir on **every**
 boot, so the image — not a file left behind by an older image — is always the
 source of truth for the profile.
+
+The CLI's executor **lockfile** (`…/bridge/executor-<id>.lock`) also lands in
+that directory, and it is deliberately *not* treated as persistent state: the
+entrypoint deletes this executor's lock immediately before starting. A lock is a
+claim that a process on this machine is already running, decided by a bare
+`kill(pid, 0)`; a container that died ungracefully leaves one behind, and the
+next boot's fresh PID namespace can easily make that dead PID look alive —
+refusing to start, forever. A fresh container has no executor running by
+definition, so the lock is stale by construction. Only *this* executor's lock is
+removed, never every `executor-*.lock`, so a lock belonging to some other id is
+left alone rather than pulled out from under whoever owns it.
 
 Volume unavailability is **not** fatal. Because the identity dir is the same
 directory the `alissa auth login` preflight probes, a missing or root-owned mount
@@ -642,7 +668,8 @@ volumes:
    daemon's on-demand `alissa code workspace add` no-ops on a repo already listed
    in the manifest, leaving an empty folder and looping forever hub-ifying a hub
    that never completes.
-3b. **Executor role only, and the end of the shared path**: `exec alissa bridge
+3d. **Executor role only, and the end of the shared path**: drop this executor's
+   stale lockfile, then `exec alissa bridge
    start …`. `exec`, so the container's only process is the executor — steps 4
    and 5 below never run in this role, and the daemon role never reaches this
    step. Nothing after this point applies to an executor service.

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -9,6 +9,11 @@ and enqueues sessions; the worker is what drains the queue and spawns reviewers,
 so the image bundles all three tiers (see the top-of-file comment in
 [`Dockerfile`](./Dockerfile)).
 
+The same image also serves a **second, separate service**: with
+`CONTAINER_ROLE=executor` it runs `alissa bridge start` as an Alissa Studio queue
+executor instead of the review loop. See
+[Bridge executor role](#bridge-executor-role-a-second-service-from-this-same-image).
+
 ## Build
 
 ```sh
@@ -437,6 +442,156 @@ docker run -d --name alissa-review \
 
 See [`init-firewall.sh`](./init-firewall.sh) for the allowlist.
 
+## Bridge executor role (a SECOND service from this same image)
+
+`CONTAINER_ROLE=executor` boots this image as an **Alissa Studio queue
+executor** instead of the review daemon. The executor is `alissa bridge start`:
+it registers a `bridgeExecutors` row, polls `/v1/bridge/jobs`, and runs each
+claimed job as an `alissa code --handoff claude` session in its own tmux session
+inside the workspace hubs.
+
+### Why a separate service, and not a sidecar of the daemon
+
+This is a pinned decision, recorded here so it survives the next round of
+refactoring:
+
+1. **Different restart domains.** A queue job is a tmux session that runs for
+   hours (6h default budget). Every revloop redeploy or restart would kill the
+   in-flight ones, and each hand-back costs the job a retry attempt
+   (`reconcileResumed`, attempt + 1). The review daemon redeploys often; the
+   executor must not.
+2. **A separate service is a separate environment, and that is a security
+   control.** The executor resolves a job spec's env **names** out of its own
+   process environment (`resolveJobEnv`), so *every variable this service holds
+   is nameable by any queue agent belonging to the token's user*. Running it as
+   its own service is what lets you give it a minimal credential set instead of
+   the review daemon's full one. See [Exactly what a job spec can
+   name](#exactly-what-a-job-spec-can-name) below.
+3. **An in-container background sidecar was considered and rejected.** That
+   pattern (the devloop repo's UI console) is fine for a stateless console; it is
+   wrong for hour-long stateful jobs, for reason 1.
+
+The entrypoint enforces the split by construction rather than by convention: the
+executor role `exec`s the CLI, so the container's only process is the executor —
+no `alissa worker`, no `alissa-revloop`, no console. And the daemon role never
+starts a bridge, however the `ALISSA_BRIDGE_*` variables are set. Both directions
+are asserted in
+[`tests-entrypoint-executor.sh`](./tests-entrypoint-executor.sh).
+
+### Deploying it
+
+Same image, same Dockerfile, no second build. On Railway: add a second service
+from this repo, attach **its own** volume at `/workspace`, and set the runtime
+variables below. Locally:
+
+```sh
+docker run -d --name alissa-bridge-executor \
+  -e CONTAINER_ROLE=executor \
+  -e ALISSA_BRIDGE_EXECUTOR=1 \
+  -e ALISSA_BRIDGE_EXECUTOR_ID=revloop-executor \
+  -e ALISSA_BRIDGE_LABEL="Revloop executor" \
+  -e ALISSA_API_TOKEN=alissa_… \
+  -e GH_TOKEN=ghp_… \
+  -e ALISSA_REVIEW_REPOS="fahera-mx/studio.alissa.app" \
+  -v alissa-executor-workspace:/workspace \
+  alissa-review-daemon
+```
+
+Extra CMD args pass through to `alissa bridge start`, so
+`docker run … alissa-review-daemon --once` is a one-poll smoke test.
+
+### Configuration (runtime env only — no build ARGs)
+
+Unlike the daemon knobs, none of these is a build ARG. `CONTAINER_ROLE` is what
+makes one image serve two services, so baking it would make the artifact
+role-specific; `ALISSA_BRIDGE_EXECUTOR` is an arming gate, so it ships unset; and
+the rest only mean anything on a service that already set those two.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `CONTAINER_ROLE` | `daemon` | `executor` selects this role. Any other value **dies at boot** naming the two the image ships |
+| `ALISSA_BRIDGE_EXECUTOR` | *(unset ⇒ off)* | the arming gate: `1`/`true`/`yes`/`on`. With the role set and this off, the container **refuses cleanly** and registers nothing — selecting the role is not consent to claim jobs |
+| `ALISSA_BRIDGE_EXECUTOR_ID` | `revloop-executor` | **required** (an explicitly empty value is fatal), validated as a slug at boot. It **must differ from every other executor of the same Alissa user** — the devloop image's executor above all. Identity is `(userId, executorId)` and registration *takes over* an existing row, so a shared id means two services evicting each other in a loop and stranding every sticky claim pinned to it. Never left to the CLI's own fallback (a slugified hostname, which on a platform is a fresh string per deploy) |
+| `ALISSA_BRIDGE_HANDOFF` | `claude` | agent used when a job spec names none. Structural, like `ALISSA_AGENT_PROFILE`: it must name a profile in the baked [`agents.yaml`](./agents.yaml) |
+| `ALISSA_BRIDGE_LABEL` | *(CLI default: the hostname)* | human name shown in Studio; **pass-through** — unset ⇒ the CLI decides |
+| `ALISSA_BRIDGE_MAX_CONCURRENT` | *(CLI default)* | jobs to run at once (the CLI clamps to 1–16); **pass-through** |
+| `ALISSA_BRIDGE_POLL_SECONDS` | *(CLI default: 15)* | seconds between queue polls; maps to the CLI's `--interval`; **pass-through** |
+
+The model pin works exactly as it does for the daemon: `ALISSA_AGENT_MODEL`
+(default `opus`) is rewritten into the `claude` profile's `command:` at boot, and
+job sessions inherit it. The profile deliberately carries **no**
+`disable_alissa_code`, which is what makes the CLI launch it via `alissa code -y
+--handoff claude` — that wrapper is what registers the codeSession and its
+10-minute log checkpoints. Adding the flag would launch a bare `claude` and lose
+both.
+
+### Exactly what a job spec can name
+
+A job spec carries environment variable **names**, never values; the executor
+resolves each name against its own process environment and fails the job
+(`spec_rejected`) if one is missing. So the set of variables a queue agent can
+pull into a job session is *exactly the set this service holds*. Keep it minimal.
+
+What the executor genuinely needs:
+
+| Variable | Why |
+| --- | --- |
+| `ALISSA_API_TOKEN` | polls the job queue and reports results — without it there is no executor |
+| `GH_TOKEN` (or `GITHUB_TOKEN`) | the workspace bootstrap clones the hubs, and job sessions do the repo work |
+| `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` | only if you are not using the persisted `claude /login` on the volume (which is preferred — see [claude auth](#claude-auth-log-in-once-persisted-on-the-volume-recommended)) |
+| `ALISSA_REVIEW_REPOS` | the repo allowlist the manifest (and therefore the hubs) is built from |
+
+What it must **not** carry:
+
+* **the reviewer's GitHub token.** An executor posts no verdicts. If
+  `ALISSA_REVIEWER_TOKEN_ENV` is set on an executor service the entrypoint warns
+  and ignores it — but the *token itself* being present is the problem, because a
+  job spec can name it.
+* **`ALISSA_UI_PASSCODE`.** The console is a review-loop surface and is never
+  started in this role.
+* anything else the review daemon happens to hold. Copying the daemon service's
+  variable set across is the mistake this whole split exists to prevent.
+
+### Persistence, and what happens when the volume is not there
+
+Two things have to outlive a redeploy, and both live on the `/workspace` volume:
+
+* **the executor identity** — `${ALISSA_CONFIG_DIR}/bridge-executor.json`, the id
+  plus the fingerprint Studio displays. In this role `ALISSA_CONFIG_DIR` defaults
+  to `/workspace/.alissa-config` (the CLI's own default is the *ephemeral* home,
+  which would mint a new fingerprint on every boot and re-register as a changed
+  machine). Set it explicitly only if you move the volume.
+* **the claude credential** — `CLAUDE_CONFIG_DIR`, already `/workspace/.claude-config`
+  in this image. The entrypoint verifies it is under the workspace root and warns
+  if a deploy moved it off; a queue job is long and unattended, and re-logging in
+  is manual.
+
+The resolved `agents.yaml` is copied into the executor's config dir on **every**
+boot, so the image — not a file left behind by an older image — is always the
+source of truth for the profile.
+
+Volume unavailability is **not** fatal. Because the identity dir is the same
+directory the `alissa auth login` preflight probes, a missing or root-owned mount
+lands in that gate's "config dir unwritable" class: it logs what it saw and
+retries with capped backoff, forever, and proceeds the moment the mount appears —
+[the same posture](#alissa-auth-failures-are-triaged-not-guessed) the rest of the
+entrypoint takes, and deliberately not a crash loop.
+
+### Firewall
+
+The egress allowlist is shared by both roles and **verified**, not assumed: a job
+session needs the Alissa API (`api.alissa.app`), `api.anthropic.com`, GitHub
+(`github.com`, `api.github.com`, `codeload.github.com`,
+`objects.githubusercontent.com`) and the skill/installer hosts
+(`skills.alissa.app`, `share.alissa.app`), and every one of those is already in
+[`init-firewall.sh`](./init-firewall.sh). Nothing had to be added for this role.
+`firewall_domains` there is sourceable precisely so
+[`tests-entrypoint-executor.sh`](./tests-entrypoint-executor.sh) asserts that
+membership against the shipped list instead of a second copy of it. Package
+registries (`registry.npmjs.org`, `pypi.org`, `files.pythonhosted.org`) are
+allowed too, which a job that installs dependencies will want; extend with
+`ALISSA_FIREWALL_EXTRA` for anything else.
+
 ## docker-compose
 
 ```yaml
@@ -465,7 +620,11 @@ volumes:
 
 ## What the entrypoint does
 
-0. As root: `chown` the `/workspace` mount to `alissa`, (optionally) raise the
+0. Resolve `CONTAINER_ROLE` (`daemon` by default) and, in the `executor` role,
+   its gates — the arming flag, the executor id, and where the identity is
+   persisted. A bad role or an unarmed executor **dies here**, before any
+   bootstrap. See [Bridge executor role](#bridge-executor-role-a-second-service-from-this-same-image).
+0b. As root: `chown` the `/workspace` mount to `alissa`, (optionally) raise the
    egress firewall, then drop to `alissa` via `gosu`. Everything below runs
    unprivileged.
 1. Preflight + onboard the identities: validate `gh` (fatal if missing) and run
@@ -483,6 +642,10 @@ volumes:
    daemon's on-demand `alissa code workspace add` no-ops on a repo already listed
    in the manifest, leaving an empty folder and looping forever hub-ifying a hub
    that never completes.
+3b. **Executor role only, and the end of the shared path**: `exec alissa bridge
+   start …`. `exec`, so the container's only process is the executor — steps 4
+   and 5 below never run in this role, and the daemon role never reaches this
+   step. Nothing after this point applies to an executor service.
 4. Start `alissa worker --daemon`, wait until it reports running (the daemon only
    *warns* if the worker is absent, so ordering matters).
 4b. When `ALISSA_UI_ENABLED` is set, start the reviewer console

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -11,6 +11,24 @@
 #
 # The daemon is a thin poller; the worker is what actually spawns reviewers, so
 # the worker MUST be running first — the daemon only warns if it isn't.
+#
+# TWO ROLES, ONE IMAGE (CONTAINER_ROLE, issue #73)
+# ------------------------------------------------
+# `CONTAINER_ROLE=executor` boots this same image as an Alissa Studio queue
+# EXECUTOR instead: it shares steps 0-3 (identities, workspace bootstrap, hub
+# sync) and then `exec`s `alissa bridge start` — no worker, no console, no
+# `alissa-revloop`. The executor is a SEPARATE SERVICE, not a sidecar of the
+# daemon, and the split is the point:
+#
+#   * queue jobs are hours-long tmux sessions; a revloop redeploy would kill
+#     them mid-run and burn a retry attempt each. Different restart domain.
+#   * the executor resolves a job spec's env NAMES out of its OWN process env,
+#     so every variable this service holds is nameable by any queue agent of the
+#     token's user. A separate service is what keeps that set minimal — see
+#     "Bridge executor role" in docker/claude/README.md.
+#
+# So the two roles never share a process chain: whichever one is selected, the
+# other's supervisor is never started.
 # =============================================================================
 set -euo pipefail
 
@@ -27,6 +45,81 @@ ENTRYPOINT_DIR="$(cd "$(dirname "$0")" && pwd)"
 WORKSPACE_ROOT="${ALISSA_WORKSPACE_ROOT:-/workspace}"
 WORKSPACE_NAME="${ALISSA_WORKSPACE:-alissa-review}"
 RUNTIME_USER=alissa
+
+# Truthiness for the container's on/off flags: 1/true/yes/on (case-insensitive),
+# anything else — including unset — is off. One definition, so the console gate
+# (2d) and the bridge-executor gate below can never drift apart.
+is_truthy() {
+  case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes|on) return 0 ;;
+    *)             return 1 ;;
+  esac
+}
+
+# -----------------------------------------------------------------------------
+# Role selection + the executor's gates (issue #73).
+#
+# Resolved FIRST, before any bootstrap: a role/gate misconfiguration is a deploy
+# mistake, and the cheapest place to say so is the top of the log. This block
+# runs on the root pass too, so a refusal happens before the privilege drop.
+# -----------------------------------------------------------------------------
+CONTAINER_ROLE="$(printf '%s' "${CONTAINER_ROLE:-daemon}" | tr '[:upper:]' '[:lower:]')"
+case "${CONTAINER_ROLE}" in
+  daemon|executor) ;;
+  *) die "CONTAINER_ROLE=${CONTAINER_ROLE} is not a role this image ships. Use 'daemon' (the review loop, the default) or 'executor' (an Alissa Studio queue executor running 'alissa bridge start')." ;;
+esac
+
+BRIDGE_EXECUTOR_ID=""
+BRIDGE_HANDOFF=""
+if [ "${CONTAINER_ROLE}" = "executor" ]; then
+  # (a) The master gate. Default OFF: selecting the role is not consent to run
+  #     one. An executor claims queued jobs from the whole user's queue and runs
+  #     them as unattended agent sessions holding this service's credentials, so
+  #     it takes TWO explicit settings to arm — and a service that only has the
+  #     role set refuses cleanly instead of quietly registering itself.
+  is_truthy "${ALISSA_BRIDGE_EXECUTOR:-0}" \
+    || die "CONTAINER_ROLE=executor but ALISSA_BRIDGE_EXECUTOR=${ALISSA_BRIDGE_EXECUTOR:-0} (default off) — refusing to register an executor or claim any job. Set ALISSA_BRIDGE_EXECUTOR=1 on THIS service to arm it (see 'Bridge executor role' in docker/claude/README.md), or unset CONTAINER_ROLE to run the review daemon."
+
+  # (b) The executor id, which is the identity half of the registry key
+  #     (userId, executorId). Registration TAKES OVER an existing row with the
+  #     same key, so two executors of the same user sharing an id evict each
+  #     other in a loop and strand every sticky claim pinned to it. Hence:
+  #     defaulted (never the CLI's slugified-hostname fallback, which on a
+  #     platform is a random per-deploy string), required non-empty, and
+  #     validated here so a bad slug fails at boot instead of at register time.
+  #     `-` not `:-`: an explicitly EMPTY value is an error, not a request for
+  #     the default — it is exactly how a deploy silently falls back to the
+  #     hostname slug.
+  BRIDGE_EXECUTOR_ID="${ALISSA_BRIDGE_EXECUTOR_ID-revloop-executor}"
+  [ -n "${BRIDGE_EXECUTOR_ID}" ] \
+    || die "ALISSA_BRIDGE_EXECUTOR_ID is set but EMPTY — an executor id is required. Leave it unset for the default 'revloop-executor', or give this service its own id; it MUST differ from every other executor of the same Alissa user (the devloop image's executor included), because registering the same id takes the other one over."
+  printf '%s' "${BRIDGE_EXECUTOR_ID}" | grep -qE '^[a-z0-9][a-z0-9-]*$' \
+    || die "ALISSA_BRIDGE_EXECUTOR_ID=${BRIDGE_EXECUTOR_ID} is not a valid executor id — lowercase letters, digits and dashes, starting with a letter or digit (e.g. 'revloop-executor')."
+
+  # (c) Which agent runs a job whose spec names none. STRUCTURAL, like
+  #     agent_profile: it must name a profile the baked agents.yaml ships, and
+  #     that file defines exactly `claude`. Drifting to the CLI's own default
+  #     would select a profile this image may not have.
+  BRIDGE_HANDOFF="${ALISSA_BRIDGE_HANDOFF:-claude}"
+
+  # (d) Identity persistence. The CLI keeps the executor identity (its id and
+  #     the fingerprint Studio shows) in ${ALISSA_CONFIG_DIR}/bridge-executor.json,
+  #     which defaults to the EPHEMERAL home — so every redeploy would mint a new
+  #     fingerprint and re-register as a changed machine. Point the whole config
+  #     dir at the persisted volume instead (it also holds the verified API token,
+  #     same posture as the claude credential already kept there), and EXPORT it
+  #     so the CLI actually sees it.
+  #
+  #     Volume unavailability is handled, not crashed on: this is the same dir
+  #     the auth preflight's writability probe (class 2 below) guards, so a mount
+  #     that is missing or root-owned degrades to that capped backoff — log and
+  #     retry forever, never a crash loop (2026-07-29 lesson).
+  export ALISSA_CONFIG_DIR="${ALISSA_CONFIG_DIR:-${WORKSPACE_ROOT}/.alissa-config}"
+  # Logged once, after the privilege drop — this block runs on both passes.
+  ROLE_SUMMARY="EXECUTOR — id=${BRIDGE_EXECUTOR_ID}, handoff=${BRIDGE_HANDOFF}, identity file ${ALISSA_CONFIG_DIR}/bridge-executor.json"
+else
+  ROLE_SUMMARY="daemon (review loop)"
+fi
 
 # -----------------------------------------------------------------------------
 # 0. Privilege bootstrap (runs only on the first pass, as root)
@@ -58,6 +151,8 @@ if [ "$(id -u)" = "0" ]; then
   exec gosu "${RUNTIME_USER}" "$0" "$@"
 fi
 
+log "role: ${ROLE_SUMMARY}"
+
 # -----------------------------------------------------------------------------
 # 1. Preflight the three identities
 #
@@ -82,6 +177,22 @@ else
   log "WARN: no persisted claude login and no ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN — run 'claude /login' once (see README); reviewers will 401 until then"
 fi
 
+# 2a-ii. Executor role: the claude credential has to OUTLIVE a redeploy, because
+#        a queue job is an hours-long agent session and a re-login is manual. The
+#        image points CLAUDE_CONFIG_DIR at the volume already; verify it rather
+#        than assume it, and WARN (never die) if a deploy has moved it off — the
+#        executor still runs, it just loses the login on the next restart.
+if [ "${CONTAINER_ROLE}" = "executor" ]; then
+  case "${CLAUDE_CONFIG_DIR:-}" in
+    "${WORKSPACE_ROOT}"/*|"${WORKSPACE_ROOT}")
+      log "claude config persisted on the volume: ${CLAUDE_CONFIG_DIR}" ;;
+    "")
+      log "WARN: CLAUDE_CONFIG_DIR is unset — a 'claude /login' lands in the ephemeral home and is gone on the next redeploy. Point it at a path under ${WORKSPACE_ROOT}." ;;
+    *)
+      log "WARN: CLAUDE_CONFIG_DIR=${CLAUDE_CONFIG_DIR} is not under ${WORKSPACE_ROOT} — if that path is not a persisted mount, a 'claude /login' is gone on the next redeploy and job sessions 401 until someone logs in again." ;;
+  esac
+fi
+
 # 2b. gh — the review queue, round counting, PR comments. gh reads GH_TOKEN /
 #     GITHUB_TOKEN from the environment automatically.
 if [ -z "${GH_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
@@ -101,7 +212,16 @@ log "gh authenticated as: ${GH_LOGIN}"
 # token routes every daemon `gh` call through it explicitly. We resolve it here
 # so a bad credential fails at boot with a login in the log, not silently at the
 # first verdict; the daemon re-asserts the same identity before every post.
-if [ -n "${ALISSA_REVIEWER_TOKEN_ENV:-}" ]; then
+if [ "${CONTAINER_ROLE}" = "executor" ]; then
+  # An executor posts no verdicts, so it needs no reviewer identity — and it
+  # must not HOLD one. `resolveJobEnv` resolves a job spec's env names out of
+  # this process's environment, so any credential parked on this service is
+  # nameable by any queue agent of the token's user. Say so rather than
+  # silently ignoring the variable.
+  if [ -n "${ALISSA_REVIEWER_TOKEN_ENV:-}" ]; then
+    log "WARN: ALISSA_REVIEWER_TOKEN_ENV=${ALISSA_REVIEWER_TOKEN_ENV} is set on an EXECUTOR service. The executor posts no reviews, so it is unused — and a job spec can name any variable this service holds. Drop the reviewer credential from this service's env."
+  fi
+elif [ -n "${ALISSA_REVIEWER_TOKEN_ENV:-}" ]; then
   # Indirect expansion: read the variable whose NAME is in
   # ALISSA_REVIEWER_TOKEN_ENV. The `:-` keeps `set -u` from aborting when that
   # variable does not exist, so the empty check below is what reports it.
@@ -312,12 +432,19 @@ done
 # Truthiness matches the sidecar's own _env_flag (1/true/yes/on, case-insensitive)
 # so `ALISSA_UI_ENABLED=true` behaves like `=1`; anything else (incl. unset) is off.
 # -----------------------------------------------------------------------------
+#
+# The console renders the review loop's own panels (spawn ledger, review-*
+# sessions), of which an executor has none — so the executor role never starts
+# it, and says so if a deploy asked for one.
 UI_ENABLED=0
-case "$(printf '%s' "${ALISSA_UI_ENABLED:-0}" | tr '[:upper:]' '[:lower:]')" in
-  1|true|yes|on) UI_ENABLED=1 ;;
-esac
+if is_truthy "${ALISSA_UI_ENABLED:-0}"; then UI_ENABLED=1; fi
 UI_PORT="${PORT:-8080}"
-if [ "${UI_ENABLED}" = "1" ]; then
+if [ "${CONTAINER_ROLE}" = "executor" ]; then
+  [ "${UI_ENABLED}" = "1" ] \
+    && log "WARN: ALISSA_UI_ENABLED is set on an EXECUTOR service — the reviewer console is a review-loop surface and is NOT started here; no listener." \
+    || log "reviewer console not applicable in the executor role — no listener"
+  UI_ENABLED=0
+elif [ "${UI_ENABLED}" = "1" ]; then
   [ -n "${ALISSA_UI_PASSCODE:-}" ] \
     || die "ALISSA_UI_ENABLED is set but ALISSA_UI_PASSCODE is empty — the console is fail-closed on the passcode (it is the ONLY gate, and it rides the public URL once you enable networking). Set ALISSA_UI_PASSCODE, or unset ALISSA_UI_ENABLED."
   log "reviewer console ENABLED (ALISSA_UI_ENABLED) — will serve on 0.0.0.0:${UI_PORT} (passcode required)"
@@ -380,6 +507,38 @@ PY
   log "effective reviewer command: ${CLAUDE_CMD}"
 fi
 
+# 2e-ii. Executor role: put the resolved agents.yaml where the CLI will look.
+#
+# The CLI reads agent profiles from ${ALISSA_CONFIG_DIR}/agents.yaml, and the
+# role block at the top moved that dir onto the volume — so the baked profile
+# in the ephemeral home would be invisible and `alissa bridge start` would reject
+# every job with "no agent profile named claude". Copy the just-resolved file
+# across on EVERY boot (never generate-if-absent): the image is the source of
+# truth for the profile, and a copy left on the volume by an older image must not
+# outlive it. Both locations stay populated, so whichever one a job session
+# resolves finds the same profile.
+#
+# The profile deliberately carries no `disable_alissa_code`, which is what makes
+# the CLI launch it via `alissa code -y --handoff claude` — that is the wrapper
+# registering the codeSession and its 10-minute log checkpoints. Adding the flag
+# would launch a bare claude and lose both.
+if [ "${CONTAINER_ROLE}" = "executor" ] && [ -f "${AGENTS_YAML}" ]; then
+  EXECUTOR_AGENTS_YAML="${ALISSA_CONFIG_DIR}/agents.yaml"
+  if [ "${EXECUTOR_AGENTS_YAML}" = "${AGENTS_YAML}" ]; then
+    log "executor agent profiles: ${AGENTS_YAML} (config dir is the baked one)"
+  elif mkdir -p "${ALISSA_CONFIG_DIR}" 2>/dev/null \
+       && cp "${AGENTS_YAML}" "${EXECUTOR_AGENTS_YAML}" 2>/dev/null; then
+    log "executor agent profiles: copied ${AGENTS_YAML} -> ${EXECUTOR_AGENTS_YAML}"
+  else
+    # Non-fatal by design. The auth preflight above already proved this exact
+    # directory writable, so reaching here means the mount changed under us —
+    # and a mount blip must not become a crash loop (2026-07-29). The job that
+    # would have used the profile fails with the CLI's own "no agent profile"
+    # rejection, which is a per-job failure, not a dead service.
+    log "WARN: could not copy agents.yaml to ${EXECUTOR_AGENTS_YAML} (volume not writable?) — jobs will be rejected with 'no agent profile' until the next boot"
+  fi
+fi
+
 # -----------------------------------------------------------------------------
 # 3. Bootstrap the workspace (bootstrap-from-manifest model)
 #
@@ -432,7 +591,16 @@ if [ -n "$(repos_lines)" ]; then
   # the allowlist is the full set of repos the daemon may touch (on_missing_hub
   # only hub-ifies repos already in it), and the cloned hub dirs on the volume
   # are untouched by rewriting this text.
-  log "generating ${MANIFEST} + revloop.config.json from ALISSA_REVIEW_REPOS"
+  #
+  # The EXECUTOR role shares this exact flow — a queue job runs inside the same
+  # worktree hubs a reviewer does, so the manifest is what makes those hubs
+  # exist. It skips only revloop.config.json, which configures a daemon this
+  # service never starts.
+  if [ "${CONTAINER_ROLE}" = "executor" ]; then
+    log "generating ${MANIFEST} from ALISSA_REVIEW_REPOS (executor role: no revloop.config.json — no daemon here)"
+  else
+    log "generating ${MANIFEST} + revloop.config.json from ALISSA_REVIEW_REPOS"
+  fi
   {
     printf 'name: %s\n' "${WORKSPACE_NAME}"
     printf 'description: Containerized Alissa review daemon workspace\n'
@@ -453,17 +621,19 @@ if [ -n "$(repos_lines)" ]; then
   # own default applies (env var > library default, no shadowing entrypoint
   # layer). Structural keys (on_missing_hub, agent_profile) are always emitted.
   # See revloop-config.sh for the precedence contract and per-key rationale.
-  repos_json="$(repos_lines | jq -R . | jq -s -c .)"
-  # `|| true` because an EMPTY operator list is the normal case: the last
-  # filter in operators_lines is a grep, which exits 1 when it matches nothing,
-  # and under `set -e -o pipefail` that non-zero status would kill the
-  # entrypoint mid-bootstrap. jq's own status still propagates.
-  operators_json="$({ operators_lines || true; } | jq -R . | jq -s -c .)"
-  render_revloop_config "${repos_json}" "${operators_json}" > "${CONFIG}"
+  if [ "${CONTAINER_ROLE}" != "executor" ]; then
+    repos_json="$(repos_lines | jq -R . | jq -s -c .)"
+    # `|| true` because an EMPTY operator list is the normal case: the last
+    # filter in operators_lines is a grep, which exits 1 when it matches nothing,
+    # and under `set -e -o pipefail` that non-zero status would kill the
+    # entrypoint mid-bootstrap. jq's own status still propagates.
+    operators_json="$({ operators_lines || true; } | jq -R . | jq -s -c .)"
+    render_revloop_config "${repos_json}" "${operators_json}" > "${CONFIG}"
+  fi
 else
   # MOUNTED MODE: no allowlist in the env — respect a mounted workspace as-is.
   [ -f "${MANIFEST}" ] \
-    || die "no alissa-workspace.yaml mounted and ALISSA_REVIEW_REPOS is empty — nothing to review"
+    || die "no alissa-workspace.yaml mounted and ALISSA_REVIEW_REPOS is empty — nothing to work on (the manifest is what materializes the worktree hubs a reviewer, or a queue job, runs inside)"
   log "using mounted workspace at ${WORKSPACE_ROOT} (ALISSA_REVIEW_REPOS unset)"
 fi
 
@@ -542,8 +712,12 @@ PY
 # A fresh container has no reviewer running by definition (tmux server is down),
 # so every `spawns` row is stale: clear them and the daemon re-enqueues on its
 # first poll. `escalations` is kept, so capped-out PRs are not re-escalated.
+#
+# Daemon-only: the ledger belongs to `alissa-revloop`, which the executor role
+# never starts. An executor's own in-flight jobs are reconciled server-side
+# (`reconcileResumed`), not from this file.
 STATE_DB="${WORKSPACE_ROOT}/.revloop/state.db"
-if [ -f "${STATE_DB}" ]; then
+if [ "${CONTAINER_ROLE}" != "executor" ] && [ -f "${STATE_DB}" ]; then
   python3 - "${STATE_DB}" <<'PY' || true
 import sqlite3, sys
 db = sqlite3.connect(sys.argv[1])
@@ -577,7 +751,53 @@ if [ -f "${MANIFEST}" ]; then
 fi
 
 # -----------------------------------------------------------------------------
-# 4. Start the worker, wait until it reports running.
+# 3d. EXECUTOR ROLE — hand the container over to `alissa bridge start`.
+#
+# This is the end of the shared path. `exec` replaces this shell, so tini's only
+# child is the executor itself: no worker, no console, no `alissa-revloop`, and
+# nothing of this entrypoint left to be torn down with them. That is the "not in
+# the daemon's process chain" property, enforced by construction rather than by
+# a flag someone has to remember.
+#
+# Flag mapping, on this repo's usual pass-through contract (env > CLI default,
+# no hidden entrypoint layer):
+#
+#   ALISSA_BRIDGE_EXECUTOR_ID   -> --executor-id     STRUCTURAL, always passed
+#   ALISSA_BRIDGE_HANDOFF       -> --handoff         STRUCTURAL, always passed
+#   ALISSA_BRIDGE_LABEL         -> --label           pass-through (unset: the CLI
+#                                                    falls back to the hostname)
+#   ALISSA_BRIDGE_MAX_CONCURRENT-> --max-concurrent  pass-through (CLI clamps 1-16)
+#   ALISSA_BRIDGE_POLL_SECONDS  -> --interval        pass-through (CLI default 15s)
+#
+# The two structural ones are pinned for the same reason `agent_profile` is: the
+# CLI's own fallbacks (slugified hostname, its default handoff) are wrong for a
+# platform container — a per-deploy hostname is an identity that takes over its
+# own registry row every redeploy, and a handoff this image has no profile for
+# rejects every job.
+#
+# Extra CMD args still pass through, so `docker run … --once` works for a smoke
+# test exactly as the daemon's flags do.
+# -----------------------------------------------------------------------------
+if [ "${CONTAINER_ROLE}" = "executor" ]; then
+  mkdir -p "${TMUX_TMPDIR:-/home/${RUNTIME_USER}/.tmux}"
+  BRIDGE_ARGS=( --executor-id "${BRIDGE_EXECUTOR_ID}"
+                --workspace-root "${WORKSPACE_ROOT}"
+                --handoff "${BRIDGE_HANDOFF}" )
+  if [ -n "${ALISSA_BRIDGE_LABEL:-}" ]; then
+    BRIDGE_ARGS+=( --label "${ALISSA_BRIDGE_LABEL}" )
+  fi
+  if [ -n "${ALISSA_BRIDGE_MAX_CONCURRENT:-}" ]; then
+    BRIDGE_ARGS+=( --max-concurrent "${ALISSA_BRIDGE_MAX_CONCURRENT}" )
+  fi
+  if [ -n "${ALISSA_BRIDGE_POLL_SECONDS:-}" ]; then
+    BRIDGE_ARGS+=( --interval "${ALISSA_BRIDGE_POLL_SECONDS}" )
+  fi
+  log "starting alissa bridge start (executor ${BRIDGE_EXECUTOR_ID}) over ${WORKSPACE_ROOT}"
+  exec alissa bridge start "${BRIDGE_ARGS[@]}" "$@"
+fi
+
+# -----------------------------------------------------------------------------
+# 4. Start the worker, wait until it reports running.  (daemon role only)
 # -----------------------------------------------------------------------------
 mkdir -p "${TMUX_TMPDIR:-/home/alissa/.tmux}"
 

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -47,8 +47,14 @@ WORKSPACE_NAME="${ALISSA_WORKSPACE:-alissa-review}"
 RUNTIME_USER=alissa
 
 # Truthiness for the container's on/off flags: 1/true/yes/on (case-insensitive),
-# anything else — including unset — is off. One definition, so the console gate
-# (2d) and the bridge-executor gate below can never drift apart.
+# anything else — including unset — is off. Shared by the console gate (2d) and
+# the bridge-executor gate below, so those two cannot drift apart.
+#
+# NOT used by the ALISSA_ENABLE_FIREWALL gate in the root block, which still
+# tests `= "1"` exactly — a pre-existing narrower contract, left alone here on
+# purpose (TASK-112733143): widening it would make a deploy that today sets
+# `true`, gets no firewall and therefore never passed --cap-add=NET_ADMIN start
+# attempting the firewall init and die on it. That is a rollout, not a drive-by.
 is_truthy() {
   case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
     1|true|yes|on) return 0 ;;
@@ -93,8 +99,13 @@ if [ "${CONTAINER_ROLE}" = "executor" ]; then
   BRIDGE_EXECUTOR_ID="${ALISSA_BRIDGE_EXECUTOR_ID-revloop-executor}"
   [ -n "${BRIDGE_EXECUTOR_ID}" ] \
     || die "ALISSA_BRIDGE_EXECUTOR_ID is set but EMPTY — an executor id is required. Leave it unset for the default 'revloop-executor', or give this service its own id; it MUST differ from every other executor of the same Alissa user (the devloop image's executor included), because registering the same id takes the other one over."
-  printf '%s' "${BRIDGE_EXECUTOR_ID}" | grep -qE '^[a-z0-9][a-z0-9-]*$' \
-    || die "ALISSA_BRIDGE_EXECUTOR_ID=${BRIDGE_EXECUTOR_ID} is not a valid executor id — lowercase letters, digits and dashes, starting with a letter or digit (e.g. 'revloop-executor')."
+  #     The pattern is the CLI's own EXECUTOR_ID_RE, length bound included: an
+  #     unbounded version would pass a 65-character id here and let it die
+  #     inside `alissa bridge start` after the whole bootstrap had run — which
+  #     is the register-time failure this gate exists to convert into a boot-time
+  #     one.
+  printf '%s' "${BRIDGE_EXECUTOR_ID}" | grep -qE '^[a-z0-9][a-z0-9-]{0,63}$' \
+    || die "ALISSA_BRIDGE_EXECUTOR_ID=${BRIDGE_EXECUTOR_ID} is not a valid executor id — lowercase letters, digits and dashes, starting with a letter or digit, at most 64 characters (e.g. 'revloop-executor')."
 
   # (c) Which agent runs a job whose spec names none. STRUCTURAL, like
   #     agent_profile: it must name a profile the baked agents.yaml ships, and
@@ -780,6 +791,31 @@ fi
 # -----------------------------------------------------------------------------
 if [ "${CONTAINER_ROLE}" = "executor" ]; then
   mkdir -p "${TMUX_TMPDIR:-/home/${RUNTIME_USER}/.tmux}"
+
+  # Drop this executor's stale lockfile before starting.
+  #
+  # The CLI guards against two executors of the same id on one machine with
+  # ${ALISSA_CONFIG_DIR}/bridge/executor-<id>.lock, holding the owner's pid, and
+  # decides staleness with a bare `process.kill(pid, 0)` — no boot id, no start
+  # time, no cmdline. That was safe while the config dir was the ephemeral home,
+  # because a lock could not outlive its container. It is NOT safe now that the
+  # dir is on the volume: any ungraceful stop (OOM, platform hard-restart,
+  # SIGKILL after the grace period) leaves the file behind, and the next boot
+  # evaluates that pid against a fresh pid namespace that restarts at 1 and
+  # replays the same deterministic boot — so it can easily be live, and can even
+  # be this container's own executor (`exec` hands the CLI this shell's pid).
+  # The CLI then refuses to start, exits non-zero, the platform restarts it, and
+  # it repeats: a crash loop, which is the one thing this entrypoint must never
+  # cause (2026-07-29).
+  #
+  # Same argument step 3b makes for the spawn ledger: a fresh container has no
+  # executor running, by definition, so a lock found here is stale by
+  # construction. Scoped to OUR id and NOT globbed over `executor-*.lock`: if a
+  # config dir is ever shared with another container, a glob would delete a LIVE
+  # peer's lock. A stale lock under some other id is never consulted for ours,
+  # so leaving it is harmless.
+  rm -f "${ALISSA_CONFIG_DIR}/bridge/executor-${BRIDGE_EXECUTOR_ID}.lock" 2>/dev/null || true
+
   BRIDGE_ARGS=( --executor-id "${BRIDGE_EXECUTOR_ID}"
                 --workspace-root "${WORKSPACE_ROOT}"
                 --handoff "${BRIDGE_HANDOFF}" )

--- a/docker/claude/init-firewall.sh
+++ b/docker/claude/init-firewall.sh
@@ -11,67 +11,88 @@
 # Runs as root (the entrypoint invokes it during its root bootstrap, before it
 # drops to the unprivileged user) and needs --cap-add=NET_ADMIN. Gated behind
 # ALISSA_ENABLE_FIREWALL=1 — off by default.
+#
+# The allowlist is shared by BOTH container roles (issue #73): a bridge-executor
+# service runs the same kind of unattended agent session a reviewer does, so the
+# hosts it needs — the Alissa API it polls, api.anthropic.com, and GitHub for the
+# repo work a job does — are the ones already listed. `firewall_domains` exists so
+# that is ASSERTED rather than assumed: sourcing this file defines the list
+# without touching iptables, and tests-entrypoint-executor.sh checks it.
 # =============================================================================
 set -euo pipefail
 
-echo "[firewall] resetting rules"
-iptables -F || true
-iptables -X || true
-ipset destroy allowed-domains 2>/dev/null || true
-
-# Allow loopback and established/related return traffic.
-iptables -A INPUT  -i lo -j ACCEPT
-iptables -A OUTPUT -o lo -j ACCEPT
-iptables -A INPUT  -m state --state ESTABLISHED,RELATED -j ACCEPT
-iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
-
-# DNS must be allowed before we can resolve the allowlist.
-iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
-iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
-
-ipset create allowed-domains hash:ip
-
-# The hosts the review loop actually talks to. Extend via ALISSA_FIREWALL_EXTRA
-# (space-separated hostnames) for private registries or self-hosted GitHub.
-DOMAINS=(
-  api.github.com
-  github.com
-  codeload.github.com
-  objects.githubusercontent.com
-  api.anthropic.com
-  share.alissa.app
-  skills.alissa.app
-  api.alissa.app
-  registry.npmjs.org
-  pypi.org
-  files.pythonhosted.org
-  deb.nodesource.com
-  cli.github.com
-  ${ALISSA_FIREWALL_EXTRA:-}
-)
-
-for domain in "${DOMAINS[@]}"; do
-  [ -n "${domain}" ] || continue
-  ips="$(getent ahostsv4 "${domain}" | awk '{print $1}' | sort -u || true)"
-  if [ -z "${ips}" ]; then
-    echo "[firewall] WARN: could not resolve ${domain}" >&2
-    continue
-  fi
-  for ip in ${ips}; do
-    ipset add allowed-domains "${ip}" 2>/dev/null || true
+# The hosts the loop actually talks to, one per line. Extend via
+# ALISSA_FIREWALL_EXTRA (space-separated hostnames) for private registries or
+# self-hosted GitHub.
+firewall_domains() {
+  printf '%s\n' \
+    api.github.com \
+    github.com \
+    codeload.github.com \
+    objects.githubusercontent.com \
+    api.anthropic.com \
+    share.alissa.app \
+    skills.alissa.app \
+    api.alissa.app \
+    registry.npmjs.org \
+    pypi.org \
+    files.pythonhosted.org \
+    deb.nodesource.com \
+    cli.github.com
+  # Unquoted on purpose: this variable is a space-separated LIST.
+  # shellcheck disable=SC2086
+  for extra in ${ALISSA_FIREWALL_EXTRA:-}; do
+    printf '%s\n' "${extra}"
   done
-  echo "[firewall] allowed ${domain}"
-done
+}
 
-# Allow egress to the allowlist; drop everything else.
-iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
-iptables -P INPUT   DROP
-iptables -P FORWARD DROP
-iptables -P OUTPUT  DROP
-# Re-allow the essentials the policy would otherwise have dropped.
-iptables -A OUTPUT -o lo -j ACCEPT
-iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
-iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
-iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+init_firewall() {
+  echo "[firewall] resetting rules"
+  iptables -F || true
+  iptables -X || true
+  ipset destroy allowed-domains 2>/dev/null || true
 
-echo "[firewall] egress locked to allowlist"
+  # Allow loopback and established/related return traffic.
+  iptables -A INPUT  -i lo -j ACCEPT
+  iptables -A OUTPUT -o lo -j ACCEPT
+  iptables -A INPUT  -m state --state ESTABLISHED,RELATED -j ACCEPT
+  iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+  # DNS must be allowed before we can resolve the allowlist.
+  iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+  iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+
+  ipset create allowed-domains hash:ip
+
+  while IFS= read -r domain; do
+    [ -n "${domain}" ] || continue
+    ips="$(getent ahostsv4 "${domain}" | awk '{print $1}' | sort -u || true)"
+    if [ -z "${ips}" ]; then
+      echo "[firewall] WARN: could not resolve ${domain}" >&2
+      continue
+    fi
+    for ip in ${ips}; do
+      ipset add allowed-domains "${ip}" 2>/dev/null || true
+    done
+    echo "[firewall] allowed ${domain}"
+  done < <(firewall_domains)
+
+  # Allow egress to the allowlist; drop everything else.
+  iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
+  iptables -P INPUT   DROP
+  iptables -P FORWARD DROP
+  iptables -P OUTPUT  DROP
+  # Re-allow the essentials the policy would otherwise have dropped.
+  iptables -A OUTPUT -o lo -j ACCEPT
+  iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+  iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+  iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+
+  echo "[firewall] egress locked to allowlist"
+}
+
+# Direct execution raises the firewall; sourcing only defines the functions, so
+# the allowlist can be asserted in a test without root or NET_ADMIN.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  init_firewall
+fi

--- a/docker/claude/tests-entrypoint-executor.sh
+++ b/docker/claude/tests-entrypoint-executor.sh
@@ -1,0 +1,394 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Tests for the entrypoint's BRIDGE EXECUTOR role (issue #73).
+#
+# The image serves two services from one artifact: the review daemon
+# (CONTAINER_ROLE unset/daemon) and an Alissa Studio queue executor
+# (CONTAINER_ROLE=executor, running `alissa bridge start`). The executor is a
+# separate SERVICE on purpose — queue jobs are hours-long tmux sessions and a
+# revloop redeploy would kill them mid-run — so the property that matters most
+# is that the two roles never share a process chain.
+#
+# This boots the REAL entrypoint.sh (CLIs stubbed, no docker needed — CI has no
+# docker-in-docker, and the image adds layers, not entrypoint behaviour):
+#
+#   1. role=executor, gate off (default)  -> refuses cleanly, starts NOTHING
+#   2. role=executor, gate on             -> execs `alissa bridge start` with the
+#                                            structural flags; no worker, no
+#                                            daemon, no revloop.config.json;
+#                                            identity + agent profile on the volume
+#   3. executor id required + validated   -> empty dies, bad slug dies
+#   4. the pass-through knobs             -> label / concurrency / interval only
+#                                            appear when they are set
+#   5. daemon role, bridge env set        -> still the daemon; bridge never runs
+#   6. unknown CONTAINER_ROLE             -> dies naming the two it ships
+#   7. volume unwritable                  -> capped backoff, NOT a crash loop,
+#                                            and it self-heals mid-flight
+#   8. CLAUDE_CONFIG_DIR off the volume   -> WARNs, still boots
+#   9. firewall + agents.yaml             -> the allowlist really does admit what
+#                                            a job session needs; the profile
+#                                            really does still route via alissa code
+#
+# Usage: bash docker/claude/tests-entrypoint-executor.sh
+# Needs: bash, python3, jq (the entrypoint's own bootstrap uses both).
+# =============================================================================
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENTRYPOINT="${HERE}/entrypoint.sh"
+
+fail=0
+pass() { printf '  ok   %s\n' "$1"; }
+bad()  { printf '  FAIL %s\n' "$1" >&2; fail=1; }
+info() { printf '%s\n' "$*"; }
+
+assert_contains() {
+  if grep -qF -- "$2" "$1"; then pass "$3"; else bad "$3 (not in $1: $2)"; fi
+}
+assert_not_contains() {
+  if grep -qF -- "$2" "$1"; then bad "$3 (unexpected in $1: $2)"; else pass "$3"; fi
+}
+assert_file()     { if [ -e "$1" ]; then pass "$2"; else bad "$2 (missing: $1)"; fi; }
+assert_no_file()  { if [ -e "$1" ]; then bad "$2 (unexpected file: $1)"; else pass "$2"; fi; }
+assert_eq()       { if [ "$1" = "$2" ]; then pass "$3"; else bad "$3 (expected '$2', got '$1')"; fi; }
+
+TMPROOT="$(mktemp -d)"
+BIN="${TMPROOT}/bin"; mkdir -p "${BIN}"
+FAKE_HOME="${TMPROOT}/home"; mkdir -p "${FAKE_HOME}/.config/alissa"
+WORKSPACE="${TMPROOT}/workspace"; mkdir -p "${WORKSPACE}"
+SPY="${TMPROOT}/spy"; mkdir -p "${SPY}"
+cp "${HERE}/agents.yaml" "${FAKE_HOME}/.config/alissa/agents.yaml"
+cleanup() {
+  chmod -R u+rwX "${TMPROOT}" 2>/dev/null || true
+  rm -rf "${TMPROOT}"
+}
+trap cleanup EXIT
+
+cat > "${BIN}/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  "api user -q .login") echo alissa-app ;;
+esac
+exit 0
+STUB
+
+# The alissa CLI stub. Every surface the entrypoint touches records that it was
+# reached, so a test can assert what the role did AND what it never did.
+# `bridge start` records its full argv and then blocks like the real daemon,
+# because the entrypoint `exec`s it and never comes back.
+cat > "${BIN}/alissa" <<'STUB'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "auth login")
+    echo "Authenticated."
+    exit 0
+    ;;
+  "worker start")
+    echo "start" >> "${SPY_DIR}/worker-start"
+    exit 0
+    ;;
+  "worker status")
+    echo "worker is running"
+    exit 0
+    ;;
+  "code workspace")
+    echo "sync" >> "${SPY_DIR}/workspace-sync"
+    exit 0
+    ;;
+  "bridge start")
+    shift 2
+    printf '%s\n' "$*" > "${SPY_DIR}/bridge-argv"
+    trap 'exit 0' TERM INT
+    sleep 600 &
+    wait $!
+    exit 0
+    ;;
+esac
+exit 0
+STUB
+
+# The review daemon. It must never be reached in the executor role — the spy
+# file is the assertion, not the sleep.
+cat > "${BIN}/alissa-revloop" <<'STUB'
+#!/usr/bin/env bash
+echo "start" >> "${SPY_DIR}/revloop-start"
+trap 'exit 0' TERM INT
+sleep 600 &
+wait $!
+STUB
+
+# The API reachability probe. Always up: this suite is about the role, and the
+# transport classes have their own suite (tests-entrypoint-auth.sh).
+cat > "${BIN}/curl" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod 0755 "${BIN}/gh" "${BIN}/alissa" "${BIN}/alissa-revloop" "${BIN}/curl"
+
+reset_spies() {
+  rm -f "${SPY}"/bridge-argv "${SPY}"/worker-start "${SPY}"/revloop-start \
+        "${SPY}"/workspace-sync
+  rm -rf "${WORKSPACE:?}"/* "${WORKSPACE:?}"/.alissa-config
+}
+
+BOOT_PID=""
+BOOT_STATUS=0
+start_boot() {
+  local log="$1"; shift
+  env -i \
+    PATH="${BIN}:/usr/local/bin:/usr/bin:/bin" \
+    HOME="${FAKE_HOME}" \
+    TMUX_TMPDIR="${TMPROOT}/tmux" \
+    ALISSA_WORKSPACE_ROOT="${WORKSPACE}" \
+    GH_TOKEN=dev-default-token \
+    ALISSA_API_TOKEN=stub-alissa-token \
+    ALISSA_REVIEW_REPOS="fahera-mx/example-repo" \
+    SPY_DIR="${SPY}" \
+    ALISSA_AUTH_RETRY_SECONDS=1 \
+    ALISSA_AUTH_RETRY_CAP_SECONDS=4 \
+    "$@" \
+    bash "${ENTRYPOINT}" > "${log}" 2>&1 &
+  BOOT_PID=$!
+}
+
+# wait_boot <logfile> <max seconds> <marker> — until the marker appears in the
+# log (the role's "I am up" milestone) or the boot dies. Then stop it.
+wait_boot() {
+  local log="$1" limit="$2" marker="$3" i
+  BOOT_STATUS=0
+  for i in $(seq 1 "${limit}"); do
+    grep -qF "${marker}" "${log}" && break
+    kill -0 "${BOOT_PID}" 2>/dev/null || break
+    sleep 1
+  done
+  if kill -0 "${BOOT_PID}" 2>/dev/null; then
+    kill -TERM "${BOOT_PID}" 2>/dev/null || true
+    # The executor role `exec`s the CLI, so SIGTERM reaches the stub directly.
+    BOOT_STATUS=0
+  fi
+  wait "${BOOT_PID}" 2>/dev/null || BOOT_STATUS=$?
+}
+
+EXECUTOR_UP="starting alissa bridge start"
+DAEMON_UP="alissa worker is running"
+
+# -----------------------------------------------------------------------------
+info "1. role=executor with the gate OFF (default) -> refuses, starts nothing"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG1="${TMPROOT}/gate-off.log"
+start_boot "${LOG1}" CONTAINER_ROLE=executor
+wait_boot "${LOG1}" 20 "${EXECUTOR_UP}"
+
+if [ "${BOOT_STATUS}" != "0" ]; then
+  pass "the boot exits non-zero"
+else
+  bad "an unarmed executor should not have kept running"
+fi
+assert_contains "${LOG1}" "ALISSA_BRIDGE_EXECUTOR=0 (default off)" \
+  "the refusal names the gate and says it defaults off"
+assert_contains "${LOG1}" "refusing to register an executor or claim any job" \
+  "...and says what it refused to do"
+assert_no_file "${SPY}/bridge-argv" "alissa bridge start is NEVER invoked"
+assert_no_file "${SPY}/worker-start" "and neither is the worker"
+assert_no_file "${SPY}/revloop-start" "and neither is the review daemon"
+
+# -----------------------------------------------------------------------------
+info ""
+info "2. role=executor, gate ON -> execs the bridge, and only the bridge"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG2="${TMPROOT}/executor.log"
+start_boot "${LOG2}" CONTAINER_ROLE=executor ALISSA_BRIDGE_EXECUTOR=1
+wait_boot "${LOG2}" 30 "${EXECUTOR_UP}"
+
+assert_file "${SPY}/bridge-argv" "alissa bridge start is invoked"
+ARGV="$(cat "${SPY}/bridge-argv" 2>/dev/null || true)"
+assert_contains "${SPY}/bridge-argv" "--executor-id revloop-executor" \
+  "the executor id defaults to revloop-executor (distinct from the devloop's)"
+assert_contains "${SPY}/bridge-argv" "--workspace-root ${WORKSPACE}" \
+  "it serves the container's workspace root"
+assert_contains "${SPY}/bridge-argv" "--handoff claude" \
+  "the handoff is pinned to the profile the image bakes"
+case "${ARGV}" in
+  *--label*|*--max-concurrent*|*--interval*)
+    bad "unset knobs must be OMITTED so the CLI default applies (got: ${ARGV})" ;;
+  *) pass "unset label/concurrency/interval are omitted (CLI default applies)" ;;
+esac
+
+# The process-chain property, which is the whole reason this is a second service.
+assert_no_file "${SPY}/worker-start" "the alissa worker is NOT started in the executor role"
+assert_no_file "${SPY}/revloop-start" "the review daemon is NOT started in the executor role"
+assert_contains "${LOG2}" "reviewer console not applicable in the executor role" \
+  "and neither is the console"
+
+# Bootstrap reuse: the manifest and the hubs, but no daemon config.
+assert_file "${WORKSPACE}/alissa-workspace.yaml" "the workspace manifest is generated"
+assert_file "${SPY}/workspace-sync" "the worktree hubs are synced, as in the daemon role"
+assert_no_file "${WORKSPACE}/revloop.config.json" \
+  "revloop.config.json is NOT written (there is no daemon here to read it)"
+assert_contains "${LOG2}" "executor role: no revloop.config.json" \
+  "...and the log says so"
+
+# Identity + agent profile on the persisted volume.
+assert_contains "${LOG2}" "identity file ${WORKSPACE}/.alissa-config/bridge-executor.json" \
+  "the executor identity file is placed on the volume"
+assert_file "${WORKSPACE}/.alissa-config/agents.yaml" \
+  "the resolved agents.yaml is copied to the executor's config dir"
+assert_contains "${WORKSPACE}/.alissa-config/agents.yaml" "--model opus" \
+  "...with the model pin applied, exactly as the daemon role gets it"
+assert_not_contains "${WORKSPACE}/.alissa-config/agents.yaml" "disable_alissa_code" \
+  "...and WITHOUT disable_alissa_code, so job sessions still launch via alissa code"
+
+# -----------------------------------------------------------------------------
+info ""
+info "3. the executor id is required and validated"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG3A="${TMPROOT}/id-empty.log"
+start_boot "${LOG3A}" CONTAINER_ROLE=executor ALISSA_BRIDGE_EXECUTOR=1 \
+                      ALISSA_BRIDGE_EXECUTOR_ID=
+wait_boot "${LOG3A}" 20 "${EXECUTOR_UP}"
+[ "${BOOT_STATUS}" != "0" ] && pass "an EMPTY executor id is fatal" \
+  || bad "an empty executor id should not have booted"
+assert_contains "${LOG3A}" "an executor id is required" "the reason says it is required"
+assert_contains "${LOG3A}" "takes the other one over" \
+  "...and why a shared id is the hazard"
+assert_no_file "${SPY}/bridge-argv" "nothing registers"
+
+reset_spies
+LOG3B="${TMPROOT}/id-bad.log"
+start_boot "${LOG3B}" CONTAINER_ROLE=executor ALISSA_BRIDGE_EXECUTOR=1 \
+                      ALISSA_BRIDGE_EXECUTOR_ID="Revloop Executor"
+wait_boot "${LOG3B}" 20 "${EXECUTOR_UP}"
+[ "${BOOT_STATUS}" != "0" ] && pass "a malformed executor id is fatal at BOOT" \
+  || bad "a malformed executor id should not have booted"
+assert_contains "${LOG3B}" "is not a valid executor id" "the reason names the slug shape"
+assert_no_file "${SPY}/bridge-argv" "nothing registers"
+
+# -----------------------------------------------------------------------------
+info ""
+info "4. the pass-through knobs reach the CLI when they are set"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG4="${TMPROOT}/knobs.log"
+start_boot "${LOG4}" CONTAINER_ROLE=executor ALISSA_BRIDGE_EXECUTOR=1 \
+                     ALISSA_BRIDGE_EXECUTOR_ID=revloop-executor-2 \
+                     ALISSA_BRIDGE_LABEL="Revloop executor (staging)" \
+                     ALISSA_BRIDGE_MAX_CONCURRENT=3 \
+                     ALISSA_BRIDGE_POLL_SECONDS=45 \
+                     ALISSA_BRIDGE_HANDOFF=claude
+wait_boot "${LOG4}" 30 "${EXECUTOR_UP}"
+assert_contains "${SPY}/bridge-argv" "--executor-id revloop-executor-2" "a custom id wins"
+assert_contains "${SPY}/bridge-argv" "--label Revloop executor (staging)" \
+  "the Studio label is passed through"
+assert_contains "${SPY}/bridge-argv" "--max-concurrent 3" "the concurrency cap is passed through"
+assert_contains "${SPY}/bridge-argv" "--interval 45" \
+  "ALISSA_BRIDGE_POLL_SECONDS maps to the CLI's --interval"
+
+# -----------------------------------------------------------------------------
+info ""
+info "5. the daemon role is unaffected, even with the bridge env set"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG5="${TMPROOT}/daemon.log"
+start_boot "${LOG5}" ALISSA_BRIDGE_EXECUTOR=1 ALISSA_BRIDGE_EXECUTOR_ID=revloop-executor
+wait_boot "${LOG5}" 30 "${DAEMON_UP}"
+assert_contains "${LOG5}" "role: daemon (review loop)" "the default role is the daemon"
+assert_no_file "${SPY}/bridge-argv" \
+  "the gate alone never starts an executor — the ROLE selects it"
+assert_file "${SPY}/worker-start" "the worker still starts"
+assert_file "${WORKSPACE}/revloop.config.json" "and revloop.config.json is still written"
+assert_contains "${LOG5}" "starting alissa-revloop" "the daemon still runs"
+
+# -----------------------------------------------------------------------------
+info ""
+info "6. an unknown role is refused, naming the two the image ships"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG6="${TMPROOT}/role-unknown.log"
+start_boot "${LOG6}" CONTAINER_ROLE=sidecar
+wait_boot "${LOG6}" 20 "${DAEMON_UP}"
+[ "${BOOT_STATUS}" != "0" ] && pass "an unknown role is fatal" \
+  || bad "an unknown role should not have booted"
+assert_contains "${LOG6}" "is not a role this image ships" "the reason is explicit"
+assert_no_file "${SPY}/worker-start" "and nothing is started meanwhile"
+
+# -----------------------------------------------------------------------------
+info ""
+info "7. volume unwritable -> capped backoff, no crash loop, heals mid-flight"
+# -----------------------------------------------------------------------------
+# The executor's identity lives in ALISSA_CONFIG_DIR, so an unavailable volume
+# is exactly the auth preflight's "config dir unwritable" class: log and retry
+# forever (2026-07-29 lesson), never exit and let the platform restart-loop.
+reset_spies
+LOG7="${TMPROOT}/volume.log"
+UNWRITABLE="${TMPROOT}/novolume"
+mkdir -p "${UNWRITABLE}"
+chmod 0555 "${UNWRITABLE}"
+start_boot "${LOG7}" CONTAINER_ROLE=executor ALISSA_BRIDGE_EXECUTOR=1 \
+                     ALISSA_CONFIG_DIR="${UNWRITABLE}/alissa"
+for _ in $(seq 1 20); do
+  [ "$(grep -c 'is not writable' "${LOG7}" 2>/dev/null || true)" -ge 2 ] && break
+  kill -0 "${BOOT_PID}" 2>/dev/null || break
+  sleep 1
+done
+assert_contains "${LOG7}" "is not writable" "an unavailable volume is diagnosed as such"
+assert_not_contains "${LOG7}" "FATAL" "it does NOT crash-loop the service"
+assert_contains "${LOG7}" "retrying alissa auth" "it backs off and retries instead"
+assert_no_file "${SPY}/bridge-argv" "and no executor registers while the volume is gone"
+chmod 0755 "${UNWRITABLE}"
+wait_boot "${LOG7}" 30 "${EXECUTOR_UP}"
+assert_file "${SPY}/bridge-argv" "restoring the volume is enough — it proceeds, no restart"
+assert_contains "${LOG7}" "identity file ${UNWRITABLE}/alissa/bridge-executor.json" \
+  "an explicit ALISSA_CONFIG_DIR is honoured for the identity file"
+
+# -----------------------------------------------------------------------------
+info ""
+info "8. CLAUDE_CONFIG_DIR off the volume -> warns, still boots"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG8="${TMPROOT}/claudecfg.log"
+start_boot "${LOG8}" CONTAINER_ROLE=executor ALISSA_BRIDGE_EXECUTOR=1 \
+                     CLAUDE_CONFIG_DIR="${FAKE_HOME}/.claude"
+wait_boot "${LOG8}" 30 "${EXECUTOR_UP}"
+assert_contains "${LOG8}" "is not under ${WORKSPACE}" \
+  "a claude config dir off the volume is called out"
+assert_file "${SPY}/bridge-argv" "...but it is a WARNing, not a refusal"
+
+reset_spies
+LOG8B="${TMPROOT}/claudecfg-ok.log"
+start_boot "${LOG8B}" CONTAINER_ROLE=executor ALISSA_BRIDGE_EXECUTOR=1 \
+                      CLAUDE_CONFIG_DIR="${WORKSPACE}/.claude-config"
+wait_boot "${LOG8B}" 30 "${EXECUTOR_UP}"
+assert_contains "${LOG8B}" "claude config persisted on the volume" \
+  "the image's own CLAUDE_CONFIG_DIR (under the volume) is confirmed, not assumed"
+
+# -----------------------------------------------------------------------------
+info ""
+info "9. the firewall allowlist really does admit what a job session needs"
+# -----------------------------------------------------------------------------
+# Asserted against the shipped list itself: init-firewall.sh is sourceable, so
+# this reads the same array the root bootstrap resolves — no root, no NET_ADMIN,
+# and no second copy of the list to drift.
+# shellcheck source=init-firewall.sh
+DOMAINS="$(bash -c '. "'"${HERE}"'/init-firewall.sh"; firewall_domains')"
+for host in api.alissa.app api.anthropic.com github.com api.github.com \
+            share.alissa.app skills.alissa.app; do
+  if printf '%s\n' "${DOMAINS}" | grep -qx "${host}"; then
+    pass "the egress allowlist admits ${host}"
+  else
+    bad "a queue job session needs ${host}, and the firewall allowlist omits it"
+  fi
+done
+EXTRA_OUT="$(ALISSA_FIREWALL_EXTRA="ghe.internal" \
+  bash -c '. "'"${HERE}"'/init-firewall.sh"; firewall_domains' | tail -n 1)"
+assert_eq "${EXTRA_OUT}" "ghe.internal" "ALISSA_FIREWALL_EXTRA still extends the list"
+
+echo
+if [ "${fail}" = "0" ]; then
+  echo "entrypoint executor-role tests: PASS"
+else
+  echo "entrypoint executor-role tests: FAIL" >&2
+fi
+exit "${fail}"

--- a/docker/claude/tests-entrypoint-executor.sh
+++ b/docker/claude/tests-entrypoint-executor.sh
@@ -22,8 +22,12 @@
 #                                            appear when they are set
 #   5. daemon role, bridge env set        -> still the daemon; bridge never runs
 #   6. unknown CONTAINER_ROLE             -> dies naming the two it ships
+#   4b. the id length bound              -> matches the CLI's own 64, so a long
+#                                            id is refused at boot, not later
 #   7. volume unwritable                  -> capped backoff, NOT a crash loop,
 #                                            and it self-heals mid-flight
+#   7b. a stale executor lock             -> swept, so persisting the config dir
+#                                            cannot wedge the next boot
 #   8. CLAUDE_CONFIG_DIR off the volume   -> WARNs, still boots
 #   9. firewall + agents.yaml             -> the allowlist really does admit what
 #                                            a job session needs; the profile
@@ -97,7 +101,28 @@ case "$1 $2" in
     ;;
   "bridge start")
     shift 2
+    # Model the CLI's own single-daemon lock, because the entrypoint's stale-lock
+    # sweep is only meaningful against it. Faithful to `acquireExecutorLock` /
+    # `runningExecutorPid`: the lock is ${ALISSA_CONFIG_DIR}/bridge/executor-<id>.lock
+    # holding a pid, and staleness is decided by a bare liveness check with no
+    # boot id and no start time — so a leftover file whose pid happens to be live
+    # in the new namespace refuses the start and exits non-zero.
+    eid="revloop-executor"
+    prev=""
+    for arg in "$@"; do
+      [ "${prev}" = "--executor-id" ] && eid="${arg}"
+      prev="${arg}"
+    done
+    lock="${ALISSA_CONFIG_DIR:-${HOME}/.config/alissa}/bridge/executor-${eid}.lock"
+    if [ -f "${lock}" ] && kill -0 "$(cat "${lock}" 2>/dev/null)" 2>/dev/null; then
+      echo "A bridge executor \"${eid}\" is already running on this machine (pid $(cat "${lock}"))." >&2
+      exit 1
+    fi
+    mkdir -p "$(dirname "${lock}")"
+    printf '%s\n' "$$" > "${lock}"
     printf '%s\n' "$*" > "${SPY_DIR}/bridge-argv"
+    # Deliberately NO lock cleanup on the way out: an ungraceful stop is exactly
+    # the condition the sweep exists for.
     trap 'exit 0' TERM INT
     sleep 600 &
     wait $!
@@ -129,10 +154,15 @@ reset_spies() {
   rm -f "${SPY}"/bridge-argv "${SPY}"/worker-start "${SPY}"/revloop-start \
         "${SPY}"/workspace-sync
   rm -rf "${WORKSPACE:?}"/* "${WORKSPACE:?}"/.alissa-config
+  BOOT_ARGS=()
 }
 
 BOOT_PID=""
 BOOT_STATUS=0
+# Extra CMD args handed to the entrypoint itself (not env assignments) — the
+# `docker run … --once` path. Reset by reset_spies; `${…[@]+…}` so an empty
+# array is safe under `set -u`.
+BOOT_ARGS=()
 start_boot() {
   local log="$1"; shift
   env -i \
@@ -147,7 +177,7 @@ start_boot() {
     ALISSA_AUTH_RETRY_SECONDS=1 \
     ALISSA_AUTH_RETRY_CAP_SECONDS=4 \
     "$@" \
-    bash "${ENTRYPOINT}" > "${log}" 2>&1 &
+    bash "${ENTRYPOINT}" ${BOOT_ARGS[@]+"${BOOT_ARGS[@]}"} > "${log}" 2>&1 &
   BOOT_PID=$!
 }
 
@@ -286,6 +316,44 @@ assert_contains "${SPY}/bridge-argv" "--max-concurrent 3" "the concurrency cap i
 assert_contains "${SPY}/bridge-argv" "--interval 45" \
   "ALISSA_BRIDGE_POLL_SECONDS maps to the CLI's --interval"
 
+# Extra CMD args, which the README promotes as the one-poll smoke test
+# (`docker run … --once`). Without the trailing "$@" on the exec line every
+# assertion above still passes, so this is what pins it — position included,
+# since a flag ahead of the structural ones would be a different command.
+reset_spies
+BOOT_ARGS=( --once )
+LOG4B="${TMPROOT}/cmd-args.log"
+start_boot "${LOG4B}" CONTAINER_ROLE=executor ALISSA_BRIDGE_EXECUTOR=1
+wait_boot "${LOG4B}" 30 "${EXECUTOR_UP}"
+assert_contains "${SPY}/bridge-argv" "--once" "extra CMD args reach alissa bridge start"
+case "$(cat "${SPY}/bridge-argv" 2>/dev/null || true)" in
+  *"--handoff claude --once") pass "...after the structural flags, not ahead of them" ;;
+  *) bad "extra args must come LAST (got: $(cat "${SPY}/bridge-argv" 2>/dev/null || true))" ;;
+esac
+
+info ""
+info "4b. the executor id boundary matches the CLI's own (64 characters)"
+# The CLI's EXECUTOR_ID_RE caps the id at 64. An unbounded boot check would let a
+# 65-character id through and kill it INSIDE `alissa bridge start`, after the
+# whole bootstrap — the register-time failure this gate exists to prevent.
+ID64="$(printf 'a%.0s' $(seq 1 64))"
+ID65="$(printf 'a%.0s' $(seq 1 65))"
+reset_spies
+LOG4C="${TMPROOT}/id-64.log"
+start_boot "${LOG4C}" CONTAINER_ROLE=executor ALISSA_BRIDGE_EXECUTOR=1 \
+                      ALISSA_BRIDGE_EXECUTOR_ID="${ID64}"
+wait_boot "${LOG4C}" 30 "${EXECUTOR_UP}"
+assert_contains "${SPY}/bridge-argv" "--executor-id ${ID64}" \
+  "a 64-character id is accepted (the CLI's own bound)"
+reset_spies
+LOG4D="${TMPROOT}/id-65.log"
+start_boot "${LOG4D}" CONTAINER_ROLE=executor ALISSA_BRIDGE_EXECUTOR=1 \
+                      ALISSA_BRIDGE_EXECUTOR_ID="${ID65}"
+wait_boot "${LOG4D}" 20 "${EXECUTOR_UP}"
+[ "${BOOT_STATUS}" != "0" ] && pass "a 65-character id is refused at BOOT, not at register time" \
+  || bad "a 65-character id should not have booted"
+assert_no_file "${SPY}/bridge-argv" "...so the bootstrap never runs for it"
+
 # -----------------------------------------------------------------------------
 info ""
 info "5. the daemon role is unaffected, even with the bridge env set"
@@ -342,6 +410,36 @@ wait_boot "${LOG7}" 30 "${EXECUTOR_UP}"
 assert_file "${SPY}/bridge-argv" "restoring the volume is enough — it proceeds, no restart"
 assert_contains "${LOG7}" "identity file ${UNWRITABLE}/alissa/bridge-executor.json" \
   "an explicit ALISSA_CONFIG_DIR is honoured for the identity file"
+
+# -----------------------------------------------------------------------------
+info ""
+info "7b. a stale executor lock on the volume does not wedge the next boot"
+# -----------------------------------------------------------------------------
+# Persisting ALISSA_CONFIG_DIR also persists the CLI's executor lockfile, and the
+# CLI decides that lock is stale with a bare `kill(pid, 0)` — no boot id, no
+# start time. A container that died ungracefully leaves the file behind, and the
+# next boot's fresh PID namespace can make that dead PID look alive, so the CLI
+# refuses to start and the platform restart-loops it.
+#
+# The lock is planted with a PID that is definitely LIVE (this test's own), which
+# is the case the CLI would reject — so this fails if the sweep is removed,
+# rather than passing beside it.
+reset_spies
+LOG7B="${TMPROOT}/stale-lock.log"
+LOCK_DIR="${WORKSPACE}/.alissa-config/bridge"
+mkdir -p "${LOCK_DIR}"
+printf '%s\n' "$$" > "${LOCK_DIR}/executor-revloop-executor.lock"
+# A second executor's lock, which this container does not own.
+printf '%s\n' "$$" > "${LOCK_DIR}/executor-someone-else.lock"
+start_boot "${LOG7B}" CONTAINER_ROLE=executor ALISSA_BRIDGE_EXECUTOR=1
+wait_boot "${LOG7B}" 30 "${EXECUTOR_UP}"
+assert_file "${SPY}/bridge-argv" \
+  "a stale lock holding a LIVE pid does not stop the boot"
+assert_not_contains "${LOG7B}" "is already running on this machine" \
+  "...and the CLI never refuses to start (the crash-loop condition)"
+assert_eq "${BOOT_STATUS}" "0" "...with a live container, not a non-zero exit"
+assert_file "${LOCK_DIR}/executor-someone-else.lock" \
+  "...and another id's lock is left alone (never a blanket executor-*.lock glob)"
 
 # -----------------------------------------------------------------------------
 info ""


### PR DESCRIPTION
Closes #73

`CONTAINER_ROLE=executor` boots this same image as an Alissa Studio queue
executor (`alissa bridge start`) instead of the review daemon — deployed as a
**second service**, never as a sidecar of the first.

The split is enforced by construction rather than by convention: the executor
role `exec`s the CLI, so the container's only process is the executor (no
`alissa worker`, no console, no `alissa-revloop`), and the daemon role never
starts a bridge however the `ALISSA_BRIDGE_*` env is set. Both directions are
asserted in the new suite.

**What landed**

* **Role switch + gates**, resolved before any bootstrap so a deploy mistake
  fails at the top of the log. `ALISSA_BRIDGE_EXECUTOR` defaults **off** and
  refuses cleanly; `ALISSA_BRIDGE_EXECUTOR_ID` is required, defaults to
  `revloop-executor` (distinct from the devloop's — identity is
  `(userId, executorId)` and registration *takes over*, so a shared id means two
  services evicting each other) and is slug-validated at boot rather than at
  register time. `--handoff` is pinned structurally to `claude`; label /
  concurrency / interval are pass-through, on this repo's usual
  env-&gt;CLI-default contract.
* **Identity persistence.** `ALISSA_CONFIG_DIR` defaults onto the volume in this
  role, so `bridge-executor.json` (id + fingerprint) survives a redeploy instead
  of re-registering as a changed machine. That choice also makes an unavailable
  volume land in the `alissa auth login` preflight's existing "config dir
  unwritable" class — capped backoff forever, never a crash loop.
  `CLAUDE_CONFIG_DIR` is verified under the workspace root, warn-only.
* **Bootstrap reuse.** Same manifest generation, same claude first-run seeding,
  same `alissa code workspace sync`. Only `revloop.config.json` and the spawn
  ledger reset are skipped — both belong to a daemon this service never starts.
* **`agents.yaml`** keeps routing through `alissa code` (no
  `disable_alissa_code`), and the resolved file — model pin included — is copied
  into the executor's config dir on every boot, so the image stays the source of
  truth for the profile.
* **Firewall verified, not assumed.** The existing allowlist already admits
  everything a job session needs; `init-firewall.sh` is now sourceable so the
  test asserts that membership against the shipped list instead of a second copy.
* **Docs.** `docker/claude/README.md` gains a "Bridge executor role" section with
  the sidecar decision and its rationale, the deploy recipe, the env table, the
  exposed-env security note, and the persistence/degradation contract.

No dist files were touched, so no version bump (the guard's own scope note
exempts `docker/`, `README.md` and `.github/`).

## Delivery notes

**Judgment calls**

* Role switch lives **inside** `entrypoint.sh` rather than a sibling
  `entrypoint-executor.sh` (the issue left this to the implementer). Steps 0–3
  are shared verbatim — privilege drop, auth triage, model pin, manifest, hub
  sync — and a sibling script would have duplicated ~250 lines of hard-won
  crash-resilience logic that then drifts.
* Two knobs to arm, not one (`CONTAINER_ROLE=executor` **and**
  `ALISSA_BRIDGE_EXECUTOR=1`), because the issue specifies both. The role
  selects; the gate consents. A service with only the gate set stays the daemon.
* "Refuses cleanly" is implemented as `die` (non-zero exit + a message naming the
  remedy), matching this entrypoint's existing posture for misconfiguration (the
  console passcode gate). It is not exit 0.
* `ALISSA_BRIDGE_POLL_SECONDS` maps to the CLI's `-i/--interval`; there is no
  `--poll-seconds` flag. The env name from the issue is kept and the mapping is
  documented in the entrypoint and the README.
* Persisting the identity was done by relocating the **whole** `ALISSA_CONFIG_DIR`
  onto the volume, not by symlinking `bridge-executor.json`. A symlink write
  failure would throw inside `alissa bridge start` (that write is not guarded);
  relocating the dir puts volume failure in the entrypoint's existing retry class
  instead. The cost is that `agents.yaml` must be copied across (step 2e-ii) —
  **and, as round 1 found, that the CLI's executor lockfile and the stored API
  token come along too.** The lock is now swept before `exec` (a fresh container
  has no executor running, so a lock found there is stale by construction) and
  the token at rest is documented. See the round-1 note below.
* No build ARGs for any bridge knob — they are runtime-only, like the console
  knobs. Baking `CONTAINER_ROLE` would make the artifact role-specific, and an
  ARG default for the arming gate is a value every deploy inherits. Rationale is
  in the Dockerfile next to the console's equivalent note.
* Label is pass-through (omitted when unset) rather than defaulted to something
  friendlier. That follows the repo's "no hidden entrypoint layer" precedence
  contract; the consequence is that Studio shows the container hostname unless
  `ALISSA_BRIDGE_LABEL` is set, and the README says so.
* `ALISSA_REVIEW_SKILLS` is reused unchanged for the executor's manifest (it
  still installs the review skills into the workspace). The issue asked for the
  bootstrap "exactly as the daemon does", so no new skills knob was invented.

**Not verified — operator's gate**

- [ ] **No container was built or run.** There is no docker in this environment;
      every entrypoint assertion comes from booting the real `entrypoint.sh`
      with stubbed CLIs, which is this repo's established precedent. The image
      layers themselves are unexercised.
- [ ] **`alissa bridge start` was never executed.** Its flag set was read off the
      installed CLI (`alissa bridge start --help` and the option registration in
      `cli.mjs`), and the entrypoint's argv is asserted against a stub. Nothing
      registered a real `bridgeExecutors` row, claimed a job, or ran one.
      (A `--help` probe does **not** validate flags — commander short-circuits
      before parsing — so the help listing is the evidence, not an exit code.)
- [ ] **Identity persistence across a real restart is unproven.** The tests
      assert the identity path lands on the volume and that the config dir is
      honoured; they do not restart a container and confirm the CLI re-registers
      without a takeover or a fingerprint change.
- [ ] **The firewall was never raised.** `init-firewall.sh` needs root and
      `NET_ADMIN`. The test asserts the allowlist's *contents*; it does not
      confirm a job session actually reaches those hosts through live iptables
      rules. Worth one `ALISSA_ENABLE_FIREWALL=1` smoke run on the first deploy.
- [ ] **Executor-id collision with the devloop's executor** is documented and
      defaulted apart, not detected. Nothing at boot can see the other service's
      id; if an operator sets them equal, the takeover loop is what will surface
      it.
- [ ] **The `ALISSA_CONFIG_DIR` relocation moves the stored API token onto the
      volume** (`config.json`). Now stated in the operator docs too, not only
      here. It is a real change in where a secret rests, and accepting it is the
      operator's call — nothing about the executor needs the token persisted; it
      is the price of persisting the identity file beside it.
- [ ] **tmux env inheritance for job sessions** was reasoned about, not measured:
      `agents.yaml` is written to *both* the baked home and the relocated config
      dir so the profile resolves either way, rather than proving which one a
      spawned session reads.

**Verification**

* `bash docker/claude/tests-entrypoint-executor.sh` — **PASS** (new suite, 11
  cases / 66 assertions: both roles, gate refusal, empty + malformed + over-long
  id, pass-through knobs, extra-CMD-args, unwritable volume with mid-flight heal,
  stale executor lock, `CLAUDE_CONFIG_DIR` on and off the volume, firewall
  allowlist membership).
* **Counterfactual on the round-1 `[major]`**: with the stale-lock sweep line
  deleted and nothing else changed, case 7b fails three ways — the boot exits 1,
  the log carries the CLI's `is already running on this machine`, and
  `bridge-argv` is never written. Restored, it passes. The `alissa` stub models
  the CLI's own `acquireExecutorLock` / `runningExecutorPid` so that case
  exercises the real refusal rather than a stand-in.
* `bash docker/claude/tests-entrypoint-config.sh` — **PASS** (incl. the live
  library-default cross-check against the pinned 0.16.14).
* `bash docker/claude/tests-entrypoint-identity.sh` — **PASS**.
* `bash docker/claude/tests-entrypoint-auth.sh` — **PASS**.
* `bash docker/claude/tests-entrypoint-ui.sh` — **PASS** (against the real
  installed sidecar).
* `bash check-style.sh alissa-tools-github-revloop` — **PASS**.
* `bash check-types.sh alissa-tools-github-revloop` — **PASS** (29 files).
* `bash tests-unit.sh alissa-tools-github-revloop` — **659 passed, 1 failed**.
  The failure is `test_webui_sysinfo.py::test_read_stat_basic`, which parses this
  machine's `/proc`; it fails identically on an untouched checkout of this repo
  and no Python file is in this diff. Pre-existing and environmental, not
  introduced here — but flagging it rather than calling the run green.
* `bash -n` on every modified shell file; `.github/workflows/check-entrypoint.yaml`
  parsed with pyyaml and its step list confirmed.
* `firewall_domains` sourced and its output diffed against the previous inline
  array, including the `ALISSA_FIREWALL_EXTRA` extension path.

**Scope touched**

Declared scope was `docker/claude/*, README.md`.

* `docker/claude/entrypoint.sh` — role switch, gates, identity/config-dir
  placement, executor `exec` point, daemon-only guards.
* `docker/claude/init-firewall.sh` — allowlist extracted into a sourceable
  `firewall_domains`, body moved into `init_firewall` behind the
  direct-execution guard this repo already uses in `revloop-config.sh`.
  Behaviour is unchanged; the refactor exists so the allowlist can be asserted.
* `docker/claude/tests-entrypoint-executor.sh` — new.
* `docker/claude/Dockerfile` — comments only (the two-role note and the
  "deliberately not an ARG" rationale). No layer, pin or ENV changed.
* `docker/claude/README.md` — the new section plus the entrypoint-steps list.
* `README.md` — pointer to the new role, and the entrypoint-suite list corrected
  (it claimed "two shell suites"; there were four before this PR, five now).
* **Excursion:** `.github/workflows/check-entrypoint.yaml` — outside the declared
  scope. Adding the suite without wiring it into CI would ship a test nothing
  runs; it is one step plus a comment, and no other workflow was touched.

### Round 1 (request_changes) — what changed

All five inline findings and both body-level findings triaged `[pursue]`; replies
are on their threads and in
[this comment](https://github.com/fahera-mx/alissa-github-review-daemon/pull/76#issuecomment-5236566907).

* **[major] stale executor lock.** Real, and mine. Persisting `ALISSA_CONFIG_DIR`
  also persisted the CLI's `bridge/executor-<id>.lock`, whose staleness is decided
  by a bare `kill(pid, 0)` — no boot id, no start time. On a volume that survives
  an ungraceful stop, the next boot's fresh PID namespace can make the recorded
  PID look live, the CLI refuses to start, and the platform restart-loops it.
  Swept just before `exec`, scoped to this executor's id (an `executor-*.lock`
  glob would delete a live peer's lock if a config dir were ever shared, while a
  stale lock under another id is never consulted for ours).
* **[minor]** the boot-time id check now carries the CLI's 64-character bound;
  **[minor]** the API token at rest on the volume is documented for operators;
  **[nit]** README step label `3b`→`3d`; **[nit]** the extra-CMD-args
  pass-through the README promotes as the smoke test is now covered by a test.
* **[minor] commit trailers** — the base commit was amended rather than topped
  with a trailer-only commit (a trailer describes the commit it sits on), so this
  round is a force-push: `24c2aa6` → `770744e` + `691c191`.
* **[nit] `is_truthy` vs `ALISSA_ENABLE_FIREWALL`** — comment softened rather than
  the gate widened, with the underlying footgun registered as **TASK-112733143**
  (`committed`, soft-linked to TASK-479723890). Folding that gate in would make a
  deploy that today sets `true` — and therefore never needed `--cap-add=NET_ADMIN`
  — start attempting the firewall init and die on it, turning a silently-degraded
  container into a crash-looping one. That wants a deliberate rollout, not a
  drive-by inside a fix round. Happy to be overruled and do it here.

### Round 2 (approve) — one deferred nit

Approved. One new `[nit]`: in `tests-entrypoint-executor.sh`'s header case map the
`4b` entry is filed between `6` and `7` while the suite runs it between `4` and
`5`, and its arrow column is one space out. Both true, and my error from the
round-1 fix.

**Deferred, not fixed here — `[triage:later]`, tracked as TASK-2137886541**
(`committed`, soft-linked to TASK-479723890).

The branch carries an approve, so it takes no further commits: an approved branch
is merge-racy and anything pushed after the squash-merge is silently lost. The
normal path — a follow-up PR off `main` — does not work for *this* finding:
`docker/claude/tests-entrypoint-executor.sh` does not exist on `main`, it arrives
with this PR. A branch cut from the default branch could therefore only re-add
the whole file, which add/add-conflicts with this PR whichever merges first, and
basing it on this branch is the stranding hazard that makes "off the default
branch" a rule. Risking a merge conflict on an approved PR to reorder a comment
block is the wrong trade, so the task carries the sequencing constraint instead:
branch off `main` **after** this merges.

Nothing functional is deferred — the suite's execution order was always correct.

Origin task: TASK-34600665
Implementation task: TASK-479723890
