### PR TITLE
TASK-1002979593: guard the boot-time volume chown so warm boots stop charging ~6GB of reclaimable cache (issue #78)

### DIFF
--- a/.github/workflows/check-entrypoint.yaml
+++ b/.github/workflows/check-entrypoint.yaml
@@ -16,7 +16,10 @@ on: [pull_request]
 #     fast FATAL), same way — docker/claude/tests-entrypoint-auth.sh;
 #   * the bridge-executor role (CONTAINER_ROLE / ALISSA_BRIDGE_* gate, executor
 #     identity, and the guarantee that neither role starts the other's
-#     supervisor) — docker/claude/tests-entrypoint-executor.sh.
+#     supervisor) — docker/claude/tests-entrypoint-executor.sh;
+#   * the guarded boot-time chown (warm boot skips the volume walk, a root-owned
+#     probe result or ALISSA_FORCE_CHOWN=1 still runs it) —
+#     docker/claude/tests-entrypoint-chown.sh.
 jobs:
   entrypoint-config-check:
     name: Entrypoint config renderer + console wiring
@@ -81,6 +84,15 @@ jobs:
         # off instead of crash-looping, hence the timeout headroom.
         timeout-minutes: 6
         run: bash docker/claude/tests-entrypoint-executor.sh
+      - name: Execute Entrypoint Guarded-Chown Tests
+        # Boots the entrypoint six times through a FAKE root pass (`id -u`
+        # answers 0 once, `gosu` execs in place) so the root-only step 0 is
+        # exercised without root or docker. `chown`/`find` record instead of
+        # running and `stat` answers scripted ownership, which is what makes
+        # "the probe stayed O(top-level entries)" an assertion rather than a
+        # claim; the last case runs against the real stat and the real tree.
+        timeout-minutes: 4
+        run: bash docker/claude/tests-entrypoint-chown.sh
       - name: Execute Entrypoint Console Wiring Tests
         # Boots the entrypoint four times (console off / enabled-without-passcode
         # / enabled / sidecar killed under it). No docker needed: the CLIs the

--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -297,6 +297,13 @@ ARG ALISSA_WORKER_INTERVAL="2"
 # Optional egress firewall (needs --cap-add=NET_ADMIN at runtime).
 ARG ALISSA_ENABLE_FIREWALL="0"
 ARG ALISSA_FIREWALL_EXTRA=""
+# Force the root phase's full `chown -R` of the volume (issue #78). Default OFF:
+# the entrypoint probes ownership at depth 1 and only walks when it finds
+# something not owned by `alissa`, because the walk charges GBs of reclaimable
+# dentry/inode slab to the container cgroup and a warm boot gains nothing from
+# it. Set this to 1 for ONE boot after a root shell has written files DEEPER in
+# the tree than the probe can see — that is the probe's only blind spot.
+ARG ALISSA_FORCE_CHOWN="0"
 
 ENV ALISSA_REVIEW_REPOS=${ALISSA_REVIEW_REPOS} \
     ALISSA_REVIEW_OPERATORS=${ALISSA_REVIEW_OPERATORS} \
@@ -315,7 +322,8 @@ ENV ALISSA_REVIEW_REPOS=${ALISSA_REVIEW_REPOS} \
     ALISSA_ON_MISSING_HUB=${ALISSA_ON_MISSING_HUB} \
     ALISSA_WORKER_INTERVAL=${ALISSA_WORKER_INTERVAL} \
     ALISSA_ENABLE_FIREWALL=${ALISSA_ENABLE_FIREWALL} \
-    ALISSA_FIREWALL_EXTRA=${ALISSA_FIREWALL_EXTRA}
+    ALISSA_FIREWALL_EXTRA=${ALISSA_FIREWALL_EXTRA} \
+    ALISSA_FORCE_CHOWN=${ALISSA_FORCE_CHOWN}
 
 # The reviewer console (alissa-revloop-ui) listens here when ALISSA_UI_ENABLED is
 # set. EXPOSE is documentation/metadata only — it opens no port by itself; the

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -234,6 +234,7 @@ automatically; locally pass `--build-arg`):
 | `ALISSA_WORKER_INTERVAL` | `2` | worker reconcile tick (seconds) |
 | `ALISSA_ENABLE_FIREWALL` | `0` | `1` raises the egress firewall (needs `--cap-add=NET_ADMIN`) |
 | `ALISSA_FIREWALL_EXTRA` | *(empty)* | extra firewall allowlist hosts, space-separated |
+| `ALISSA_FORCE_CHOWN` | `0` | `1` forces the root phase's full `chown -R` of the volume for that boot. Off by default: the entrypoint probes ownership at depth 1 and walks only when it finds a foreign owner (see [Boot-time ownership](#boot-time-ownership-the-volume-walk-is-guarded)). Set it for **one** boot after a root shell wrote files deeper in the tree |
 
 #### Config precedence: env var > daemon library default
 
@@ -256,6 +257,37 @@ that the baked [`agents.yaml`](./agents.yaml) ships (`claude`), and
 `on_missing_hub` must be `add` for the self-contained hub-ify-on-demand model —
 the library default `skip` would make a fresh volume review nothing. Both are
 still overridable via their env var.
+
+#### Boot-time ownership: the volume walk is guarded
+
+The container starts as root only to make a root-owned volume mount writable
+(see [Persistence](#persistence--mount-the-volume-at-workspace)). That `chown -R`
+used to run on **every** boot, and on a warm volume it is both a no-op and
+expensive: the walk stats every inode of every worktree hub, and the resulting
+dentry/inode slab is charged to the container's cgroup. An audit of the Railway
+service on 2026-08-09 found `memory.current` at **~5.98 GB** against **176 MB**
+of actual process RSS — 3.71 GB of it `slab_reclaimable` from the walk, the rest
+page cache from the hub sync — with zero reviewer sessions running. It is
+reclaimable cache, not a leak (the kernel drops it under real pressure at the
+cgroup limit), but it plateaus flat from the moment of deploy and makes the
+memory graph useless for spotting a real problem.
+
+So step 0 now **probes before it walks**: one `stat` over the mount point and its
+immediate children, and the `chown -R` runs only if something there is not owned
+by `alissa`. The probe is O(top-level entries) by construction — deliberately not
+`find … ! -user alissa`, which stats every inode and would recreate the same slab
+storm. A first boot on a fresh root-owned volume is unaffected: the mount point
+itself is root-owned, so the probe trips and the full walk runs exactly as before.
+
+The blind spot is a root-owned file created **deeper** than depth 1 — realistically,
+a platform console shell running as root. `ALISSA_FORCE_CHOWN=1` is the escape
+hatch: it skips the probe and forces the full walk for that boot. Set it, restart,
+then unset it.
+
+Reclaiming the cache after the fact is not an option on Railway: `/sys/fs/cgroup`
+is mounted read-only inside the container, so writing `memory.reclaim` fails with
+`EROFS` even as root (verified 2026-08-09). Avoidance is the only lever, which is
+why the entrypoint has no reclaim call.
 
 ### Reviewer console (runtime env only — `ALISSA_UI_ENABLED`, `ALISSA_UI_PASSCODE`, `PORT`)
 
@@ -425,6 +457,12 @@ volumes typically mount **root-owned**, so the container starts as root, the
 entrypoint `chown`s the mount to `alissa` (uid 1000), and then drops to that user
 (via `gosu`) for everything else — so a root-owned mount just works, no manual
 `chown` or init container needed. (claude still runs unprivileged, as it must.)
+
+That `chown` is **guarded**: on a warm volume it is skipped, because walking it
+charges GBs of reclaimable kernel cache to the container's memory metric for no
+benefit. See [Boot-time ownership](#boot-time-ownership-the-volume-walk-is-guarded)
+for the numbers and for `ALISSA_FORCE_CHOWN`, the escape hatch to use after a root
+console shell has written into the volume.
 
 ### Optional egress firewall
 
@@ -650,9 +688,12 @@ volumes:
    its gates — the arming flag, the executor id, and where the identity is
    persisted. A bad role or an unarmed executor **dies here**, before any
    bootstrap. See [Bridge executor role](#bridge-executor-role-a-second-service-from-this-same-image).
-0b. As root: `chown` the `/workspace` mount to `alissa`, (optionally) raise the
-   egress firewall, then drop to `alissa` via `gosu`. Everything below runs
-   unprivileged.
+0b. As root: make the `/workspace` mount writable by `alissa` — probing
+   ownership at depth 1 and running the full `chown -R` only when the probe finds
+   a foreign owner or `ALISSA_FORCE_CHOWN=1` says so
+   ([why](#boot-time-ownership-the-volume-walk-is-guarded)) — then (optionally)
+   raise the egress firewall and drop to `alissa` via `gosu`. Everything below
+   runs unprivileged.
 1. Preflight + onboard the identities: validate `gh` (fatal if missing) and run
    `gh auth setup-git`; `alissa auth login` — fatal only when the API **rejects**
    the token, otherwise triaged and retried (see

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -143,13 +143,88 @@ fi
 #
 # claude refuses --dangerously-skip-permissions as root, so everything past this
 # point MUST run unprivileged — that is exactly what the drop guarantees.
+#
+# THE WALK IS GUARDED (issue #78). `chown -R` over the persistent volume stats
+# every inode of every worktree hub, and the dentry/inode slab it fills is
+# charged to the container's cgroup: a 2026-08-09 audit of the Railway service
+# found `memory.current` at ~5.98 GB with 176 MB of actual RSS — 3.71 GB of it
+# `slab_reclaimable` from this walk, the rest page cache from the hub sync in
+# step 3c. The kernel has no pressure to drop any of it below the cgroup limit,
+# so the metric plateaus flat at ~6 GB from the moment of deploy and stops being
+# usable for spotting a real leak. On a warm restart that whole cost buys
+# nothing: the volume is already `alissa`-owned from the previous boot.
+#
+# So the walk now runs only when a cheap probe says it has to. The probe is
+# O(top-level entries) BY CONSTRUCTION — one `stat` over the mount point plus
+# its depth-1 children. It deliberately does NOT `find … ! -user alissa`: find
+# stats every inode too, which is the exact slab storm this guard exists to
+# remove. The blind spot that buys is root-owned files created DEEPER in the
+# tree (a Railway console shell running as root is the realistic way) — hence
+# ALISSA_FORCE_CHOWN=1, which forces the full walk for one boot.
+#
+# Reclaiming after the fact is not an option here: `/sys/fs/cgroup` is mounted
+# read-only inside a Railway container, so `echo … > memory.reclaim` fails with
+# EROFS even as root (verified 2026-08-09). Avoidance is the only lever, which
+# is why there is no reclaim call in this block.
 # -----------------------------------------------------------------------------
+
+# Does <path> need the recursive chown? Returns 0 (yes) when the probe finds any
+# entry not owned by ${RUNTIME_USER} — or when it cannot tell, because a walk we
+# did not need is cheaper than a volume the daemon cannot write.
+#
+# Scope is the path itself plus its immediate children, nothing deeper: that is
+# what makes the probe O(top-level entries) instead of O(inodes). One `stat`
+# call for the lot, so a hub-per-repo mount costs a single process.
+needs_recursive_chown() {
+  local path="$1"
+  local entry owners owner
+  local -a entries=()
+
+  [ -e "${path}" ] || return 0
+  entries+=("${path}")
+  # Dotfiles included; `..?*` catches `..foo` without ever matching `..`.
+  for entry in "${path}"/* "${path}"/.[!.]* "${path}"/..?*; do
+    [ -e "${entry}" ] || [ -L "${entry}" ] || continue   # unmatched glob / dangling link
+    entries+=("${entry}")
+  done
+
+  # GNU stat does not dereference symlinks without -L, so a dangling link
+  # reports its own ownership rather than failing the whole call.
+  owners="$(stat -c '%U' -- "${entries[@]}" 2>/dev/null)" || return 0
+  [ -n "${owners}" ] || return 0
+  while IFS= read -r owner; do
+    # An uid with no passwd entry prints as UNKNOWN, which is correctly "not ours".
+    [ "${owner}" = "${RUNTIME_USER}" ] || return 0
+  done <<<"${owners}"
+  return 1
+}
+
 if [ "$(id -u)" = "0" ]; then
-  mkdir -p "${WORKSPACE_ROOT}" "${TMUX_TMPDIR:-/home/${RUNTIME_USER}/.tmux}"
-  # Fix ownership so the unprivileged user can write. -R because a restart may
-  # find files a previous root-mounted run left behind.
-  chown -R "${RUNTIME_USER}:${RUNTIME_USER}" \
-    "${WORKSPACE_ROOT}" "${TMUX_TMPDIR:-/home/${RUNTIME_USER}/.tmux}" 2>/dev/null || true
+  TMUX_DIR="${TMUX_TMPDIR:-/home/${RUNTIME_USER}/.tmux}"
+  mkdir -p "${WORKSPACE_ROOT}" "${TMUX_DIR}"
+
+  # Fix ownership so the unprivileged user can write. -R because a first boot
+  # finds a root-owned mount, and a root console shell can leave root-owned
+  # files behind — but only when the probe (or the operator) says so, per the
+  # block comment above. Each target is decided on its own: the tmux dir is a
+  # handful of sockets, the volume is millions of inodes.
+  FORCE_CHOWN=0
+  if is_truthy "${ALISSA_FORCE_CHOWN:-0}"; then
+    FORCE_CHOWN=1
+    log "ALISSA_FORCE_CHOWN=${ALISSA_FORCE_CHOWN} — forcing the full recursive chown (the depth-1 probe is skipped; use this once after a root shell has written deeper into the volume)"
+  fi
+  for CHOWN_TARGET in "${WORKSPACE_ROOT}" "${TMUX_DIR}"; do
+    if [ "${FORCE_CHOWN}" = "1" ] || needs_recursive_chown "${CHOWN_TARGET}"; then
+      chown -R "${RUNTIME_USER}:${RUNTIME_USER}" "${CHOWN_TARGET}" 2>/dev/null || true
+      if [ "${FORCE_CHOWN}" = "1" ]; then
+        log "chown -R ${RUNTIME_USER}:${RUNTIME_USER} ${CHOWN_TARGET} (forced)"
+      else
+        log "chown -R ${RUNTIME_USER}:${RUNTIME_USER} ${CHOWN_TARGET} (probe found entries not owned by ${RUNTIME_USER})"
+      fi
+    else
+      log "${CHOWN_TARGET} already owned by ${RUNTIME_USER} — skipping the recursive chown (set ALISSA_FORCE_CHOWN=1 to force it)"
+    fi
+  done
   log "workspace mount ${WORKSPACE_ROOT} owned by ${RUNTIME_USER}"
 
   if [ "${ALISSA_ENABLE_FIREWALL:-0}" = "1" ]; then

--- a/docker/claude/tests-entrypoint-chown.sh
+++ b/docker/claude/tests-entrypoint-chown.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Tests for the entrypoint's GUARDED boot-time chown (#78).
+#
+# The defect: step 0 ran `chown -R alissa:alissa ${WORKSPACE_ROOT}` on EVERY
+# boot. The walk stats every inode of every worktree hub on the persistent
+# volume, and the dentry/inode slab it fills is charged to the container cgroup
+# — a 2026-08-09 audit of the Railway service found memory.current at ~5.98 GB
+# against 176 MB of real RSS, 3.71 GB of it slab_reclaimable from this walk.
+# On a warm restart the walk fixes nothing: the volume is already alissa-owned.
+#
+# The contract this pins:
+#
+#   1. warm boot (probe finds everything alissa-owned) -> NO recursive chown,
+#      and the probe stays O(top-level entries): one stat per target, never a
+#      `find`, never a depth-2 path
+#   2. a root-owned entry among the mount's depth-1 CHILDREN -> full chown runs
+#   3. the mount point ITSELF root-owned (the first-boot case) -> full chown runs
+#   4. ALISSA_FORCE_CHOWN=1 -> full chown runs with everything alissa-owned, and
+#      the probe is skipped entirely (the escape hatch for root-owned files
+#      deeper than the probe can see)
+#   5. ALISSA_FORCE_CHOWN=0 -> back to the probe (the flag is off by default)
+#   6. the probe against the REAL filesystem and the REAL stat, with the outcome
+#      derived from the tree's actual owner — so a stub that lies about stat's
+#      interface cannot make cases 1-5 pass on their own
+#
+# HOW (no docker, no root — CI has neither): this boots the REAL entrypoint.sh
+# with the commands its root phase shells out to replaced by stubs.
+#   * `id -u` answers 0 ONCE, so the root phase runs; the re-exec then sees the
+#     real uid, exactly like the post-gosu pass in the container
+#   * `gosu` drops its user argument and execs, standing in for the privilege drop
+#   * `chown` and `find` record their arguments instead of running (a non-root
+#     test cannot chown, and `find` must never be called at all)
+#   * `stat` answers scripted ownership per path (cases 1-5) or is the real stat
+#     (case 6), and records every invocation so the probe's COST is assertable
+#
+# Usage: bash docker/claude/tests-entrypoint-chown.sh
+# Needs: bash, awk, coreutils.
+# =============================================================================
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENTRYPOINT="${HERE}/entrypoint.sh"
+REAL_STAT="$(command -v stat)"
+
+fail=0
+pass() { printf '  ok   %s\n' "$1"; }
+bad()  { printf '  FAIL %s\n' "$1" >&2; fail=1; }
+info() { printf '%s\n' "$*"; }
+
+assert_contains() {
+  if grep -qF -- "$2" "$1"; then pass "$3"; else bad "$3 (not in $1: $2)"; fi
+}
+assert_not_contains() {
+  if grep -qF -- "$2" "$1"; then bad "$3 (unexpected in $1: $2)"; else pass "$3"; fi
+}
+
+TMPROOT="$(mktemp -d)"
+BIN="${TMPROOT}/bin"; mkdir -p "${BIN}"
+FAKE_HOME="${TMPROOT}/home"; mkdir -p "${FAKE_HOME}/.config/alissa"
+cp "${HERE}/agents.yaml" "${FAKE_HOME}/.config/alissa/agents.yaml"
+cleanup() { rm -rf "${TMPROOT}"; }
+trap cleanup EXIT
+
+# --- stubs -------------------------------------------------------------------
+
+# `id -u` is the root gate. Answer 0 exactly once (the pre-drop pass) and defer
+# to the real id afterwards, so the script takes the root branch and then
+# behaves like the unprivileged re-exec.
+cat > "${BIN}/id" <<STUB
+#!/usr/bin/env bash
+if [ "\${1:-}" = "-u" ] && [ ! -e "\${ROOT_PASS_DONE}" ]; then
+  : > "\${ROOT_PASS_DONE}"
+  echo 0
+  exit 0
+fi
+exec $(command -v id) "\$@"
+STUB
+
+# The privilege drop: `gosu <user> <cmd...>` -> run <cmd...> as who we already are.
+cat > "${BIN}/gosu" <<'STUB'
+#!/usr/bin/env bash
+shift
+exec "$@"
+STUB
+
+# chown / find never really run here; what matters is WHETHER they were called.
+cat > "${BIN}/chown" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${CHOWN_LOG}"
+exit 0
+STUB
+cat > "${BIN}/find" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FIND_LOG}"
+exit 0
+STUB
+
+# Scripted ownership. FAKE_OWNERS names a TSV of "<path>\t<owner>" lines; any
+# path not listed is owned by `alissa`. Unset FAKE_OWNERS => the real stat.
+# Every invocation is appended to STAT_LOG, which is how the probe's cost (one
+# call per target, depth-1 paths only) becomes an assertion instead of a claim.
+cat > "${BIN}/stat" <<STUB
+#!/usr/bin/env bash
+if [ -z "\${FAKE_OWNERS:-}" ]; then
+  exec ${REAL_STAT} "\$@"
+fi
+printf '%s\n' "\$*" >> "\${STAT_LOG}"
+for arg in "\$@"; do
+  case "\${arg}" in
+    -*|'%U') continue ;;
+  esac
+  owner="\$(awk -F'\t' -v p="\${arg}" '\$1==p{print \$2; exit}' "\${FAKE_OWNERS}")"
+  [ -n "\${owner}" ] || owner=alissa
+  printf '%s\n' "\${owner}"
+done
+exit 0
+STUB
+
+# The identities the boot preflights, and the daemon it ends up running. None of
+# them is under test here — every assertion is about the root phase — so they
+# only have to be credible enough to get past their gates.
+cat > "${BIN}/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  "api user -q .login") echo alissa-app ;;
+esac
+exit 0
+STUB
+cat > "${BIN}/alissa" <<'STUB'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "worker status") echo "worker is running" ;;
+esac
+exit 0
+STUB
+cat > "${BIN}/alissa-revloop" <<'STUB'
+#!/usr/bin/env bash
+trap 'exit 0' TERM INT
+sleep 600 &
+wait $!
+STUB
+chmod 0755 "${BIN}"/*
+
+# --- harness -----------------------------------------------------------------
+
+# run_boot <case-name> [env assignments...]
+#
+# Builds a fresh workspace tree for the case, boots the entrypoint through the
+# fake root pass, and stops it once the drop has happened (the marker line
+# "role: " is the first thing the unprivileged pass logs, so it proves the root
+# phase completed AND that we are past it). Exports, per case:
+#   WORKSPACE  the mount point       LOG        the boot log
+#   CHOWN_LOG  chown invocations     STAT_LOG   stat invocations
+#   FIND_LOG   find invocations
+case_workspace() { printf '%s\n' "${TMPROOT}/$1/workspace"; }
+
+run_boot() {
+  local name="$1"; shift
+  local case_dir="${TMPROOT}/${name}"
+  WORKSPACE="$(case_workspace "${name}")"
+  LOG="${case_dir}/boot.log"
+  CHOWN_LOG="${case_dir}/chown.log"
+  STAT_LOG="${case_dir}/stat.log"
+  FIND_LOG="${case_dir}/find.log"
+  mkdir -p "${WORKSPACE}/fahera-mx" "${WORKSPACE}/.revloop" "${case_dir}/tmux"
+  : > "${CHOWN_LOG}"; : > "${STAT_LOG}"; : > "${FIND_LOG}"
+
+  env -i \
+    PATH="${BIN}:/usr/local/bin:/usr/bin:/bin" \
+    HOME="${FAKE_HOME}" \
+    TMUX_TMPDIR="${case_dir}/tmux" \
+    ALISSA_WORKSPACE_ROOT="${WORKSPACE}" \
+    ROOT_PASS_DONE="${case_dir}/root-pass-done" \
+    CHOWN_LOG="${CHOWN_LOG}" \
+    STAT_LOG="${STAT_LOG}" \
+    FIND_LOG="${FIND_LOG}" \
+    GH_TOKEN=stub-gh-token \
+    ALISSA_API_TOKEN=stub-alissa-token \
+    ALISSA_REVIEW_REPOS="fahera-mx/example-repo" \
+    "$@" \
+    bash "${ENTRYPOINT}" > "${LOG}" 2>&1 &
+  local pid=$! i
+  for i in $(seq 1 30); do
+    grep -qF "[entrypoint] role: " "${LOG}" && break
+    kill -0 "${pid}" 2>/dev/null || break
+    sleep 1
+  done
+  kill -TERM "${pid}" 2>/dev/null || true
+  wait "${pid}" 2>/dev/null || true
+}
+
+# Did the recursive chown of the workspace mount run?
+chowned_workspace() { grep -qF -- "-R alissa:alissa ${WORKSPACE}" "${CHOWN_LOG}"; }
+
+# --- 1. warm boot: the whole volume is already alissa-owned ------------------
+info "1. warm boot (everything alissa-owned) -> no recursive walk"
+: > "${TMPROOT}/owners-warm.tsv"
+run_boot warm FAKE_OWNERS="${TMPROOT}/owners-warm.tsv"
+if chowned_workspace; then bad "the recursive chown must NOT run on a warm boot"
+else pass "no recursive chown of the workspace mount"; fi
+assert_contains "${LOG}" "already owned by alissa — skipping the recursive chown" \
+  "the log says the walk was skipped, and how to force it"
+if [ ! -s "${FIND_LOG}" ]; then pass "no \`find\` sweep (it would stat every inode too)"
+else bad "the probe shelled out to find: $(cat "${FIND_LOG}")"; fi
+# O(top-level entries): one stat call per target, and nothing below depth 1.
+if [ "$(wc -l < "${STAT_LOG}")" = "2" ]; then
+  pass "the probe cost exactly one stat call per target (workspace + tmux dir)"
+else
+  bad "expected 2 stat calls, got $(wc -l < "${STAT_LOG}"): $(cat "${STAT_LOG}")"
+fi
+if grep -qF -- "${WORKSPACE}/fahera-mx/" "${STAT_LOG}"; then
+  bad "the probe descended past depth 1 (that is the walk it exists to avoid)"
+else
+  pass "the probe never looked below the mount's immediate children"
+fi
+assert_contains "${STAT_LOG}" "${WORKSPACE}/.revloop" \
+  "...but it DID probe the depth-1 children, dotted ones included"
+
+# --- 2. a root-owned child of the mount --------------------------------------
+info ""
+info "2. a depth-1 child is root-owned -> the full chown runs"
+printf '%s\t%s\n' "$(case_workspace child-root)/fahera-mx" root > "${TMPROOT}/owners-child.tsv"
+run_boot child-root FAKE_OWNERS="${TMPROOT}/owners-child.tsv"
+if chowned_workspace; then pass "the recursive chown of the mount ran"
+else bad "a root-owned child must trigger the full chown"; fi
+assert_contains "${LOG}" "probe found entries not owned by alissa" \
+  "the log says why the walk ran"
+
+# --- 3. the mount point itself is root-owned (first boot) --------------------
+info ""
+info "3. the mount point itself is root-owned (fresh volume) -> the full chown runs"
+printf '%s\t%s\n' "$(case_workspace mount-root)" root > "${TMPROOT}/owners-mount.tsv"
+run_boot mount-root FAKE_OWNERS="${TMPROOT}/owners-mount.tsv"
+if chowned_workspace; then pass "first-boot behaviour is unchanged: the full chown still runs"
+else bad "a root-owned mount point must trigger the full chown"; fi
+
+# --- 4. the escape hatch -----------------------------------------------------
+info ""
+info "4. ALISSA_FORCE_CHOWN=1 -> the walk runs even though the probe would skip it"
+: > "${TMPROOT}/owners-force.tsv"
+run_boot force FAKE_OWNERS="${TMPROOT}/owners-force.tsv" ALISSA_FORCE_CHOWN=1
+if chowned_workspace; then pass "the recursive chown ran on an alissa-owned tree"
+else bad "ALISSA_FORCE_CHOWN=1 must force the walk"; fi
+assert_contains "${LOG}" "ALISSA_FORCE_CHOWN=1 — forcing the full recursive chown" \
+  "the log announces the forced walk"
+assert_contains "${LOG}" "(forced)" "...and attributes the walk to the flag, not the probe"
+if [ ! -s "${STAT_LOG}" ]; then pass "the probe is skipped entirely when forced"
+else bad "forced boot still probed: $(cat "${STAT_LOG}")"; fi
+
+# --- 5. the flag is off by default -------------------------------------------
+info ""
+info "5. ALISSA_FORCE_CHOWN=0 -> back to the probe"
+: > "${TMPROOT}/owners-off.tsv"
+run_boot force-off FAKE_OWNERS="${TMPROOT}/owners-off.tsv" ALISSA_FORCE_CHOWN=0
+if chowned_workspace; then bad "ALISSA_FORCE_CHOWN=0 must not force the walk"
+else pass "no recursive chown"; fi
+assert_not_contains "${LOG}" "forcing the full recursive chown" "no forced-walk banner"
+
+# --- 6. the real stat, against the real filesystem ---------------------------
+info ""
+info "6. real stat, real tree -> the outcome follows the tree's actual owner"
+run_boot real-stat
+REAL_OWNER="$(${REAL_STAT} -c '%U' "${WORKSPACE}")"
+if [ "${REAL_OWNER}" = "alissa" ]; then
+  # The container this repo builds runs as `alissa`, so a local run lands here.
+  if chowned_workspace; then bad "a genuinely alissa-owned tree must skip the walk"
+  else pass "tree really owned by alissa -> skipped"; fi
+else
+  # CI runs as `runner`; every entry is foreign, which is the first-boot shape.
+  if chowned_workspace; then pass "tree really owned by ${REAL_OWNER} (not alissa) -> walked"
+  else bad "a tree owned by ${REAL_OWNER} must trigger the walk"; fi
+fi
+
+info ""
+[ "${fail}" = "0" ] && { echo "ALL PASS"; exit 0; } || { echo "FAILURES"; exit 1; }


### PR DESCRIPTION
Closes #78

**Origin task:** TASK-357393641
**Implementation task:** TASK-1002979593

## What changed

Step 0 of `docker/claude/entrypoint.sh` ran `chown -R alissa:alissa ${WORKSPACE_ROOT}` on
every boot. The walk stats every inode of every worktree hub on the persistent volume, and
the dentry/inode slab it fills is charged to the container cgroup — the 2026-08-09 audit
found `memory.current` at ~5.98 GB against 176 MB of real RSS (3.71 GB `slab_reclaimable`
from the walk, ~2.2 GB page cache from the step-3c hub sync) with zero reviewer sessions
running. It is reclaimable cache rather than a leak, but it plateaus from the moment of
deploy and makes the memory graph useless for spotting a real problem, and on a warm
restart the walk fixes nothing.

* **Guarded walk.** A `needs_recursive_chown` probe stats the mount point plus its depth-1
  children in a single `stat` call; the recursive chown runs only if something there is not
  owned by `alissa`. O(top-level entries) by construction — deliberately *not*
  `find … ! -user alissa`, which stats every inode and would recreate the same slab storm.
  The probe fails **safe**: if it cannot tell (missing path, `stat` error, unknown uid), it
  walks. First-boot behaviour is unchanged — a fresh volume is root-owned at the mount
  point, so the probe trips.
* **Escape hatch.** `ALISSA_FORCE_CHOWN=1` (new ARG/ENV, default off, same pass-through
  shape as the other knobs) skips the probe and forces the full walk for one boot, covering
  the probe's only blind spot: root-owned files written deeper than depth 1, e.g. by a
  platform console shell.
* **Targets decided independently.** `${WORKSPACE_ROOT}` and `${TMUX_TMPDIR}` each get
  their own probe, so a stale tmux socket dir cannot drag the volume into a walk.
* **Tests.** `docker/claude/tests-entrypoint-chown.sh` boots the **real** entrypoint six
  times through a fake root pass and is wired into `check-entrypoint`.
* **Docs.** README settings-table row plus a "Boot-time ownership" section carrying the
  audit numbers, the probe's blind spot, and why reclaim is not the fix here.

## Follow-up

Round 1 approved this PR with three `[minor]` and one `[nit]`; all four were triaged
`[triage:pursue]` on their threads and implemented in **#80**, which is cut from this PR's
approved head `7d91b8e` and based on `main`. **Merge this PR (#79) first** — merging #80
first would squash this PR's delta into `main` under #80's commit message and leave this
one resolving as empty. #80's own approve carried four further diagnostics/docs findings,
deferred as TASK-313195870.

## Delivery notes

### Judgment calls

* **Scope item 3 (`memory.reclaim`) skipped, as the issue recommends.** The issue verified
  `/sys/fs/cgroup` is read-only inside a Railway container, so the write is a guaranteed
  no-op there and would only ever fire on self-hosted docker with cgroup delegation. Shipped
  the recorded decision instead: a comment in the entrypoint block and a paragraph in the
  README saying reclaim was considered, why it cannot work on Railway, and that avoidance is
  therefore the only lever.
* **The probe compares owner NAMES (`stat -c '%U'`), not uids.** An uid with no passwd entry
  renders as `UNKNOWN`, which correctly reads as "not ours" and forces the walk — the
  fail-safe direction. It does mean the probe would walk on a container whose passwd entry
  for uid 1000 was renamed; that container is broken in worse ways already.
* **The tmux dir is guarded too, not just the volume.** The issue only names
  `${WORKSPACE_ROOT}`, but both paths were in the same `chown -R` call and splitting them
  was the honest way to keep the volume's decision independent. The tmux dir is a handful of
  sockets, so its probe costs nothing either way.
* **`is_truthy` for the new flag, not `= "1"`.** It matches the console and executor gates
  rather than the deliberately narrow `ALISSA_ENABLE_FIREWALL` test; a new flag has no
  deploy already relying on the narrower contract, which is the reason that one was left
  alone.
* **The old `workspace mount … owned by alissa` log line is kept** after the per-target
  lines, so anything grepping the boot log for that marker still finds it.
* **Test method: the root phase is exercised through stubs, not root.** These runners (and
  CI) have neither root nor docker, and the root-only branch cannot otherwise be reached.
  `id -u` answers 0 exactly once so the root pass runs, `gosu` execs in place as the
  privilege drop, `chown`/`find` record their arguments instead of running, and `stat`
  answers scripted ownership per path — which is what turns "the probe stayed
  O(top-level entries)" into an assertion (stat-call count, no depth-2 path, `find` never
  invoked) rather than a claim. Case 6 runs the same boot against the **real** `stat` and
  the real tree, deriving the expected outcome from the tree's actual owner, so a stub that
  misrepresents `stat`'s interface cannot carry the other five cases.

### Not verified — operator's gate

* [ ] **The acceptance criterion that matters is a deploy measurement and cannot be made
  here.** Redeploy this image onto the existing warm Railway volume and confirm the memory
  metric settles far below the ~6 GB plateau (expect hundreds of MB: anon + genuine work
  cache). The ~2.2 GB `workspace sync` page-cache share is *not* removed by this task and
  will still appear once the hubs are fetched.
* [ ] **Warm-boot skip against a real root-owned-then-fixed volume.** In CI and locally the
  probe was driven by scripted ownership (plus one real-`stat` case); no environment here
  can create a genuinely root-owned file. Confirm in the deploy log that the boot prints
  `… already owned by alissa — skipping the recursive chown`.
* [ ] **First boot on a fresh, cold, root-owned volume** — the full `chown -R` must still
  run and the daemon must come up. Covered by test case 3 with scripted ownership only.
* [ ] **`ALISSA_FORCE_CHOWN=1` on the real service.** It is a build ARG baked to an ENV on
  Railway, so setting it needs a rebuild/redeploy like every other knob here; verify the
  forced walk fires once and remember to unset it.
* [ ] **No image was built.** No docker daemon in this environment, so the Dockerfile
  ARG/ENV addition is unbuilt and unlinted; it follows the existing pattern exactly.
* [ ] **Boot sequence regression (worker up, daemon polling, console serving)** was checked
  only through the stubbed-CLI entrypoint suites, never against real `gh`/`alissa`/`claude`.

### Verification

* `docker/claude/tests-entrypoint-chown.sh` — **ALL PASS** (6 cases, new).
  Counterfactually checked, not just run: forcing the probe to always report "clean" fails
  cases 2/3 and the cost assertions; restoring the unguarded walk (`if true`) fails cases
  1/5/6. Both mutations were applied to the narrowest clause, in a scratch copy.
  The real-`stat` case covers both directions across the two environments: locally the tree
  is genuinely `alissa`-owned and the walk is skipped; on the CI runner it is `runner`-owned
  and the walk fires — both outcomes are visible in the check log.
* `tests-entrypoint-config.sh` — ALL PASS. `tests-entrypoint-identity.sh` — ALL PASS.
  `tests-entrypoint-auth.sh` — PASS. `tests-entrypoint-executor.sh` — PASS.
  `tests-entrypoint-ui.sh` — PASS (all four boots, real console sidecar).
* `bash -n docker/claude/entrypoint.sh` — clean. No shellcheck in this repo's CI, and none
  installed here, so the shell was not statically linted beyond the syntax check.
* The Python suites (`check-style` / `check-tests` / `check-types`) were **not** run: this
  diff contains no Python and touches nothing under `alissa-tools-github-revloop/`, so
  `check-version-bump` also does not apply (docker/ and .github/ are outside the guarded
  dist prefix).

### Scope touched

Declared scope was `docker/**, README.md`.

* `docker/claude/entrypoint.sh` — the guard, the probe function, the rationale comment.
* `docker/claude/Dockerfile` — `ARG`/`ENV ALISSA_FORCE_CHOWN` pass-through.
* `docker/claude/README.md` — settings-table row, the "Boot-time ownership" section, and
  the two cross-references (persistence section, "What the entrypoint does" step 0b).
  Note: the settings table lives in the **docker** README; the repo-root `README.md` has no
  settings table and was not touched.
* `docker/claude/tests-entrypoint-chown.sh` — new suite.
* **Excursion:** `.github/workflows/check-entrypoint.yaml` — one step added to run the new
  suite, plus the header comment. Outside the declared `Autonomous-Scope` paths but
  explicitly required by the issue's scope item 4 ("`check-entrypoint` workflow") and by the
  acceptance criterion "CI check-entrypoint workflow green on the PR". No other workflow
  changed.

