### PR TITLE
TASK-1002979593: PR #79 round-1 follow-up — probe owner+group, report a failed walk, pin target independence

### DIFF
--- a/.github/workflows/check-entrypoint.yaml
+++ b/.github/workflows/check-entrypoint.yaml
@@ -16,7 +16,10 @@ on: [pull_request]
 #     fast FATAL), same way — docker/claude/tests-entrypoint-auth.sh;
 #   * the bridge-executor role (CONTAINER_ROLE / ALISSA_BRIDGE_* gate, executor
 #     identity, and the guarantee that neither role starts the other's
-#     supervisor) — docker/claude/tests-entrypoint-executor.sh.
+#     supervisor) — docker/claude/tests-entrypoint-executor.sh;
+#   * the guarded boot-time chown (warm boot skips the volume walk, a root-owned
+#     probe result or ALISSA_FORCE_CHOWN=1 still runs it) —
+#     docker/claude/tests-entrypoint-chown.sh.
 jobs:
   entrypoint-config-check:
     name: Entrypoint config renderer + console wiring
@@ -81,6 +84,15 @@ jobs:
         # off instead of crash-looping, hence the timeout headroom.
         timeout-minutes: 6
         run: bash docker/claude/tests-entrypoint-executor.sh
+      - name: Execute Entrypoint Guarded-Chown Tests
+        # Boots the entrypoint six times through a FAKE root pass (`id -u`
+        # answers 0 once, `gosu` execs in place) so the root-only step 0 is
+        # exercised without root or docker. `chown`/`find` record instead of
+        # running and `stat` answers scripted ownership, which is what makes
+        # "the probe stayed O(top-level entries)" an assertion rather than a
+        # claim; the last case runs against the real stat and the real tree.
+        timeout-minutes: 4
+        run: bash docker/claude/tests-entrypoint-chown.sh
       - name: Execute Entrypoint Console Wiring Tests
         # Boots the entrypoint four times (console off / enabled-without-passcode
         # / enabled / sidecar killed under it). No docker needed: the CLIs the

--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -297,6 +297,13 @@ ARG ALISSA_WORKER_INTERVAL="2"
 # Optional egress firewall (needs --cap-add=NET_ADMIN at runtime).
 ARG ALISSA_ENABLE_FIREWALL="0"
 ARG ALISSA_FIREWALL_EXTRA=""
+# Force the root phase's full `chown -R` of the volume (issue #78). Default OFF:
+# the entrypoint probes ownership at depth 1 and only walks when it finds
+# something not owned by `alissa`, because the walk charges GBs of reclaimable
+# dentry/inode slab to the container cgroup and a warm boot gains nothing from
+# it. Set this to 1 for ONE boot after a root shell has written files DEEPER in
+# the tree than the probe can see — that is the probe's only blind spot.
+ARG ALISSA_FORCE_CHOWN="0"
 
 ENV ALISSA_REVIEW_REPOS=${ALISSA_REVIEW_REPOS} \
     ALISSA_REVIEW_OPERATORS=${ALISSA_REVIEW_OPERATORS} \
@@ -315,7 +322,8 @@ ENV ALISSA_REVIEW_REPOS=${ALISSA_REVIEW_REPOS} \
     ALISSA_ON_MISSING_HUB=${ALISSA_ON_MISSING_HUB} \
     ALISSA_WORKER_INTERVAL=${ALISSA_WORKER_INTERVAL} \
     ALISSA_ENABLE_FIREWALL=${ALISSA_ENABLE_FIREWALL} \
-    ALISSA_FIREWALL_EXTRA=${ALISSA_FIREWALL_EXTRA}
+    ALISSA_FIREWALL_EXTRA=${ALISSA_FIREWALL_EXTRA} \
+    ALISSA_FORCE_CHOWN=${ALISSA_FORCE_CHOWN}
 
 # The reviewer console (alissa-revloop-ui) listens here when ALISSA_UI_ENABLED is
 # set. EXPOSE is documentation/metadata only — it opens no port by itself; the

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -234,7 +234,7 @@ automatically; locally pass `--build-arg`):
 | `ALISSA_WORKER_INTERVAL` | `2` | worker reconcile tick (seconds) |
 | `ALISSA_ENABLE_FIREWALL` | `0` | `1` raises the egress firewall (needs `--cap-add=NET_ADMIN`) |
 | `ALISSA_FIREWALL_EXTRA` | *(empty)* | extra firewall allowlist hosts, space-separated |
-| `ALISSA_FORCE_CHOWN` | `0` | `1` forces the root phase's full `chown -R` of the volume for that boot. Off by default: the entrypoint probes ownership at depth 1 and walks only when it finds a foreign owner (see [Boot-time ownership](#boot-time-ownership-the-volume-walk-is-guarded)). Set it for **one** boot after a root shell wrote files deeper in the tree |
+| `ALISSA_FORCE_CHOWN` | `0` | `1`/`true`/`yes`/`on` forces the root phase's full `chown -R` of the volume for that boot; anything else (incl. unset) leaves the probe in charge. Off by default: the entrypoint probes ownership at depth 1 and walks only when it finds a foreign owner (see [Boot-time ownership](#boot-time-ownership-the-volume-walk-is-guarded)). Set it for **one** boot after a root shell wrote files deeper in the tree |
 
 #### Config precedence: env var > daemon library default
 
@@ -273,16 +273,30 @@ cgroup limit), but it plateaus flat from the moment of deploy and makes the
 memory graph useless for spotting a real problem.
 
 So step 0 now **probes before it walks**: one `stat` over the mount point and its
-immediate children, and the `chown -R` runs only if something there is not owned
-by `alissa`. The probe is O(top-level entries) by construction — deliberately not
-`find … ! -user alissa`, which stats every inode and would recreate the same slab
-storm. A first boot on a fresh root-owned volume is unaffected: the mount point
-itself is root-owned, so the probe trips and the full walk runs exactly as before.
+immediate children, and the `chown -R` runs only if something there is not
+`alissa:alissa`. Owner **and** group, because that is what the walk asserts — a
+probe testing only the owner would read an `alissa:root` entry as clean, and the
+unconditional every-boot walk that used to repair the group is exactly what this
+change removes. The probe is O(top-level entries) by construction — deliberately
+not `find … ! -user alissa`, which stats every inode and would recreate the same
+slab storm. A first boot on a fresh root-owned volume is unaffected: the mount
+point itself is root-owned, so the probe trips and the full walk runs exactly as
+before.
 
-The blind spot is a root-owned file created **deeper** than depth 1 — realistically,
-a platform console shell running as root. `ALISSA_FORCE_CHOWN=1` is the escape
-hatch: it skips the probe and forces the full walk for that boot. Set it, restart,
-then unset it.
+The blind spot is precisely one thing: **depth**. Anything below the mount point's
+immediate children is invisible to the probe — realistically, a platform console
+shell running as root. `ALISSA_FORCE_CHOWN=1` is the escape hatch: it skips the
+probe and forces the full walk for that boot. Set it, redeploy, then unset it.
+
+Two failure modes are worth knowing about, because the guard changed their
+consequences. A walk that **fails** partway (a permission error deep in the tree)
+still processes the mount point and its children — `chown -R` is post-order and
+continues past per-entry errors — so the probe would read the tree as clean
+forever after. The entrypoint therefore logs `WARNING: chown -R … reported errors`
+and names `ALISSA_FORCE_CHOWN=1` as the remedy; that warning is the only signal
+there is, so it is worth alerting on. A walk that is **interrupted** (the container
+is killed mid-boot) is self-healing for the same post-order reason: the mount point
+is chowned last, so a partial walk leaves the probe tripping on the next boot.
 
 Reclaiming the cache after the fact is not an option on Railway: `/sys/fs/cgroup`
 is mounted read-only inside the container, so writing `memory.reclaim` fails with
@@ -689,8 +703,9 @@ volumes:
    persisted. A bad role or an unarmed executor **dies here**, before any
    bootstrap. See [Bridge executor role](#bridge-executor-role-a-second-service-from-this-same-image).
 0b. As root: make the `/workspace` mount writable by `alissa` — probing
-   ownership at depth 1 and running the full `chown -R` only when the probe finds
-   a foreign owner or `ALISSA_FORCE_CHOWN=1` says so
+   ownership (owner **and** group) at depth 1 and running the full `chown -R` only
+   when the probe finds something foreign or `ALISSA_FORCE_CHOWN=1` says so, and
+   **warning** if that walk reports errors
    ([why](#boot-time-ownership-the-volume-walk-is-guarded)) — then (optionally)
    raise the egress firewall and drop to `alissa` via `gosu`. Everything below
    runs unprivileged.

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -234,6 +234,7 @@ automatically; locally pass `--build-arg`):
 | `ALISSA_WORKER_INTERVAL` | `2` | worker reconcile tick (seconds) |
 | `ALISSA_ENABLE_FIREWALL` | `0` | `1` raises the egress firewall (needs `--cap-add=NET_ADMIN`) |
 | `ALISSA_FIREWALL_EXTRA` | *(empty)* | extra firewall allowlist hosts, space-separated |
+| `ALISSA_FORCE_CHOWN` | `0` | `1` forces the root phase's full `chown -R` of the volume for that boot. Off by default: the entrypoint probes ownership at depth 1 and walks only when it finds a foreign owner (see [Boot-time ownership](#boot-time-ownership-the-volume-walk-is-guarded)). Set it for **one** boot after a root shell wrote files deeper in the tree |
 
 #### Config precedence: env var > daemon library default
 
@@ -256,6 +257,37 @@ that the baked [`agents.yaml`](./agents.yaml) ships (`claude`), and
 `on_missing_hub` must be `add` for the self-contained hub-ify-on-demand model —
 the library default `skip` would make a fresh volume review nothing. Both are
 still overridable via their env var.
+
+#### Boot-time ownership: the volume walk is guarded
+
+The container starts as root only to make a root-owned volume mount writable
+(see [Persistence](#persistence--mount-the-volume-at-workspace)). That `chown -R`
+used to run on **every** boot, and on a warm volume it is both a no-op and
+expensive: the walk stats every inode of every worktree hub, and the resulting
+dentry/inode slab is charged to the container's cgroup. An audit of the Railway
+service on 2026-08-09 found `memory.current` at **~5.98 GB** against **176 MB**
+of actual process RSS — 3.71 GB of it `slab_reclaimable` from the walk, the rest
+page cache from the hub sync — with zero reviewer sessions running. It is
+reclaimable cache, not a leak (the kernel drops it under real pressure at the
+cgroup limit), but it plateaus flat from the moment of deploy and makes the
+memory graph useless for spotting a real problem.
+
+So step 0 now **probes before it walks**: one `stat` over the mount point and its
+immediate children, and the `chown -R` runs only if something there is not owned
+by `alissa`. The probe is O(top-level entries) by construction — deliberately not
+`find … ! -user alissa`, which stats every inode and would recreate the same slab
+storm. A first boot on a fresh root-owned volume is unaffected: the mount point
+itself is root-owned, so the probe trips and the full walk runs exactly as before.
+
+The blind spot is a root-owned file created **deeper** than depth 1 — realistically,
+a platform console shell running as root. `ALISSA_FORCE_CHOWN=1` is the escape
+hatch: it skips the probe and forces the full walk for that boot. Set it, restart,
+then unset it.
+
+Reclaiming the cache after the fact is not an option on Railway: `/sys/fs/cgroup`
+is mounted read-only inside the container, so writing `memory.reclaim` fails with
+`EROFS` even as root (verified 2026-08-09). Avoidance is the only lever, which is
+why the entrypoint has no reclaim call.
 
 ### Reviewer console (runtime env only — `ALISSA_UI_ENABLED`, `ALISSA_UI_PASSCODE`, `PORT`)
 
@@ -425,6 +457,12 @@ volumes typically mount **root-owned**, so the container starts as root, the
 entrypoint `chown`s the mount to `alissa` (uid 1000), and then drops to that user
 (via `gosu`) for everything else — so a root-owned mount just works, no manual
 `chown` or init container needed. (claude still runs unprivileged, as it must.)
+
+That `chown` is **guarded**: on a warm volume it is skipped, because walking it
+charges GBs of reclaimable kernel cache to the container's memory metric for no
+benefit. See [Boot-time ownership](#boot-time-ownership-the-volume-walk-is-guarded)
+for the numbers and for `ALISSA_FORCE_CHOWN`, the escape hatch to use after a root
+console shell has written into the volume.
 
 ### Optional egress firewall
 
@@ -650,9 +688,12 @@ volumes:
    its gates — the arming flag, the executor id, and where the identity is
    persisted. A bad role or an unarmed executor **dies here**, before any
    bootstrap. See [Bridge executor role](#bridge-executor-role-a-second-service-from-this-same-image).
-0b. As root: `chown` the `/workspace` mount to `alissa`, (optionally) raise the
-   egress firewall, then drop to `alissa` via `gosu`. Everything below runs
-   unprivileged.
+0b. As root: make the `/workspace` mount writable by `alissa` — probing
+   ownership at depth 1 and running the full `chown -R` only when the probe finds
+   a foreign owner or `ALISSA_FORCE_CHOWN=1` says so
+   ([why](#boot-time-ownership-the-volume-walk-is-guarded)) — then (optionally)
+   raise the egress firewall and drop to `alissa` via `gosu`. Everything below
+   runs unprivileged.
 1. Preflight + onboard the identities: validate `gh` (fatal if missing) and run
    `gh auth setup-git`; `alissa auth login` — fatal only when the API **rejects**
    the token, otherwise triaged and retried (see

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -156,11 +156,26 @@ fi
 #
 # So the walk now runs only when a cheap probe says it has to. The probe is
 # O(top-level entries) BY CONSTRUCTION — one `stat` over the mount point plus
-# its depth-1 children. It deliberately does NOT `find … ! -user alissa`: find
-# stats every inode too, which is the exact slab storm this guard exists to
-# remove. The blind spot that buys is root-owned files created DEEPER in the
-# tree (a Railway console shell running as root is the realistic way) — hence
-# ALISSA_FORCE_CHOWN=1, which forces the full walk for one boot.
+# its depth-1 children, testing owner AND group, because `alissa:alissa` is what
+# the walk asserts and a probe that tested only the owner would read `alissa:root`
+# as clean and never repair it. It deliberately does NOT `find … ! -user alissa`:
+# find stats every inode too, which is the exact slab storm this guard exists to
+# remove.
+#
+# WHAT THE PROBE CANNOT SEE, precisely: anything DEEPER than the mount point's
+# immediate children. A platform console shell running as root is the realistic
+# way to get there — hence ALISSA_FORCE_CHOWN=1, which forces the full walk for
+# one boot.
+#
+# AND THE INVARIANT THIS LEANS ON, which is easy to break by accident:
+# `chown -R` walks POST-ORDER, so the mount point itself is chowned LAST. That is
+# the only reason an interrupted first boot self-heals — a partial walk leaves
+# depth 0 still root-owned, so the next boot's probe trips and the walk resumes.
+# An "optimisation" that chowned the mount point first would convert every killed
+# first boot into a permanently latched half-owned volume. Do not reorder it.
+# The same post-order property is why a walk that FAILS deep still leaves depths
+# 0 and 1 owned by `alissa` — i.e. looking clean to this probe forever — which is
+# why the failure is logged loudly below instead of being swallowed.
 #
 # Reclaiming after the fact is not an option here: `/sys/fs/cgroup` is mounted
 # read-only inside a Railway container, so `echo … > memory.reclaim` fails with
@@ -169,8 +184,8 @@ fi
 # -----------------------------------------------------------------------------
 
 # Does <path> need the recursive chown? Returns 0 (yes) when the probe finds any
-# entry not owned by ${RUNTIME_USER} — or when it cannot tell, because a walk we
-# did not need is cheaper than a volume the daemon cannot write.
+# entry that is not ${RUNTIME_USER}:${RUNTIME_USER} — or when it cannot tell,
+# because a walk we did not need is cheaper than a volume the daemon cannot write.
 #
 # Scope is the path itself plus its immediate children, nothing deeper: that is
 # what makes the probe O(top-level entries) instead of O(inodes). One `stat`
@@ -188,13 +203,19 @@ needs_recursive_chown() {
     entries+=("${entry}")
   done
 
+  # `%U:%G`, not `%U`: the repair this guards sets owner AND group, so testing
+  # only the owner would leave `alissa:root` looking clean with no repair path
+  # left (the unconditional every-boot walk used to be that path). Same single
+  # stat call either way.
+  #
   # GNU stat does not dereference symlinks without -L, so a dangling link
   # reports its own ownership rather than failing the whole call.
-  owners="$(stat -c '%U' -- "${entries[@]}" 2>/dev/null)" || return 0
+  owners="$(stat -c '%U:%G' -- "${entries[@]}" 2>/dev/null)" || return 0
   [ -n "${owners}" ] || return 0
   while IFS= read -r owner; do
-    # An uid with no passwd entry prints as UNKNOWN, which is correctly "not ours".
-    [ "${owner}" = "${RUNTIME_USER}" ] || return 0
+    # An uid/gid with no passwd/group entry prints as UNKNOWN, which is correctly
+    # "not ours".
+    [ "${owner}" = "${RUNTIME_USER}:${RUNTIME_USER}" ] || return 0
   done <<<"${owners}"
   return 1
 }
@@ -215,14 +236,27 @@ if [ "$(id -u)" = "0" ]; then
   fi
   for CHOWN_TARGET in "${WORKSPACE_ROOT}" "${TMUX_DIR}"; do
     if [ "${FORCE_CHOWN}" = "1" ] || needs_recursive_chown "${CHOWN_TARGET}"; then
-      chown -R "${RUNTIME_USER}:${RUNTIME_USER}" "${CHOWN_TARGET}" 2>/dev/null || true
+      # `|| true` stays — step 0 must not die here — but the STATUS is not
+      # discarded any more. `chown -R` continues past per-entry errors and still
+      # processes the parent directories (post-order), so a walk that fails deep
+      # finishes with depths 0 and 1 owned by ${RUNTIME_USER}: the probe reads
+      # clean on every later boot and the unrepaired subtree latches silently.
+      # Under the old unconditional walk that failure was retried next boot; now
+      # the warning is the operator's only signal, so it must exist. stderr stays
+      # suppressed so a per-entry error storm cannot flood the boot log.
+      if chown -R "${RUNTIME_USER}:${RUNTIME_USER}" "${CHOWN_TARGET}" 2>/dev/null; then
+        CHOWN_OK=1
+      else
+        CHOWN_OK=0
+      fi
       if [ "${FORCE_CHOWN}" = "1" ]; then
         log "chown -R ${RUNTIME_USER}:${RUNTIME_USER} ${CHOWN_TARGET} (forced)"
       else
-        log "chown -R ${RUNTIME_USER}:${RUNTIME_USER} ${CHOWN_TARGET} (probe found entries not owned by ${RUNTIME_USER})"
+        log "chown -R ${RUNTIME_USER}:${RUNTIME_USER} ${CHOWN_TARGET} (probe found entries that are not ${RUNTIME_USER}:${RUNTIME_USER})"
       fi
+      [ "${CHOWN_OK}" = "1" ] || log "WARNING: chown -R ${CHOWN_TARGET} reported errors — entries below depth 1 may still be foreign-owned, and the depth-1 probe will read this tree as clean on every later boot. Re-deploy once with ALISSA_FORCE_CHOWN=1 if the daemon cannot write."
     else
-      log "${CHOWN_TARGET} already owned by ${RUNTIME_USER} — skipping the recursive chown (set ALISSA_FORCE_CHOWN=1 to force it)"
+      log "${CHOWN_TARGET} already owned by ${RUNTIME_USER}:${RUNTIME_USER} — skipping the recursive chown (set ALISSA_FORCE_CHOWN=1 to force it)"
     fi
   done
   log "workspace mount ${WORKSPACE_ROOT} owned by ${RUNTIME_USER}"

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -143,13 +143,88 @@ fi
 #
 # claude refuses --dangerously-skip-permissions as root, so everything past this
 # point MUST run unprivileged — that is exactly what the drop guarantees.
+#
+# THE WALK IS GUARDED (issue #78). `chown -R` over the persistent volume stats
+# every inode of every worktree hub, and the dentry/inode slab it fills is
+# charged to the container's cgroup: a 2026-08-09 audit of the Railway service
+# found `memory.current` at ~5.98 GB with 176 MB of actual RSS — 3.71 GB of it
+# `slab_reclaimable` from this walk, the rest page cache from the hub sync in
+# step 3c. The kernel has no pressure to drop any of it below the cgroup limit,
+# so the metric plateaus flat at ~6 GB from the moment of deploy and stops being
+# usable for spotting a real leak. On a warm restart that whole cost buys
+# nothing: the volume is already `alissa`-owned from the previous boot.
+#
+# So the walk now runs only when a cheap probe says it has to. The probe is
+# O(top-level entries) BY CONSTRUCTION — one `stat` over the mount point plus
+# its depth-1 children. It deliberately does NOT `find … ! -user alissa`: find
+# stats every inode too, which is the exact slab storm this guard exists to
+# remove. The blind spot that buys is root-owned files created DEEPER in the
+# tree (a Railway console shell running as root is the realistic way) — hence
+# ALISSA_FORCE_CHOWN=1, which forces the full walk for one boot.
+#
+# Reclaiming after the fact is not an option here: `/sys/fs/cgroup` is mounted
+# read-only inside a Railway container, so `echo … > memory.reclaim` fails with
+# EROFS even as root (verified 2026-08-09). Avoidance is the only lever, which
+# is why there is no reclaim call in this block.
 # -----------------------------------------------------------------------------
+
+# Does <path> need the recursive chown? Returns 0 (yes) when the probe finds any
+# entry not owned by ${RUNTIME_USER} — or when it cannot tell, because a walk we
+# did not need is cheaper than a volume the daemon cannot write.
+#
+# Scope is the path itself plus its immediate children, nothing deeper: that is
+# what makes the probe O(top-level entries) instead of O(inodes). One `stat`
+# call for the lot, so a hub-per-repo mount costs a single process.
+needs_recursive_chown() {
+  local path="$1"
+  local entry owners owner
+  local -a entries=()
+
+  [ -e "${path}" ] || return 0
+  entries+=("${path}")
+  # Dotfiles included; `..?*` catches `..foo` without ever matching `..`.
+  for entry in "${path}"/* "${path}"/.[!.]* "${path}"/..?*; do
+    [ -e "${entry}" ] || [ -L "${entry}" ] || continue   # unmatched glob / dangling link
+    entries+=("${entry}")
+  done
+
+  # GNU stat does not dereference symlinks without -L, so a dangling link
+  # reports its own ownership rather than failing the whole call.
+  owners="$(stat -c '%U' -- "${entries[@]}" 2>/dev/null)" || return 0
+  [ -n "${owners}" ] || return 0
+  while IFS= read -r owner; do
+    # An uid with no passwd entry prints as UNKNOWN, which is correctly "not ours".
+    [ "${owner}" = "${RUNTIME_USER}" ] || return 0
+  done <<<"${owners}"
+  return 1
+}
+
 if [ "$(id -u)" = "0" ]; then
-  mkdir -p "${WORKSPACE_ROOT}" "${TMUX_TMPDIR:-/home/${RUNTIME_USER}/.tmux}"
-  # Fix ownership so the unprivileged user can write. -R because a restart may
-  # find files a previous root-mounted run left behind.
-  chown -R "${RUNTIME_USER}:${RUNTIME_USER}" \
-    "${WORKSPACE_ROOT}" "${TMUX_TMPDIR:-/home/${RUNTIME_USER}/.tmux}" 2>/dev/null || true
+  TMUX_DIR="${TMUX_TMPDIR:-/home/${RUNTIME_USER}/.tmux}"
+  mkdir -p "${WORKSPACE_ROOT}" "${TMUX_DIR}"
+
+  # Fix ownership so the unprivileged user can write. -R because a first boot
+  # finds a root-owned mount, and a root console shell can leave root-owned
+  # files behind — but only when the probe (or the operator) says so, per the
+  # block comment above. Each target is decided on its own: the tmux dir is a
+  # handful of sockets, the volume is millions of inodes.
+  FORCE_CHOWN=0
+  if is_truthy "${ALISSA_FORCE_CHOWN:-0}"; then
+    FORCE_CHOWN=1
+    log "ALISSA_FORCE_CHOWN=${ALISSA_FORCE_CHOWN} — forcing the full recursive chown (the depth-1 probe is skipped; use this once after a root shell has written deeper into the volume)"
+  fi
+  for CHOWN_TARGET in "${WORKSPACE_ROOT}" "${TMUX_DIR}"; do
+    if [ "${FORCE_CHOWN}" = "1" ] || needs_recursive_chown "${CHOWN_TARGET}"; then
+      chown -R "${RUNTIME_USER}:${RUNTIME_USER}" "${CHOWN_TARGET}" 2>/dev/null || true
+      if [ "${FORCE_CHOWN}" = "1" ]; then
+        log "chown -R ${RUNTIME_USER}:${RUNTIME_USER} ${CHOWN_TARGET} (forced)"
+      else
+        log "chown -R ${RUNTIME_USER}:${RUNTIME_USER} ${CHOWN_TARGET} (probe found entries not owned by ${RUNTIME_USER})"
+      fi
+    else
+      log "${CHOWN_TARGET} already owned by ${RUNTIME_USER} — skipping the recursive chown (set ALISSA_FORCE_CHOWN=1 to force it)"
+    fi
+  done
   log "workspace mount ${WORKSPACE_ROOT} owned by ${RUNTIME_USER}"
 
   if [ "${ALISSA_ENABLE_FIREWALL:-0}" = "1" ]; then

--- a/docker/claude/tests-entrypoint-chown.sh
+++ b/docker/claude/tests-entrypoint-chown.sh
@@ -11,7 +11,7 @@
 #
 # The contract this pins:
 #
-#   1. warm boot (probe finds everything alissa-owned) -> NO recursive chown,
+#   1. warm boot (probe finds everything alissa:alissa) -> NO recursive chown,
 #      and the probe stays O(top-level entries): one stat per target, never a
 #      `find`, never a depth-2 path
 #   2. a root-owned entry among the mount's depth-1 CHILDREN -> full chown runs
@@ -23,6 +23,13 @@
 #   6. the probe against the REAL filesystem and the REAL stat, with the outcome
 #      derived from the tree's actual owner — so a stub that lies about stat's
 #      interface cannot make cases 1-5 pass on their own
+#   7. the targets are decided INDEPENDENTLY: a root-owned tmux dir walks on its
+#      own and does not drag the volume into a walk (PR #79 round 1)
+#   8. an entry at alissa:root -> full chown runs. The walk sets owner AND group,
+#      so the probe has to test both or the group half has no repair path left
+#   9. a walk that FAILS is logged, not swallowed: chown -R keeps going past
+#      per-entry errors and still processes the parents, so a deep failure leaves
+#      depths 0/1 clean and would latch silently on every later boot
 #
 # HOW (no docker, no root — CI has neither): this boots the REAL entrypoint.sh
 # with the commands its root phase shells out to replaced by stubs.
@@ -31,8 +38,9 @@
 #   * `gosu` drops its user argument and execs, standing in for the privilege drop
 #   * `chown` and `find` record their arguments instead of running (a non-root
 #     test cannot chown, and `find` must never be called at all)
-#   * `stat` answers scripted ownership per path (cases 1-5) or is the real stat
-#     (case 6), and records every invocation so the probe's COST is assertable
+#   * `stat` answers scripted `owner:group` per path (every case but 6) or is the
+#     real stat (case 6), and records every invocation so the probe's COST is
+#     assertable
 #
 # Usage: bash docker/claude/tests-entrypoint-chown.sh
 # Needs: bash, awk, coreutils.
@@ -78,16 +86,26 @@ exec $(command -v id) "\$@"
 STUB
 
 # The privilege drop: `gosu <user> <cmd...>` -> run <cmd...> as who we already are.
+#
+# Through `bash`, not by executing the script directly: entrypoint.sh is mode 644
+# in the repo (the Dockerfile chmods it into the image), so an `exec "$@"` here
+# dies with "Permission denied" the moment the entrypoint re-execs itself — and
+# every assertion in this file is about the root phase, which happens BEFORE the
+# drop, so that death would go unnoticed. run_boot launches the first pass the
+# same way.
 cat > "${BIN}/gosu" <<'STUB'
 #!/usr/bin/env bash
 shift
-exec "$@"
+exec bash "$@"
 STUB
 
 # chown / find never really run here; what matters is WHETHER they were called.
+# CHOWN_FAIL makes the stub exit non-zero, standing in for the real thing's
+# "kept going past per-entry errors, still processed the parents, exited 1".
 cat > "${BIN}/chown" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "${CHOWN_LOG}"
+[ -n "${CHOWN_FAIL:-}" ] && exit 1
 exit 0
 STUB
 cat > "${BIN}/find" <<'STUB'
@@ -96,10 +114,11 @@ printf '%s\n' "$*" >> "${FIND_LOG}"
 exit 0
 STUB
 
-# Scripted ownership. FAKE_OWNERS names a TSV of "<path>\t<owner>" lines; any
-# path not listed is owned by `alissa`. Unset FAKE_OWNERS => the real stat.
-# Every invocation is appended to STAT_LOG, which is how the probe's cost (one
-# call per target, depth-1 paths only) becomes an assertion instead of a claim.
+# Scripted ownership. FAKE_OWNERS names a TSV of "<path>\t<owner>[:<group>]"
+# lines; a bare owner means owner:owner, and any path not listed is
+# `alissa:alissa`. Unset FAKE_OWNERS => the real stat. Every invocation is
+# appended to STAT_LOG, which is how the probe's cost (one call per target,
+# depth-1 paths only) becomes an assertion instead of a claim.
 cat > "${BIN}/stat" <<STUB
 #!/usr/bin/env bash
 if [ -z "\${FAKE_OWNERS:-}" ]; then
@@ -108,10 +127,14 @@ fi
 printf '%s\n' "\$*" >> "\${STAT_LOG}"
 for arg in "\$@"; do
   case "\${arg}" in
-    -*|'%U') continue ;;
+    -*|%*) continue ;;   # the -c flag and its format
   esac
   owner="\$(awk -F'\t' -v p="\${arg}" '\$1==p{print \$2; exit}' "\${FAKE_OWNERS}")"
   [ -n "\${owner}" ] || owner=alissa
+  case "\${owner}" in
+    *:*) ;;
+    *)   owner="\${owner}:\${owner}" ;;
+  esac
   printf '%s\n' "\${owner}"
 done
 exit 0
@@ -194,12 +217,12 @@ run_boot() {
 chowned_workspace() { grep -qF -- "-R alissa:alissa ${WORKSPACE}" "${CHOWN_LOG}"; }
 
 # --- 1. warm boot: the whole volume is already alissa-owned ------------------
-info "1. warm boot (everything alissa-owned) -> no recursive walk"
+info "1. warm boot (everything alissa:alissa) -> no recursive walk"
 : > "${TMPROOT}/owners-warm.tsv"
 run_boot warm FAKE_OWNERS="${TMPROOT}/owners-warm.tsv"
 if chowned_workspace; then bad "the recursive chown must NOT run on a warm boot"
 else pass "no recursive chown of the workspace mount"; fi
-assert_contains "${LOG}" "already owned by alissa — skipping the recursive chown" \
+assert_contains "${LOG}" "already owned by alissa:alissa — skipping the recursive chown" \
   "the log says the walk was skipped, and how to force it"
 if [ ! -s "${FIND_LOG}" ]; then pass "no \`find\` sweep (it would stat every inode too)"
 else bad "the probe shelled out to find: $(cat "${FIND_LOG}")"; fi
@@ -224,7 +247,7 @@ printf '%s\t%s\n' "$(case_workspace child-root)/fahera-mx" root > "${TMPROOT}/ow
 run_boot child-root FAKE_OWNERS="${TMPROOT}/owners-child.tsv"
 if chowned_workspace; then pass "the recursive chown of the mount ran"
 else bad "a root-owned child must trigger the full chown"; fi
-assert_contains "${LOG}" "probe found entries not owned by alissa" \
+assert_contains "${LOG}" "probe found entries that are not alissa:alissa" \
   "the log says why the walk ran"
 
 # --- 3. the mount point itself is root-owned (first boot) --------------------
@@ -271,6 +294,46 @@ else
   if chowned_workspace; then pass "tree really owned by ${REAL_OWNER} (not alissa) -> walked"
   else bad "a tree owned by ${REAL_OWNER} must trigger the walk"; fi
 fi
+
+# --- 7. the two targets are decided independently -----------------------------
+info ""
+info "7. the tmux dir is root-owned, the workspace is clean -> only the tmux dir walks"
+# The whole point of probing per target: the tmux dir is a handful of sockets,
+# the volume is millions of inodes, and one dirty socket dir must not buy the
+# volume's walk. A combined `chown -R ... "${WORKSPACE_ROOT}" "${TMUX_DIR}"`
+# repair passes every case above and fails this one.
+printf '%s\t%s\n' "${TMPROOT}/tmux-only/tmux" root > "${TMPROOT}/owners-tmux.tsv"
+run_boot tmux-only FAKE_OWNERS="${TMPROOT}/owners-tmux.tsv"
+if chowned_workspace; then bad "the workspace must NOT be dragged into the tmux dir's walk"
+else pass "the workspace is left alone"; fi
+if grep -qF -- "-R alissa:alissa ${TMPROOT}/tmux-only/tmux" "${CHOWN_LOG}"; then
+  pass "...while the tmux dir walks on its own"
+else
+  bad "the root-owned tmux dir should have been walked: $(cat "${CHOWN_LOG}")"
+fi
+
+# --- 8. the group half of the invariant --------------------------------------
+info ""
+info "8. a depth-1 child at alissa:root -> the full chown runs"
+# The walk asserts alissa:alissa, so the probe must too. Probing only %U would
+# read this tree as clean — and this PR removed the unconditional every-boot
+# walk that used to be the group's only repair path.
+printf '%s\t%s\n' "$(case_workspace group-drift)/.revloop" alissa:root > "${TMPROOT}/owners-group.tsv"
+run_boot group-drift FAKE_OWNERS="${TMPROOT}/owners-group.tsv"
+if chowned_workspace; then pass "a foreign GROUP triggers the walk, like a foreign owner"
+else bad "alissa:root must not read as clean — the walk sets owner AND group"; fi
+
+# --- 9. a failed walk is loud ------------------------------------------------
+info ""
+info "9. the recursive chown fails -> the boot warns and continues"
+printf '%s\t%s\n' "$(case_workspace chown-fails)" root > "${TMPROOT}/owners-fail.tsv"
+run_boot chown-fails FAKE_OWNERS="${TMPROOT}/owners-fail.tsv" CHOWN_FAIL=1
+assert_contains "${LOG}" "WARNING: chown -R" "the failure is reported, not swallowed"
+assert_contains "${LOG}" "Re-deploy once with ALISSA_FORCE_CHOWN=1" \
+  "...with the operator's remedy named"
+assert_contains "${LOG}" "may still be foreign-owned" \
+  "...and the reason it matters: a deep failure leaves the probe reading clean"
+assert_contains "${LOG}" "[entrypoint] role: " "step 0 does not die on a failed walk"
 
 info ""
 [ "${fail}" = "0" ] && { echo "ALL PASS"; exit 0; } || { echo "FAILURES"; exit 1; }

--- a/docker/claude/tests-entrypoint-chown.sh
+++ b/docker/claude/tests-entrypoint-chown.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Tests for the entrypoint's GUARDED boot-time chown (#78).
+#
+# The defect: step 0 ran `chown -R alissa:alissa ${WORKSPACE_ROOT}` on EVERY
+# boot. The walk stats every inode of every worktree hub on the persistent
+# volume, and the dentry/inode slab it fills is charged to the container cgroup
+# — a 2026-08-09 audit of the Railway service found memory.current at ~5.98 GB
+# against 176 MB of real RSS, 3.71 GB of it slab_reclaimable from this walk.
+# On a warm restart the walk fixes nothing: the volume is already alissa-owned.
+#
+# The contract this pins:
+#
+#   1. warm boot (probe finds everything alissa-owned) -> NO recursive chown,
+#      and the probe stays O(top-level entries): one stat per target, never a
+#      `find`, never a depth-2 path
+#   2. a root-owned entry among the mount's depth-1 CHILDREN -> full chown runs
+#   3. the mount point ITSELF root-owned (the first-boot case) -> full chown runs
+#   4. ALISSA_FORCE_CHOWN=1 -> full chown runs with everything alissa-owned, and
+#      the probe is skipped entirely (the escape hatch for root-owned files
+#      deeper than the probe can see)
+#   5. ALISSA_FORCE_CHOWN=0 -> back to the probe (the flag is off by default)
+#   6. the probe against the REAL filesystem and the REAL stat, with the outcome
+#      derived from the tree's actual owner — so a stub that lies about stat's
+#      interface cannot make cases 1-5 pass on their own
+#
+# HOW (no docker, no root — CI has neither): this boots the REAL entrypoint.sh
+# with the commands its root phase shells out to replaced by stubs.
+#   * `id -u` answers 0 ONCE, so the root phase runs; the re-exec then sees the
+#     real uid, exactly like the post-gosu pass in the container
+#   * `gosu` drops its user argument and execs, standing in for the privilege drop
+#   * `chown` and `find` record their arguments instead of running (a non-root
+#     test cannot chown, and `find` must never be called at all)
+#   * `stat` answers scripted ownership per path (cases 1-5) or is the real stat
+#     (case 6), and records every invocation so the probe's COST is assertable
+#
+# Usage: bash docker/claude/tests-entrypoint-chown.sh
+# Needs: bash, awk, coreutils.
+# =============================================================================
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENTRYPOINT="${HERE}/entrypoint.sh"
+REAL_STAT="$(command -v stat)"
+
+fail=0
+pass() { printf '  ok   %s\n' "$1"; }
+bad()  { printf '  FAIL %s\n' "$1" >&2; fail=1; }
+info() { printf '%s\n' "$*"; }
+
+assert_contains() {
+  if grep -qF -- "$2" "$1"; then pass "$3"; else bad "$3 (not in $1: $2)"; fi
+}
+assert_not_contains() {
+  if grep -qF -- "$2" "$1"; then bad "$3 (unexpected in $1: $2)"; else pass "$3"; fi
+}
+
+TMPROOT="$(mktemp -d)"
+BIN="${TMPROOT}/bin"; mkdir -p "${BIN}"
+FAKE_HOME="${TMPROOT}/home"; mkdir -p "${FAKE_HOME}/.config/alissa"
+cp "${HERE}/agents.yaml" "${FAKE_HOME}/.config/alissa/agents.yaml"
+cleanup() { rm -rf "${TMPROOT}"; }
+trap cleanup EXIT
+
+# --- stubs -------------------------------------------------------------------
+
+# `id -u` is the root gate. Answer 0 exactly once (the pre-drop pass) and defer
+# to the real id afterwards, so the script takes the root branch and then
+# behaves like the unprivileged re-exec.
+cat > "${BIN}/id" <<STUB
+#!/usr/bin/env bash
+if [ "\${1:-}" = "-u" ] && [ ! -e "\${ROOT_PASS_DONE}" ]; then
+  : > "\${ROOT_PASS_DONE}"
+  echo 0
+  exit 0
+fi
+exec $(command -v id) "\$@"
+STUB
+
+# The privilege drop: `gosu <user> <cmd...>` -> run <cmd...> as who we already are.
+cat > "${BIN}/gosu" <<'STUB'
+#!/usr/bin/env bash
+shift
+exec "$@"
+STUB
+
+# chown / find never really run here; what matters is WHETHER they were called.
+cat > "${BIN}/chown" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${CHOWN_LOG}"
+exit 0
+STUB
+cat > "${BIN}/find" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FIND_LOG}"
+exit 0
+STUB
+
+# Scripted ownership. FAKE_OWNERS names a TSV of "<path>\t<owner>" lines; any
+# path not listed is owned by `alissa`. Unset FAKE_OWNERS => the real stat.
+# Every invocation is appended to STAT_LOG, which is how the probe's cost (one
+# call per target, depth-1 paths only) becomes an assertion instead of a claim.
+cat > "${BIN}/stat" <<STUB
+#!/usr/bin/env bash
+if [ -z "\${FAKE_OWNERS:-}" ]; then
+  exec ${REAL_STAT} "\$@"
+fi
+printf '%s\n' "\$*" >> "\${STAT_LOG}"
+for arg in "\$@"; do
+  case "\${arg}" in
+    -*|'%U') continue ;;
+  esac
+  owner="\$(awk -F'\t' -v p="\${arg}" '\$1==p{print \$2; exit}' "\${FAKE_OWNERS}")"
+  [ -n "\${owner}" ] || owner=alissa
+  printf '%s\n' "\${owner}"
+done
+exit 0
+STUB
+
+# The identities the boot preflights, and the daemon it ends up running. None of
+# them is under test here — every assertion is about the root phase — so they
+# only have to be credible enough to get past their gates.
+cat > "${BIN}/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  "api user -q .login") echo alissa-app ;;
+esac
+exit 0
+STUB
+cat > "${BIN}/alissa" <<'STUB'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "worker status") echo "worker is running" ;;
+esac
+exit 0
+STUB
+cat > "${BIN}/alissa-revloop" <<'STUB'
+#!/usr/bin/env bash
+trap 'exit 0' TERM INT
+sleep 600 &
+wait $!
+STUB
+chmod 0755 "${BIN}"/*
+
+# --- harness -----------------------------------------------------------------
+
+# run_boot <case-name> [env assignments...]
+#
+# Builds a fresh workspace tree for the case, boots the entrypoint through the
+# fake root pass, and stops it once the drop has happened (the marker line
+# "role: " is the first thing the unprivileged pass logs, so it proves the root
+# phase completed AND that we are past it). Exports, per case:
+#   WORKSPACE  the mount point       LOG        the boot log
+#   CHOWN_LOG  chown invocations     STAT_LOG   stat invocations
+#   FIND_LOG   find invocations
+case_workspace() { printf '%s\n' "${TMPROOT}/$1/workspace"; }
+
+run_boot() {
+  local name="$1"; shift
+  local case_dir="${TMPROOT}/${name}"
+  WORKSPACE="$(case_workspace "${name}")"
+  LOG="${case_dir}/boot.log"
+  CHOWN_LOG="${case_dir}/chown.log"
+  STAT_LOG="${case_dir}/stat.log"
+  FIND_LOG="${case_dir}/find.log"
+  mkdir -p "${WORKSPACE}/fahera-mx" "${WORKSPACE}/.revloop" "${case_dir}/tmux"
+  : > "${CHOWN_LOG}"; : > "${STAT_LOG}"; : > "${FIND_LOG}"
+
+  env -i \
+    PATH="${BIN}:/usr/local/bin:/usr/bin:/bin" \
+    HOME="${FAKE_HOME}" \
+    TMUX_TMPDIR="${case_dir}/tmux" \
+    ALISSA_WORKSPACE_ROOT="${WORKSPACE}" \
+    ROOT_PASS_DONE="${case_dir}/root-pass-done" \
+    CHOWN_LOG="${CHOWN_LOG}" \
+    STAT_LOG="${STAT_LOG}" \
+    FIND_LOG="${FIND_LOG}" \
+    GH_TOKEN=stub-gh-token \
+    ALISSA_API_TOKEN=stub-alissa-token \
+    ALISSA_REVIEW_REPOS="fahera-mx/example-repo" \
+    "$@" \
+    bash "${ENTRYPOINT}" > "${LOG}" 2>&1 &
+  local pid=$! i
+  for i in $(seq 1 30); do
+    grep -qF "[entrypoint] role: " "${LOG}" && break
+    kill -0 "${pid}" 2>/dev/null || break
+    sleep 1
+  done
+  kill -TERM "${pid}" 2>/dev/null || true
+  wait "${pid}" 2>/dev/null || true
+}
+
+# Did the recursive chown of the workspace mount run?
+chowned_workspace() { grep -qF -- "-R alissa:alissa ${WORKSPACE}" "${CHOWN_LOG}"; }
+
+# --- 1. warm boot: the whole volume is already alissa-owned ------------------
+info "1. warm boot (everything alissa-owned) -> no recursive walk"
+: > "${TMPROOT}/owners-warm.tsv"
+run_boot warm FAKE_OWNERS="${TMPROOT}/owners-warm.tsv"
+if chowned_workspace; then bad "the recursive chown must NOT run on a warm boot"
+else pass "no recursive chown of the workspace mount"; fi
+assert_contains "${LOG}" "already owned by alissa — skipping the recursive chown" \
+  "the log says the walk was skipped, and how to force it"
+if [ ! -s "${FIND_LOG}" ]; then pass "no \`find\` sweep (it would stat every inode too)"
+else bad "the probe shelled out to find: $(cat "${FIND_LOG}")"; fi
+# O(top-level entries): one stat call per target, and nothing below depth 1.
+if [ "$(wc -l < "${STAT_LOG}")" = "2" ]; then
+  pass "the probe cost exactly one stat call per target (workspace + tmux dir)"
+else
+  bad "expected 2 stat calls, got $(wc -l < "${STAT_LOG}"): $(cat "${STAT_LOG}")"
+fi
+if grep -qF -- "${WORKSPACE}/fahera-mx/" "${STAT_LOG}"; then
+  bad "the probe descended past depth 1 (that is the walk it exists to avoid)"
+else
+  pass "the probe never looked below the mount's immediate children"
+fi
+assert_contains "${STAT_LOG}" "${WORKSPACE}/.revloop" \
+  "...but it DID probe the depth-1 children, dotted ones included"
+
+# --- 2. a root-owned child of the mount --------------------------------------
+info ""
+info "2. a depth-1 child is root-owned -> the full chown runs"
+printf '%s\t%s\n' "$(case_workspace child-root)/fahera-mx" root > "${TMPROOT}/owners-child.tsv"
+run_boot child-root FAKE_OWNERS="${TMPROOT}/owners-child.tsv"
+if chowned_workspace; then pass "the recursive chown of the mount ran"
+else bad "a root-owned child must trigger the full chown"; fi
+assert_contains "${LOG}" "probe found entries not owned by alissa" \
+  "the log says why the walk ran"
+
+# --- 3. the mount point itself is root-owned (first boot) --------------------
+info ""
+info "3. the mount point itself is root-owned (fresh volume) -> the full chown runs"
+printf '%s\t%s\n' "$(case_workspace mount-root)" root > "${TMPROOT}/owners-mount.tsv"
+run_boot mount-root FAKE_OWNERS="${TMPROOT}/owners-mount.tsv"
+if chowned_workspace; then pass "first-boot behaviour is unchanged: the full chown still runs"
+else bad "a root-owned mount point must trigger the full chown"; fi
+
+# --- 4. the escape hatch -----------------------------------------------------
+info ""
+info "4. ALISSA_FORCE_CHOWN=1 -> the walk runs even though the probe would skip it"
+: > "${TMPROOT}/owners-force.tsv"
+run_boot force FAKE_OWNERS="${TMPROOT}/owners-force.tsv" ALISSA_FORCE_CHOWN=1
+if chowned_workspace; then pass "the recursive chown ran on an alissa-owned tree"
+else bad "ALISSA_FORCE_CHOWN=1 must force the walk"; fi
+assert_contains "${LOG}" "ALISSA_FORCE_CHOWN=1 — forcing the full recursive chown" \
+  "the log announces the forced walk"
+assert_contains "${LOG}" "(forced)" "...and attributes the walk to the flag, not the probe"
+if [ ! -s "${STAT_LOG}" ]; then pass "the probe is skipped entirely when forced"
+else bad "forced boot still probed: $(cat "${STAT_LOG}")"; fi
+
+# --- 5. the flag is off by default -------------------------------------------
+info ""
+info "5. ALISSA_FORCE_CHOWN=0 -> back to the probe"
+: > "${TMPROOT}/owners-off.tsv"
+run_boot force-off FAKE_OWNERS="${TMPROOT}/owners-off.tsv" ALISSA_FORCE_CHOWN=0
+if chowned_workspace; then bad "ALISSA_FORCE_CHOWN=0 must not force the walk"
+else pass "no recursive chown"; fi
+assert_not_contains "${LOG}" "forcing the full recursive chown" "no forced-walk banner"
+
+# --- 6. the real stat, against the real filesystem ---------------------------
+info ""
+info "6. real stat, real tree -> the outcome follows the tree's actual owner"
+run_boot real-stat
+REAL_OWNER="$(${REAL_STAT} -c '%U' "${WORKSPACE}")"
+if [ "${REAL_OWNER}" = "alissa" ]; then
+  # The container this repo builds runs as `alissa`, so a local run lands here.
+  if chowned_workspace; then bad "a genuinely alissa-owned tree must skip the walk"
+  else pass "tree really owned by alissa -> skipped"; fi
+else
+  # CI runs as `runner`; every entry is foreign, which is the first-boot shape.
+  if chowned_workspace; then pass "tree really owned by ${REAL_OWNER} (not alissa) -> walked"
+  else bad "a tree owned by ${REAL_OWNER} must trigger the walk"; fi
+fi
+
+info ""
+[ "${fail}" = "0" ] && { echo "ALL PASS"; exit 0; } || { echo "FAILURES"; exit 1; }


### PR DESCRIPTION
Follow-up to PR #79 (round 1), which was approved carrying three `[minor]` findings and one
`[nit]`. All four were triaged `[triage:pursue]` on their threads; an approved branch must not
take another commit, so they land here.

**Source PR:** #79 · **review round:** 1 · **reviewer:** alissa-app
**Origin task:** TASK-357393641 · **Implementation task:** TASK-1002979593

Follow-up-To: #79

> **MERGE ORDER — merge #79 first.** This branch is cut from #79's approved head
> (`7d91b8e`), not from `main`, because every line it touches is introduced by that PR: the
> probe function, the guard block, the new test suite, and the README section do not exist on
> `main` yet, so a branch off `main` could not carry these fixes at all. GitHub's diff against
> `main` therefore shows #79's changes too; the review surface of *this* PR is the single
> commit `7d91b8e..HEAD`. Merging this one **first** would squash #79's whole delta into `main`
> under this commit message and leave #79 resolving as empty — losing its history and its
> issue-closing claim. This PR closes no issue by design.

## What changed

* **`[minor]` probe tested the owner, the walk sets owner *and* group.** `stat -c '%U:%G'`
  compared against `alissa:alissa`. An `alissa:root` entry used to read as clean, and #79 is
  what removed the unconditional every-boot walk that had been the group's only repair path.
  Same single `stat` call, so the guard's cost argument is untouched.
* **`[minor]` a failed walk was swallowed.** `chown -R` is post-order and continues past
  per-entry errors, so a walk that fails deep still leaves depths 0 and 1 owned by `alissa` —
  precisely the surface the probe inspects — and every later boot then reads clean with nothing
  in the log. The exit status is now branched on and a `WARNING` naming the target and
  `ALISSA_FORCE_CHOWN=1` is logged. `|| true` semantics stay (step 0 must not die) and stderr
  stays suppressed so a per-entry error storm cannot flood the boot log.
* **`[minor]` per-target independence was unpinned.** The reviewer's mutation — one combined
  `chown -R … "${WORKSPACE_ROOT}" "${TMUX_DIR}"` — reinstated the volume walk with all six
  cases still green. Case 7 (tmux dir root-owned, workspace clean) closes that quadrant.
* **`[nit]` README row said `1` for an `is_truthy` gate.** Now `1`/`true`/`yes`/`on`, matching
  the `ALISSA_UI_ENABLED` row, which is what keeps the deliberately narrow
  `ALISSA_ENABLE_FIREWALL` legible as a choice.
* **Documentation of the invariant the design leans on:** `chown -R` chowning the mount point
  **last** is why an interrupted first boot self-heals. Recorded in the block comment as a
  warning to the next editor, and in the README alongside the failed-walk behaviour.

## Round-1 verdict on this PR: approve, findings deferred

Approved by alissa-app carrying two `[minor]` and two `[nit]`. All four are triaged
`[triage:later]` on their threads and registered as **TASK-313195870** (soft-dependent on
TASK-1002979593): the test harness leaks one backgrounded `sleep` per boot now that the
post-drop pass actually runs; the `workspace mount … owned by alissa` summary line
contradicts the new `WARNING` on a failed walk and no case asserts it; the warning's tail
advises `ALISSA_FORCE_CHOWN=1` even when the *forced* walk is what failed, and over-claims
"will read this tree as clean" where "may" is accurate; and the settings-table row still
describes the probe as finding "a foreign owner" when this PR made it owner **and** group.

Deferred rather than stacked: #79 and #80 are both approved and unmerged, so a third PR
would have to be cut from this branch's head and would impose an exact #79 → #80 → #81
merge order — where getting it wrong squash-merges an earlier PR's whole delta under a
later PR's message. Four diagnostics-and-docs findings do not justify that risk. None of
them changes the guard's behaviour.

## Delivery notes

### Judgment calls

* **All four findings in one follow-up PR, not four.** They touch the same three files and the
  same guard; splitting them would force the operator into a four-way merge ordering for one
  round's findings. Level-three stacking was avoided deliberately — nothing here stacks on
  anything but #79.
* **Branch cut from #79's approved head rather than `main`.** Stated as a merge gate above. The
  convention's "off the default branch" protects the approved head from *moving*; cutting a new
  branch from it does not move it, and the alternative is unbuildable (add/add on files #79
  introduces). Base is `main`, as required.
* **`|| true` kept, status not.** The reviewer's own suggestion. Step 0 dying on a partial chown
  would be a worse failure than the silent latch it replaces; the warning is the signal.
* **stderr stays `2>/dev/null`.** A deep permission-error storm would otherwise be thousands of
  lines in the boot log. The exit status carries the one bit an operator needs, and the warning
  names the remedy.
* **The `[nit]` was implemented, not deferred.** It was one table cell in a file this PR already
  touches, so deferring it to a registered task would have cost more than the fix.
* **Harness flaw found and fixed while adding case 9, disclosed rather than quietly patched.**
  The `gosu` stub in #79's suite exec'd `entrypoint.sh` directly, but that file is mode 644 in
  the repo (the Dockerfile chmods it into the image), so the post-drop pass died with
  "Permission denied" on every case. Nothing caught it because every assertion in the suite is
  about the root phase, which runs *before* the drop — the boots were valid for what they
  asserted, and no result in #79's notes is invalidated by this. The stub now execs through
  `bash` (as `run_boot` already did) and case 9 asserts the boot reaches the post-drop role
  line, so the same silent death cannot recur.

### Not verified — operator's gate

* [ ] **Everything in #79's not-verified list still stands** and is not repeated here: the
  Railway memory measurement on a warm volume, first boot on a cold root-owned volume,
  `ALISSA_FORCE_CHOWN=1` on the real service, and the fact that no image was built (no docker
  in this environment).
* [ ] **The group half was never exercised against a real `alissa:root` file** — creating one
  needs root, which this environment and CI both lack. Case 8 drives it through scripted
  ownership; the real-`stat` case (6) only covers owner drift.
* [ ] **The new `WARNING` has never fired against a real failing `chown -R`** — case 9 forces a
  non-zero exit from the stub. The underlying claims about real `chown -R` (post-order,
  continues past per-entry errors, still processes the parents, exits 1) were reproduced
  locally on GNU coreutils 9.1, but on this host's filesystem, not on a Railway volume.
* [ ] **Nothing here changes the deploy-side acceptance criterion of issue #78**, which remains
  the operator's measurement after the merge of both PRs.

### Verification

* `docker/claude/tests-entrypoint-chown.sh` — **ALL PASS**, 9 cases (was 6).
  Each new case counterfactually checked against a mutation of the narrowest clause, in a
  scratch copy: the reviewer's combined-`chown` mutation fails case 7 only; a probe that
  ignores the group (`${owner%%:*}`) fails case 8 only; restoring `|| true` on the chown fails
  case 9. The pre-existing mutations from #79 (probe always clean / always walk) were re-run
  and still fail their cases.
* `tests-entrypoint-config.sh`, `-identity.sh`, `-auth.sh`, `-executor.sh`, `-ui.sh` — all
  PASS on this head (the entrypoint changed, so all five were re-run, not just the new one).
* `chown -R` behaviour reproduced directly (GNU coreutils 9.1): `-v` output shows
  `deep → sub → top` ordering, and a run failing on an unreadable child still processes the
  parent and exits 1.
* `bash -n docker/claude/entrypoint.sh` — clean. No shellcheck in this repo's CI or in this
  environment.
* No Python touched, so the package suites and `check-version-bump` do not apply.

### Scope touched

* `docker/claude/entrypoint.sh` — `%U:%G` probe, chown status branch + `WARNING`, block-comment
  documentation of the post-order invariant and the exact blind spot.
* `docker/claude/tests-entrypoint-chown.sh` — cases 7/8/9, `owner:group` stub, `CHOWN_FAIL`
  hook, the `gosu`-through-`bash` fix, tightened remedy assertion in case 9.
* `docker/claude/README.md` — the `is_truthy` values in the settings row, owner+group in the
  probe description, the failed/interrupted-walk paragraph, step 0b wording.
* No excursion: no workflow, Dockerfile, or Python file is touched — the new cases run inside
  the step #79 already added to `check-entrypoint`.
