### PR TITLE
TASK-190865621: wire `alissa code workspace prune` into the revloop entrypoint (issue #81)

### DIFF
--- a/.github/workflows/check-entrypoint.yaml
+++ b/.github/workflows/check-entrypoint.yaml
@@ -17,6 +17,9 @@ on: [pull_request]
 #   * the bridge-executor role (CONTAINER_ROLE / ALISSA_BRIDGE_* gate, executor
 #     identity, and the guarantee that neither role starts the other's
 #     supervisor) — docker/claude/tests-entrypoint-executor.sh;
+#   * the workspace-prune wiring (boot pass + supervised interval loop,
+#     default-on with an opt-out, capability-gated, --force never passed) —
+#     docker/claude/tests-entrypoint-prune.sh;
 #   * the guarded boot-time chown (warm boot skips the volume walk, a root-owned
 #     probe result or ALISSA_FORCE_CHOWN=1 still runs it) —
 #     docker/claude/tests-entrypoint-chown.sh.
@@ -93,6 +96,17 @@ jobs:
         # claim; the last case runs against the real stat and the real tree.
         timeout-minutes: 4
         run: bash docker/claude/tests-entrypoint-chown.sh
+      - name: Execute Entrypoint Workspace-Prune Tests
+        # Boots the entrypoint six times against an `alissa` stub that records
+        # every `code workspace prune` invocation with its argv AND its cwd —
+        # which is what makes "--force is never passed" and "an old CLI runs
+        # nothing" assertions rather than claims. The stub reproduces
+        # commander's real behaviour for an unknown subcommand (parent help,
+        # exit 0), so the capability probe is tested against the trap it exists
+        # for. Two cases wait out several ticks of the test-only seconds
+        # override, hence the headroom.
+        timeout-minutes: 6
+        run: bash docker/claude/tests-entrypoint-prune.sh
       - name: Execute Entrypoint Console Wiring Tests
         # Boots the entrypoint four times (console off / enabled-without-passcode
         # / enabled / sidecar killed under it). No docker needed: the CLIs the

--- a/.github/workflows/check-entrypoint.yaml
+++ b/.github/workflows/check-entrypoint.yaml
@@ -103,8 +103,8 @@ jobs:
         # nothing" assertions rather than claims. The stub reproduces
         # commander's real behaviour for an unknown subcommand (parent help,
         # exit 0), so the capability probe is tested against the trap it exists
-        # for. Two cases wait out several ticks of the test-only seconds
-        # override, hence the headroom.
+        # for. Three cases wait out several ticks of the test-only seconds
+        # override or a real `timeout` firing, hence the headroom.
         timeout-minutes: 6
         run: bash docker/claude/tests-entrypoint-prune.sh
       - name: Execute Entrypoint Console Wiring Tests

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -237,6 +237,7 @@ automatically; locally pass `--build-arg`):
 | `ALISSA_FORCE_CHOWN` | `0` | `1`/`true`/`yes`/`on` forces the root phase's full `chown -R` of the volume for that boot; anything else (incl. unset) leaves the probe in charge. Off by default: the entrypoint probes ownership at depth 1 and walks only when it finds a foreign owner (see [Boot-time ownership](#boot-time-ownership-the-volume-walk-is-guarded)). Set it for **one** boot after a root shell wrote files deeper in the tree |
 | `ALISSA_WORKSPACE_PRUNE` | `1` (**on**) | volume hygiene: `1`/`true`/`yes`/`on` runs `alissa code workspace prune` at boot **and** on an interval; `0` opts out, after which nothing in the container reclaims anything. Default-on because this is the container whose volume grows (see [Volume hygiene](#volume-hygiene-finished-worktrees-are-pruned)). Skipped, with one loud warning, if the installed CLI predates the subcommand |
 | `ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES` | `360` | minutes between prune passes. Daemon role only — the executor gets the boot pass and no loop. A non-numeric or non-positive value warns and falls back to `360` |
+| `ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS` | `900` | how long ONE prune pass may run before it is killed, so a slow first sweep over a never-pruned volume cannot hold the boot open. A timed-out pass warns (exit 124) and changes nothing. Garbage falls back to `900` |
 | `ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS` | *(CLI default)* | passed straight through as `--min-age-hours`; **pass-through** — unset ⇒ the CLI's own age gate. A value that is not a whole number of hours **disables prune for that boot** instead of falling back (the CLI's default gate may be *shorter* than the one you asked for) |
 
 #### Config precedence: env var > daemon library default
@@ -352,6 +353,25 @@ safe to leave on by default:
   gets the boot pass — it grows the same volume the same way — but not the loop:
   that role `exec`s `alissa bridge start`, which replaces the shell, so a loop
   started there would outlive the only code that knows how to stop it.
+
+**A pass cannot hold the boot open.** The boot hook runs before `alissa worker`
+starts, and the first pass after the CLI lands sweeps `git gc --auto` across hubs
+on a volume that has never had anything reclaimed — minutes of work on a large
+object store, and on a platform with a startup health-check window a slow enough
+boot is a *dead* boot. So a pass runs under `timeout`
+(`ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS`, default 900) with **stdin closed**, and
+a pass that hits either bound lands in the same warning path as any other
+failure. The neighbouring `alissa code workspace sync` is deliberately *not*
+bounded this way: hubs are a precondition for reviewing anything, while prune is
+an optimization, and only one of those may delay a boot.
+
+> **`ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS` is test-only — do not set it in a
+> deploy.** `docker/claude/tests-entrypoint-prune.sh` has to watch the loop tick
+> more than once, and the smallest cadence the supported knob can express is a
+> minute. It silently overrides
+> `ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES`, and the boot log then reads
+> `starting the workspace prune loop (every 360 min = 3s)` — which is what you
+> will find first if it is ever set by accident.
 
 If you turn this off (`ALISSA_WORKSPACE_PRUNE=0`), nothing else reclaims the
 volume; plan on pruning by hand.
@@ -783,11 +803,12 @@ volumes:
    daemon's on-demand `alissa code workspace add` no-ops on a repo already listed
    in the manifest, leaving an empty folder and looping forever hub-ifying a hub
    that never completes.
-3b. **`alissa code workspace prune`** — best-effort volume hygiene, on the path
+3c-ii. **`alissa code workspace prune`** — best-effort volume hygiene, on the path
    both roles share: remove finished-branch worktrees (never `main/`, never
    dirty, never an open PR, never `--force`) and run the hub-level git prune/gc.
    Skipped with one loud warning if the CLI predates the subcommand, or if
-   `ALISSA_WORKSPACE_PRUNE=0`. A failure here is a warning, never a dead boot
+   `ALISSA_WORKSPACE_PRUNE=0`, and bounded by `timeout` with stdin closed so a
+   slow or prompting pass cannot hold the boot open. A failure here is a warning, never a dead boot
    ([why](#volume-hygiene-finished-worktrees-are-pruned)).
 3d. **Executor role only, and the end of the shared path**: drop this executor's
    stale lockfile, then `exec alissa bridge

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -235,6 +235,9 @@ automatically; locally pass `--build-arg`):
 | `ALISSA_ENABLE_FIREWALL` | `0` | `1` raises the egress firewall (needs `--cap-add=NET_ADMIN`) |
 | `ALISSA_FIREWALL_EXTRA` | *(empty)* | extra firewall allowlist hosts, space-separated |
 | `ALISSA_FORCE_CHOWN` | `0` | `1`/`true`/`yes`/`on` forces the root phase's full `chown -R` of the volume for that boot; anything else (incl. unset) leaves the probe in charge. Off by default: the entrypoint probes ownership at depth 1 and walks only when it finds a foreign owner (see [Boot-time ownership](#boot-time-ownership-the-volume-walk-is-guarded)). Set it for **one** boot after a root shell wrote files deeper in the tree |
+| `ALISSA_WORKSPACE_PRUNE` | `1` (**on**) | volume hygiene: `1`/`true`/`yes`/`on` runs `alissa code workspace prune` at boot **and** on an interval; `0` opts out, after which nothing in the container reclaims anything. Default-on because this is the container whose volume grows (see [Volume hygiene](#volume-hygiene-finished-worktrees-are-pruned)). Skipped, with one loud warning, if the installed CLI predates the subcommand |
+| `ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES` | `360` | minutes between prune passes. Daemon role only — the executor gets the boot pass and no loop. A non-numeric or non-positive value warns and falls back to `360` |
+| `ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS` | *(CLI default)* | passed straight through as `--min-age-hours`; **pass-through** — unset ⇒ the CLI's own age gate. A value that is not a whole number of hours **disables prune for that boot** instead of falling back (the CLI's default gate may be *shorter* than the one you asked for) |
 
 #### Config precedence: env var > daemon library default
 
@@ -302,6 +305,56 @@ Reclaiming the cache after the fact is not an option on Railway: `/sys/fs/cgroup
 is mounted read-only inside the container, so writing `memory.reclaim` fails with
 `EROFS` even as root (verified 2026-08-09). Avoidance is the only lever, which is
 why the entrypoint has no reclaim call.
+
+#### Volume hygiene: finished worktrees are pruned
+
+**The diagnosis.** Until issue #81 this container removed *nothing*, ever. Every
+review round materializes a per-PR worktree inside a hub (`<repo>/TASK-…`), plus
+whatever a session's build or test run leaves in it; a merged or closed PR left
+its worktree exactly where it was; and the bare `.source` object store behind
+each hub only ever grew, because nothing pruned the remote-tracking refs the
+deleted branches left behind. There was no cleanup path anywhere in the image —
+not at boot, not on merge, not on a timer — so the only bound on the volume was
+the volume's size, and the only remedy was a human with a shell.
+
+**The remediation** is the CLI's own primitive, `alissa code workspace prune`,
+which removes finished-branch worktrees behind its safety rails (never `main/`,
+never a dirty tree without `--force`, an age gate, a live-tmux-session guard,
+never a worktree whose PR is still open, and a lookup failure *keeps* the
+worktree) and then runs the hub-level `git worktree prune` /
+`git remote prune origin` / `git gc --auto` sequence. The entrypoint calls it in
+two places:
+
+- **at boot**, right after the hub sync, best-effort — a failure logs a warning
+  and the boot continues, exactly like the other best-effort boot steps. Prune
+  is an optimization, never a boot precondition;
+- **on an interval** (`ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES`, default 360), as
+  a supervised background loop that the shutdown handler kills alongside the
+  console sidecar. A failing pass warns and the loop waits for the next tick; it
+  never takes the container down.
+
+Three properties are worth stating explicitly, because they are what make this
+safe to leave on by default:
+
+- **`--force` is never passed, and there is no env knob that adds it.** In a
+  review container a dirty worktree is *evidence* — a session that died
+  mid-round with work someone may still want. The rail that keeps it is the one
+  this container needs most.
+- **It is capability-gated, not version-pinned.** The image installs the alissa
+  CLI from its install channel, which may predate the subcommand. The entrypoint
+  probes once at boot and, if the subcommand is missing, logs exactly one loud
+  `WARN: this alissa CLI predates 'alissa code workspace prune' …` and skips
+  *both* hooks. Nothing here needs to change when the CLI catches up. (The probe
+  reads the help *output*, not its exit status: commander answers an unknown
+  subcommand by printing the parent command's help and exiting `0`, so an
+  exit-status probe would call every old CLI capable.)
+- **The interval loop is daemon-only.** The [executor role](#bridge-executor-role-a-second-service-from-this-same-image)
+  gets the boot pass — it grows the same volume the same way — but not the loop:
+  that role `exec`s `alissa bridge start`, which replaces the shell, so a loop
+  started there would outlive the only code that knows how to stop it.
+
+If you turn this off (`ALISSA_WORKSPACE_PRUNE=0`), nothing else reclaims the
+volume; plan on pruning by hand.
 
 ### Reviewer console (runtime env only — `ALISSA_UI_ENABLED`, `ALISSA_UI_PASSCODE`, `PORT`)
 
@@ -462,6 +515,12 @@ ephemeral home and are gone on restart, so a persisted "round N in-flight" would
 otherwise be stale and stall re-enqueue for 90 min. A fresh container has no
 reviewer running by definition, so clearing them is safe and the daemon
 re-enqueues any still-pending round on its first poll.
+
+The volume is also the thing that **grows**: reviewer worktrees accumulate in
+the hubs and nothing used to remove them. The entrypoint now prunes finished-branch
+worktrees at boot and every `ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES` (default
+360) — see [Volume hygiene](#volume-hygiene-finished-worktrees-are-pruned) for the
+rails it runs behind and `ALISSA_WORKSPACE_PRUNE=0` for the opt-out.
 
 Nothing else needs a volume: the gh/alissa/claude auth is re-established from the
 env tokens on every boot, and tmux sockets are deliberately ephemeral.
@@ -724,6 +783,12 @@ volumes:
    daemon's on-demand `alissa code workspace add` no-ops on a repo already listed
    in the manifest, leaving an empty folder and looping forever hub-ifying a hub
    that never completes.
+3b. **`alissa code workspace prune`** — best-effort volume hygiene, on the path
+   both roles share: remove finished-branch worktrees (never `main/`, never
+   dirty, never an open PR, never `--force`) and run the hub-level git prune/gc.
+   Skipped with one loud warning if the CLI predates the subcommand, or if
+   `ALISSA_WORKSPACE_PRUNE=0`. A failure here is a warning, never a dead boot
+   ([why](#volume-hygiene-finished-worktrees-are-pruned)).
 3d. **Executor role only, and the end of the shared path**: drop this executor's
    stale lockfile, then `exec alissa bridge
    start …`. `exec`, so the container's only process is the executor — steps 4

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -5,8 +5,8 @@
 #   0. as root: fix the volume-mount ownership (+ firewall), then drop to alissa
 #   1. preflight the identities the loop depends on (gh / alissa / claude)
 #   2. bootstrap the worktree-hub workspace + revloop config from a manifest
-#   2b. prune finished worktrees off the volume, then again on an interval
-#       (`alissa code workspace prune`, capability-gated, best-effort)
+#      …then prune finished worktrees off it (3c-ii), and again on an interval
+#      (`alissa code workspace prune`, capability-gated, bounded, best-effort)
 #   3. start `alissa worker` (backgrounded) and wait until it is up
 #   4. optionally start the `alissa-revloop-ui` console sidecar (ALISSA_UI_ENABLED)
 #   5. run `alissa-revloop` in the foreground, stopping the worker on exit
@@ -873,7 +873,7 @@ if [ -f "${MANIFEST}" ]; then
 fi
 
 # -----------------------------------------------------------------------------
-# 3e. Volume hygiene — `alissa code workspace prune` (issue #81).
+# 3c-ii. Volume hygiene — `alissa code workspace prune` (issue #81).
 #
 # Nothing in this container ever removed anything from the volume. Every review
 # round materializes a per-PR worktree in a hub (plus whatever a session's build
@@ -899,6 +899,17 @@ fi
 #     pin here would go stale on every CLI release. An older CLI gets exactly
 #     one loud warning and both hooks skip.
 #
+# CONCURRENCY WITH LIVE REVIEWER SESSIONS, since the interval loop fires into
+# hubs that may be mid-round: the CLI's live-session guard covers WORKTREE
+# REMOVAL, and for the hub-level tail we rely on git's own guarantee rather than
+# on the sweep being session-aware. `git gc --auto` never deletes a reachable
+# object, keeps unreachable ones for `gc.pruneExpire` (2 weeks by default),
+# publishes rewritten packs by atomic rename, and drops loose objects only after
+# that — so a concurrent checkout/commit in a sibling worktree sees a consistent
+# store throughout. What would NOT be safe is a pruning `gc --prune=now`, which
+# this entrypoint never asks for and has no knob to ask for, exactly like
+# `--force`.
+#
 # The interval loop is DAEMON-ONLY, and deliberately so: the executor role
 # `exec`s `alissa bridge start` a few lines below, which replaces this shell —
 # a loop started here would outlive the only code that knows how to stop it and
@@ -908,6 +919,7 @@ fi
 PRUNE_ENABLED=0
 PRUNE_INTERVAL_MINUTES=360
 PRUNE_INTERVAL_SECONDS=$(( 360 * 60 ))
+PRUNE_TIMEOUT_SECONDS=900
 # Never contains `--force`. See the block comment above; the entrypoint has no
 # knob that adds it, which is the point.
 PRUNE_ARGS=()
@@ -933,20 +945,49 @@ workspace_prune_supported() {
 # carry on", and the interval loop runs under this script's `set -e`, where a
 # non-zero return would silently kill the loop instead of the pass.
 #
+# BOUNDED AND STDIN-CLOSED, and that is the boot pass's whole safety story. A
+# failing pass is harmless — the volume simply keeps what it holds — but a pass
+# that BLOCKS would hold the boot open, and this hook runs before the worker
+# starts. Two ways that happens, both closed here rather than at the call site
+# so the interval pass inherits them too:
+#
+#   * the first pass after the CLI lands runs `git gc --auto` across hubs on a
+#     volume that, by this feature's own diagnosis, has never had anything
+#     reclaimed. On a multi-GB object store that is minutes — and on a platform
+#     with a startup health-check window, a slow enough boot IS a dead
+#     container, which is the one outcome this wiring must never cause.
+#   * command substitution inherits stdin, so a CLI that ever prompts would
+#     wait forever on a container that has no tty.
+#
+# A timed-out pass is just another non-zero exit into the WARN path below (124,
+# named there so the log says "timed out" instead of a bare number). This is
+# deliberately NOT how `workspace sync` above is treated: sync is a
+# precondition — no hubs, no reviews — while prune is an optimization, and only
+# one of those may hold a boot open.
+#
 # The CLI's per-worktree verdicts are captured and re-emitted through log(), so
 # they carry the entrypoint prefix and are greppable in the platform's boot log
-# next to everything else this boot did.
+# next to everything else this boot did. They go through redact_token() first:
+# every other captured-CLI-output path in this file does (see the auth triage),
+# prune shells out to git across every hub, and an https hub cloned by the
+# daemon's own on_missing_hub:add path has a credential helper wired in by
+# `gh auth setup-git` at step 1 — a failing `git remote prune origin` is one of
+# the few places that could echo a URL.
 workspace_prune_run() {
   local label="$1" out line rc=0
   # Run from the workspace root: the workspace binding is cwd-based, exactly as
   # for the `workspace sync` above.
-  out="$( cd "${WORKSPACE_ROOT}" && alissa code workspace prune ${PRUNE_ARGS[@]+"${PRUNE_ARGS[@]}"} 2>&1 )" \
+  out="$( cd "${WORKSPACE_ROOT}" \
+          && timeout "${PRUNE_TIMEOUT_SECONDS}" \
+             alissa code workspace prune ${PRUNE_ARGS[@]+"${PRUNE_ARGS[@]}"} </dev/null 2>&1 )" \
     || rc=$?
   if [ -n "${out}" ]; then
-    while IFS= read -r line; do log "prune[${label}]: ${line}"; done <<<"${out}"
+    while IFS= read -r line; do log "prune[${label}]: $(redact_token "${line}")"; done <<<"${out}"
   fi
   if [ "${rc}" = "0" ]; then
     log "workspace prune (${label}) finished"
+  elif [ "${rc}" = "124" ]; then
+    log "WARN: workspace prune (${label}) TIMED OUT after ${PRUNE_TIMEOUT_SECONDS}s and was killed — the boot was not held open, and nothing was removed. A first pass over a never-pruned volume can legitimately need longer: raise ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS."
   else
     log "WARN: workspace prune (${label}) exited ${rc} — nothing was removed by this pass; the volume keeps what it holds until the next one. Check the verdict lines above."
   fi
@@ -981,37 +1022,57 @@ else
 fi
 
 if [ "${PRUNE_ENABLED}" = "1" ]; then
-  # The interval is not a safety knob — a bad one only changes how often a
-  # best-effort pass runs — so a garbage value falls back to the default with a
-  # warning instead of disabling the feature.
-  PRUNE_INTERVAL_MINUTES="${ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES:-360}"
-  if ! printf '%s' "${PRUNE_INTERVAL_MINUTES}" | grep -qE '^[1-9][0-9]*$'; then
-    log "WARN: ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES=${PRUNE_INTERVAL_MINUTES} is not a positive whole number of minutes — falling back to 360"
-    PRUNE_INTERVAL_MINUTES=360
+  # How long ONE pass may run before it is killed — a bound, not a budget. 900s
+  # is generous for a warm volume and still well inside any platform's startup
+  # window. Both roles resolve it, because both run the boot pass. Garbage falls
+  # back to the default with a warning rather than failing closed: a bound that
+  # is merely wrong is still a bound, and disabling the hygiene over a typo
+  # would trade the smaller problem for the larger one.
+  PRUNE_TIMEOUT_SECONDS="${ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS:-900}"
+  if ! printf '%s' "${PRUNE_TIMEOUT_SECONDS}" | grep -qE '^[1-9][0-9]*$'; then
+    log "WARN: ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS=${PRUNE_TIMEOUT_SECONDS} is not a positive whole number of seconds — falling back to 900"
+    PRUNE_TIMEOUT_SECONDS=900
   fi
-  PRUNE_INTERVAL_SECONDS=$(( PRUNE_INTERVAL_MINUTES * 60 ))
 
-  # ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS is TEST-ONLY, on the same footing as
-  # ALISSA_AUTH_RETRY_SECONDS: tests-entrypoint-prune.sh has to watch the loop
-  # tick more than once, and the smallest value the documented knob can express
-  # is a minute per tick. A deploy leaves it unset.
-  if [ -n "${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS:-}" ]; then
-    if printf '%s' "${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS}" | grep -qE '^[1-9][0-9]*$'; then
-      PRUNE_INTERVAL_SECONDS="${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS}"
-      log "workspace prune: interval overridden to ${PRUNE_INTERVAL_SECONDS}s (ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS — test-only)"
-    else
-      log "WARN: ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS=${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS} is not a positive whole number of seconds — ignoring it"
+  if [ "${CONTAINER_ROLE}" = "executor" ]; then
+    # No interval resolution at all in this role: it never reaches 4c, and
+    # validating, defaulting and ANNOUNCING a cadence it will not run would put
+    # two contradicting lines in its boot log.
+    log "workspace prune ENABLED — boot pass only (executor role; min-age: ${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS:-CLI default}, timeout ${PRUNE_TIMEOUT_SECONDS}s, --force never passed). The interval loop belongs to the daemon's process chain: this role 'exec's the bridge, so there would be nothing left here to tear a loop down."
+  else
+    # The interval is not a safety knob — a bad one only changes how often a
+    # best-effort pass runs — so a garbage value falls back to the default with
+    # a warning instead of disabling the feature.
+    PRUNE_INTERVAL_MINUTES="${ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES:-360}"
+    if ! printf '%s' "${PRUNE_INTERVAL_MINUTES}" | grep -qE '^[1-9][0-9]*$'; then
+      log "WARN: ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES=${PRUNE_INTERVAL_MINUTES} is not a positive whole number of minutes — falling back to 360"
+      PRUNE_INTERVAL_MINUTES=360
     fi
+    PRUNE_INTERVAL_SECONDS=$(( PRUNE_INTERVAL_MINUTES * 60 ))
+
+    # ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS is TEST-ONLY, on the same footing
+    # as ALISSA_AUTH_RETRY_SECONDS and ALISSA_INSTALL_URL — and, like them, it
+    # is documented as test-only in docker/claude/README.md rather than only
+    # here: an override a shipped entrypoint honours but no operator can find is
+    # a footgun. tests-entrypoint-prune.sh has to watch the loop tick more than
+    # once, and the smallest cadence the supported knob can express is a minute.
+    # A deploy leaves it unset.
+    if [ -n "${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS:-}" ]; then
+      if printf '%s' "${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS}" | grep -qE '^[1-9][0-9]*$'; then
+        PRUNE_INTERVAL_SECONDS="${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS}"
+        log "workspace prune: interval overridden to ${PRUNE_INTERVAL_SECONDS}s (ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS — test-only, not for a deploy)"
+      else
+        log "WARN: ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS=${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS} is not a positive whole number of seconds — ignoring it"
+      fi
+    fi
+
+    log "workspace prune ENABLED — boot pass now, then every ${PRUNE_INTERVAL_MINUTES} min (min-age: ${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS:-CLI default}, timeout ${PRUNE_TIMEOUT_SECONDS}s, --force never passed)"
   fi
 
-  log "workspace prune ENABLED — boot pass now, then every ${PRUNE_INTERVAL_MINUTES} min (min-age: ${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS:-CLI default}, --force never passed)"
   # Best-effort, exactly like the other boot steps: prune is an optimization,
   # never a boot precondition. workspace_prune_run already swallows the status;
   # the `|| true` is the belt to that suspenders, and says so at the call site.
   workspace_prune_run boot || true
-  if [ "${CONTAINER_ROLE}" = "executor" ]; then
-    log "workspace prune: executor role runs the boot pass only — the interval loop belongs to the daemon's process chain, and this role 'exec's the bridge, leaving nothing here to tear a loop down"
-  fi
 fi
 
 # -----------------------------------------------------------------------------
@@ -1141,11 +1202,11 @@ if [ "${UI_ENABLED}" = "1" ]; then
 fi
 
 # -----------------------------------------------------------------------------
-# 4c. The periodic workspace prune (daemon role only — see 3e).
+# 4c. The periodic workspace prune (daemon role only — see 3c-ii).
 #
 # Same in-container background pattern as the console monitor above: a subshell
 # child of this entrypoint, so tini reaps it, and a pid the shutdown handler
-# kills. `sleep` FIRST, so the interval measures from the boot pass that 3e
+# kills. `sleep` FIRST, so the interval measures from the boot pass that 3c-ii
 # already ran rather than pruning twice in a row on every restart.
 #
 # The loop cannot die of a prune failure: workspace_prune_run returns 0 always

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -5,6 +5,8 @@
 #   0. as root: fix the volume-mount ownership (+ firewall), then drop to alissa
 #   1. preflight the identities the loop depends on (gh / alissa / claude)
 #   2. bootstrap the worktree-hub workspace + revloop config from a manifest
+#   2b. prune finished worktrees off the volume, then again on an interval
+#       (`alissa code workspace prune`, capability-gated, best-effort)
 #   3. start `alissa worker` (backgrounded) and wait until it is up
 #   4. optionally start the `alissa-revloop-ui` console sidecar (ALISSA_UI_ENABLED)
 #   5. run `alissa-revloop` in the foreground, stopping the worker on exit
@@ -871,6 +873,148 @@ if [ -f "${MANIFEST}" ]; then
 fi
 
 # -----------------------------------------------------------------------------
+# 3e. Volume hygiene — `alissa code workspace prune` (issue #81).
+#
+# Nothing in this container ever removed anything from the volume. Every review
+# round materializes a per-PR worktree in a hub (plus whatever a session's build
+# leaves behind), merged or closed PRs leave theirs in place forever, and the
+# bare `.source` object store only grows. `alissa code workspace prune` is the
+# remediation primitive: it removes finished-branch worktrees behind the CLI's
+# own safety rails (never `main/`, never a dirty tree without --force, an age
+# gate, a live-tmux-session guard, never a worktree whose PR is still open, and
+# a lookup failure KEEPS the worktree) and then runs the hub-level
+# `git worktree prune` / `git remote prune origin` / `git gc --auto` sequence.
+#
+# Three properties this wiring must have, in order of how much they matter:
+#
+#   * it can never take the container down. Prune is an optimization; a failing
+#     one leaves exactly the disk usage we already had. So: best-effort at boot,
+#     and an interval loop that warns and waits for the next tick.
+#   * `--force` is NEVER passed. In a review container a dirty worktree is
+#     evidence — a session that died mid-round, with uncommitted work someone
+#     may still want. The rail that keeps it is the one this entrypoint most
+#     needs, so the flag that defeats it is not exposed at all.
+#   * it is CAPABILITY-GATED, not version-pinned. The image installs the alissa
+#     CLI from an install channel that may predate the subcommand, and a hard
+#     pin here would go stale on every CLI release. An older CLI gets exactly
+#     one loud warning and both hooks skip.
+#
+# The interval loop is DAEMON-ONLY, and deliberately so: the executor role
+# `exec`s `alissa bridge start` a few lines below, which replaces this shell —
+# a loop started here would outlive the only code that knows how to stop it and
+# would keep pruning against jobs it cannot see being torn down. The executor
+# still gets the boot pass, because it grows the same volume the same way.
+# -----------------------------------------------------------------------------
+PRUNE_ENABLED=0
+PRUNE_INTERVAL_MINUTES=360
+PRUNE_INTERVAL_SECONDS=$(( 360 * 60 ))
+# Never contains `--force`. See the block comment above; the entrypoint has no
+# knob that adds it, which is the point.
+PRUNE_ARGS=()
+
+# Does this CLI ship `alissa code workspace prune`?
+#
+# NOT "does `--help` exit 0". Commander answers an UNKNOWN subcommand by
+# printing the PARENT command's help and exiting 0 — verified against alissa
+# CLI 0.1.0, where `alissa code workspace prune --help` prints the `workspace`
+# help and exits 0 without a word about prune. A probe on the exit status alone
+# would therefore report every old CLI as capable and we would discover the
+# truth one failing prune at a time. So the probe reads the OUTPUT: a real
+# subcommand prints its own `Usage: … workspace prune …`, and a help that lists
+# a `prune` command counts too.
+workspace_prune_supported() {
+  local out
+  out="$(alissa code workspace prune --help 2>&1)" || return 1
+  printf '%s\n' "${out}" \
+    | grep -qE '^[[:space:]]*(Usage:[[:space:]].*workspace[[:space:]]+prune|prune([[:space:]]|$))'
+}
+
+# One prune pass. ALWAYS returns 0: both callers treat a failure as "warn and
+# carry on", and the interval loop runs under this script's `set -e`, where a
+# non-zero return would silently kill the loop instead of the pass.
+#
+# The CLI's per-worktree verdicts are captured and re-emitted through log(), so
+# they carry the entrypoint prefix and are greppable in the platform's boot log
+# next to everything else this boot did.
+workspace_prune_run() {
+  local label="$1" out line rc=0
+  # Run from the workspace root: the workspace binding is cwd-based, exactly as
+  # for the `workspace sync` above.
+  out="$( cd "${WORKSPACE_ROOT}" && alissa code workspace prune ${PRUNE_ARGS[@]+"${PRUNE_ARGS[@]}"} 2>&1 )" \
+    || rc=$?
+  if [ -n "${out}" ]; then
+    while IFS= read -r line; do log "prune[${label}]: ${line}"; done <<<"${out}"
+  fi
+  if [ "${rc}" = "0" ]; then
+    log "workspace prune (${label}) finished"
+  else
+    log "WARN: workspace prune (${label}) exited ${rc} — nothing was removed by this pass; the volume keeps what it holds until the next one. Check the verdict lines above."
+  fi
+  return 0
+}
+
+# Default ON: this container is the one whose volume is growing, so the knob is
+# an opt-OUT. Same truthiness as every other gate here.
+if ! is_truthy "${ALISSA_WORKSPACE_PRUNE:-1}"; then
+  log "workspace prune DISABLED (ALISSA_WORKSPACE_PRUNE=${ALISSA_WORKSPACE_PRUNE:-1}) — nothing in this container reclaims finished worktrees, so the volume grows until someone prunes it by hand"
+elif ! workspace_prune_supported; then
+  # Exactly one warning, and it is loud: this is a silent-growth condition, and
+  # the only signal an operator gets that the hygiene they think is running is
+  # not. Both hooks stay off — see the capability-gate rationale above.
+  log "WARN: this alissa CLI predates 'alissa code workspace prune' — workspace prune is SKIPPED at boot AND on the interval, and the volume WILL grow. Upgrade the CLI in the image's install channel; nothing about this entrypoint needs to change when it lands."
+else
+  PRUNE_ENABLED=1
+
+  # `--min-age-hours` is a SAFETY knob: a larger value keeps MORE worktrees. A
+  # value the CLI would reject therefore must not fall back to the CLI's own
+  # default — that would prune worktrees younger than the operator asked to
+  # keep, which is the one direction of error that destroys something. Fail
+  # closed instead: skip the whole feature for this boot and say why.
+  if [ -n "${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS:-}" ]; then
+    if printf '%s' "${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS}" | grep -qE '^[0-9]+$'; then
+      PRUNE_ARGS+=( --min-age-hours "${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS}" )
+    else
+      PRUNE_ENABLED=0
+      log "WARN: ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS=${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS} is not a whole number of hours — workspace prune is SKIPPED entirely rather than run with the CLI's default age gate, because that gate could be SHORTER than the one you asked for. Fix the value (or unset it to accept the CLI's default) and redeploy."
+    fi
+  fi
+fi
+
+if [ "${PRUNE_ENABLED}" = "1" ]; then
+  # The interval is not a safety knob — a bad one only changes how often a
+  # best-effort pass runs — so a garbage value falls back to the default with a
+  # warning instead of disabling the feature.
+  PRUNE_INTERVAL_MINUTES="${ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES:-360}"
+  if ! printf '%s' "${PRUNE_INTERVAL_MINUTES}" | grep -qE '^[1-9][0-9]*$'; then
+    log "WARN: ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES=${PRUNE_INTERVAL_MINUTES} is not a positive whole number of minutes — falling back to 360"
+    PRUNE_INTERVAL_MINUTES=360
+  fi
+  PRUNE_INTERVAL_SECONDS=$(( PRUNE_INTERVAL_MINUTES * 60 ))
+
+  # ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS is TEST-ONLY, on the same footing as
+  # ALISSA_AUTH_RETRY_SECONDS: tests-entrypoint-prune.sh has to watch the loop
+  # tick more than once, and the smallest value the documented knob can express
+  # is a minute per tick. A deploy leaves it unset.
+  if [ -n "${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS:-}" ]; then
+    if printf '%s' "${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS}" | grep -qE '^[1-9][0-9]*$'; then
+      PRUNE_INTERVAL_SECONDS="${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS}"
+      log "workspace prune: interval overridden to ${PRUNE_INTERVAL_SECONDS}s (ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS — test-only)"
+    else
+      log "WARN: ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS=${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS} is not a positive whole number of seconds — ignoring it"
+    fi
+  fi
+
+  log "workspace prune ENABLED — boot pass now, then every ${PRUNE_INTERVAL_MINUTES} min (min-age: ${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS:-CLI default}, --force never passed)"
+  # Best-effort, exactly like the other boot steps: prune is an optimization,
+  # never a boot precondition. workspace_prune_run already swallows the status;
+  # the `|| true` is the belt to that suspenders, and says so at the call site.
+  workspace_prune_run boot || true
+  if [ "${CONTAINER_ROLE}" = "executor" ]; then
+    log "workspace prune: executor role runs the boot pass only — the interval loop belongs to the daemon's process chain, and this role 'exec's the bridge, leaving nothing here to tear a loop down"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
 # 3d. EXECUTOR ROLE — hand the container over to `alissa bridge start`.
 #
 # This is the end of the shared path. `exec` replaces this shell, so tini's only
@@ -997,6 +1141,30 @@ if [ "${UI_ENABLED}" = "1" ]; then
 fi
 
 # -----------------------------------------------------------------------------
+# 4c. The periodic workspace prune (daemon role only — see 3e).
+#
+# Same in-container background pattern as the console monitor above: a subshell
+# child of this entrypoint, so tini reaps it, and a pid the shutdown handler
+# kills. `sleep` FIRST, so the interval measures from the boot pass that 3e
+# already ran rather than pruning twice in a row on every restart.
+#
+# The loop cannot die of a prune failure: workspace_prune_run returns 0 always
+# (a non-zero return under `set -e` would end the subshell, turning one failed
+# pass into no more passes until the next redeploy).
+# -----------------------------------------------------------------------------
+PRUNE_PID=""
+if [ "${PRUNE_ENABLED}" = "1" ]; then
+  log "starting the workspace prune loop (every ${PRUNE_INTERVAL_MINUTES} min = ${PRUNE_INTERVAL_SECONDS}s)"
+  (
+    while true; do
+      sleep "${PRUNE_INTERVAL_SECONDS}"
+      workspace_prune_run interval
+    done
+  ) &
+  PRUNE_PID=$!
+fi
+
+# -----------------------------------------------------------------------------
 # 5. Run the daemon in the foreground; stop the worker on shutdown.
 # -----------------------------------------------------------------------------
 DAEMON_PID=""
@@ -1005,6 +1173,10 @@ shutdown() {
   # Silence the console monitor FIRST so tearing the sidecar down below does not
   # trip its "EXITED" alarm during an orderly shutdown.
   [ -n "${UI_MONITOR_PID}" ] && kill "${UI_MONITOR_PID}" 2>/dev/null || true
+  # The prune loop goes down with it, and for the same reason: an orderly
+  # shutdown must not start a pass into a container that is being torn down
+  # (the CLI walks hubs and can run `git gc` — work worth not interrupting).
+  [ -n "${PRUNE_PID}" ] && kill "${PRUNE_PID}" 2>/dev/null || true
   [ -n "${UI_PID}" ] && kill "${UI_PID}" 2>/dev/null || true
   [ -n "${DAEMON_PID}" ] && kill "${DAEMON_PID}" 2>/dev/null || true
   alissa worker stop >/dev/null 2>&1 || true

--- a/docker/claude/tests-entrypoint-prune.sh
+++ b/docker/claude/tests-entrypoint-prune.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Tests for the entrypoint's workspace-prune wiring (issue #81).
+#
+# Nothing in this container used to remove anything from the volume, so the
+# entrypoint now runs `alissa code workspace prune` at boot and on a supervised
+# interval. This boots the REAL entrypoint.sh six times with the CLIs it shells
+# out to replaced by stubs (no docker needed — CI has no docker-in-docker, and
+# the image adds layers, not entrypoint behaviour). The `alissa` stub records
+# every prune invocation with its argv AND its cwd, which is what makes the
+# safety properties assertions rather than claims:
+#
+#   1. default ON, capable CLI   -> boot pass runs from the workspace root, the
+#                                   interval loop keeps ticking (a FAILED tick
+#                                   warns and the next one still runs), no
+#                                   --force and no --min-age-hours ever, and
+#                                   SIGTERM stops the loop for good
+#   2. ALISSA_WORKSPACE_PRUNE=0  -> zero invocations, no loop, boot unaffected
+#   3. CLI without the subcommand-> EXACTLY ONE loud warning, zero invocations,
+#                                   and the container still boots. The stub
+#                                   reproduces commander's real behaviour here:
+#                                   an unknown subcommand's `--help` prints the
+#                                   PARENT help and exits 0 (alissa CLI 0.1.0),
+#                                   so a probe reading only the exit status
+#                                   would call this CLI capable
+#   4. min-age + garbage interval-> --min-age-hours passed through verbatim; a
+#                                   non-numeric interval falls back to 360
+#   5. garbage min-age           -> fails CLOSED (prune skipped, loud warning):
+#                                   the CLI's default age gate may be SHORTER
+#                                   than the one that was asked for
+#   6. executor role             -> boot pass yes, interval loop no (the role
+#                                   `exec`s the bridge; a loop would outlive the
+#                                   only code that stops it)
+#
+# Usage: bash docker/claude/tests-entrypoint-prune.sh
+# Needs: bash, python3, jq (the entrypoint's own bootstrap uses both).
+# =============================================================================
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENTRYPOINT="${HERE}/entrypoint.sh"
+
+fail=0
+pass() { printf '  ok   %s\n' "$1"; }
+bad()  { printf '  FAIL %s\n' "$1" >&2; fail=1; }
+info() { printf '%s\n' "$*"; }
+
+assert_contains() {
+  if grep -qF -- "$2" "$1"; then pass "$3"; else bad "$3 (not in $1: $2)"; fi
+}
+assert_not_contains() {
+  if grep -qF -- "$2" "$1"; then bad "$3 (unexpected in $1: $2)"; else pass "$3"; fi
+}
+assert_eq() { if [ "$1" = "$2" ]; then pass "$3"; else bad "$3 (expected '$2', got '$1')"; fi; }
+
+TMPROOT="$(mktemp -d)"
+BIN="${TMPROOT}/bin"; mkdir -p "${BIN}"
+FAKE_HOME="${TMPROOT}/home"; mkdir -p "${FAKE_HOME}/.config/alissa"
+WORKSPACE="${TMPROOT}/workspace"; mkdir -p "${WORKSPACE}"
+SPY="${TMPROOT}/spy"; mkdir -p "${SPY}"
+cp "${HERE}/agents.yaml" "${FAKE_HOME}/.config/alissa/agents.yaml"
+cleanup() { rm -rf "${TMPROOT}"; }
+trap cleanup EXIT
+
+cat > "${BIN}/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  "api user -q .login") echo alissa-app ;;
+esac
+exit 0
+STUB
+
+# The API reachability probe. Always up: the transport classes have their own
+# suite (tests-entrypoint-auth.sh).
+cat > "${BIN}/curl" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+
+# The alissa CLI stub.
+#
+# PRUNE_CAPABLE=0 turns it into a CLI that predates the subcommand — and it
+# models that faithfully, which is the whole point of case 3: commander prints
+# the PARENT command's help and exits 0 for an unknown subcommand, so `prune
+# --help` SUCCEEDS on a CLI that has never heard of prune.
+#
+# PRUNE_FAIL_ON=<n> makes the n-th prune invocation fail, so the interval loop's
+# tolerance of a failing pass is exercised rather than assumed.
+cat > "${BIN}/alissa" <<'STUB'
+#!/usr/bin/env bash
+case "${1:-} ${2:-} ${3:-}" in
+  "code workspace prune")
+    shift 3
+    if [ "${1:-}" = "--help" ]; then
+      if [ "${PRUNE_CAPABLE:-1}" = "1" ]; then
+        cat <<'HELP'
+Usage: alissa code workspace prune [options]
+
+Remove worktrees of finished branches from this workspace's hubs
+
+Options:
+  --min-age-hours <n>  only prune worktrees older than <n> hours
+  --force              prune even a dirty worktree
+  -h, --help           display help for command
+HELP
+        exit 0
+      fi
+      # alissa CLI 0.1.0, verbatim in shape: the `workspace` help, exit 0, no
+      # mention of prune anywhere.
+      cat <<'HELP'
+Usage: alissa code workspace [options] [command]
+
+Create and maintain an Alissa Code Workspace (multi-repo worktree hubs)
+
+Options:
+  -h, --help            display help for command
+
+Commands:
+  init [options] [dir]  Initialize a workspace here (or in <dir>)
+  add [options] <repo>  Hub-ify a repo into this workspace
+  sync [options]        Reconcile the workspace against its manifest
+  status                Show the workspace binding, hubs, and active worktrees
+  doctor                Check workspace invariants
+  help [command]        display help for command
+HELP
+      exit 0
+    fi
+    printf 'cwd=%s argv=%s\n' "${PWD}" "$*" >> "${SPY_DIR}/prune-argv"
+    n="$(wc -l < "${SPY_DIR}/prune-argv" | tr -d ' ')"
+    echo "keep  main (never pruned)"
+    echo "prune TASK-1-EXAMPLE (branch merged, PR closed)"
+    if [ -n "${PRUNE_FAIL_ON:-}" ] && [ "${n}" = "${PRUNE_FAIL_ON}" ]; then
+      echo "error: hub sweep failed" >&2
+      exit 3
+    fi
+    exit 0
+    ;;
+esac
+case "${1:-} ${2:-}" in
+  "auth login")     echo "Authenticated." ;;
+  "worker start")   : > "${SPY_DIR}/worker-started" ;;
+  "worker status")  [ -f "${SPY_DIR}/worker-started" ] && echo "worker is running" || echo "worker not running" ;;
+  "worker stop")    : > "${SPY_DIR}/worker-stopped" ;;
+  "code workspace") ;;
+  "bridge start")
+    : > "${SPY_DIR}/bridge-started"
+    trap 'exit 0' TERM INT
+    sleep 600 &
+    wait $!
+    ;;
+esac
+exit 0
+STUB
+
+# The review daemon: a foreground process the entrypoint backgrounds.
+cat > "${BIN}/alissa-revloop" <<'STUB'
+#!/usr/bin/env bash
+trap 'exit 0' TERM INT
+sleep 600 &
+wait $!
+STUB
+chmod 0755 "${BIN}/gh" "${BIN}/curl" "${BIN}/alissa" "${BIN}/alissa-revloop"
+
+reset_spies() {
+  rm -f "${SPY}"/prune-argv "${SPY}"/worker-started "${SPY}"/worker-stopped \
+        "${SPY}"/bridge-started
+}
+
+prune_count() { [ -f "${SPY}/prune-argv" ] && wc -l < "${SPY}/prune-argv" | tr -d ' ' || echo 0; }
+
+EP_PID=""
+run_entrypoint() {
+  local log="$1"; shift
+  env -i \
+    PATH="${BIN}:/usr/local/bin:/usr/bin:/bin" \
+    HOME="${FAKE_HOME}" \
+    TMUX_TMPDIR="${TMPROOT}/tmux" \
+    ALISSA_WORKSPACE_ROOT="${WORKSPACE}" \
+    GH_TOKEN=stub-gh-token \
+    ALISSA_API_TOKEN=stub-alissa-token \
+    ALISSA_REVIEW_REPOS="fahera-mx/example-repo" \
+    SPY_DIR="${SPY}" \
+    "$@" \
+    bash "${ENTRYPOINT}" > "${log}" 2>&1 &
+  EP_PID=$!
+}
+
+wait_for_log() {
+  local i
+  for i in $(seq 1 "$3"); do
+    grep -qF -- "$2" "$1" && return 0
+    kill -0 "${EP_PID}" 2>/dev/null || { grep -qF -- "$2" "$1" && return 0; return 1; }
+    sleep 1
+  done
+  return 1
+}
+
+# wait_for_prune_count <n> <seconds>
+wait_for_prune_count() {
+  local i
+  for i in $(seq 1 "$2"); do
+    [ "$(prune_count)" -ge "$1" ] && return 0
+    sleep 1
+  done
+  return 1
+}
+
+stop_entrypoint() {
+  local pid="$1" i
+  kill -TERM "${pid}" 2>/dev/null || true
+  for i in $(seq 1 15); do
+    kill -0 "${pid}" 2>/dev/null || return 0
+    sleep 1
+  done
+  kill -KILL "${pid}" 2>/dev/null || true
+}
+
+DAEMON_UP="alissa worker is running"
+
+# -----------------------------------------------------------------------------
+info "1. default ON with a capable CLI -> boot pass + a supervised interval loop"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG1="${TMPROOT}/on.log"
+# 3s ticks via the test-only seconds override, and the SECOND pass fails, so the
+# assertions below cover both "the loop ticks" and "a failed tick is survivable".
+run_entrypoint "${LOG1}" \
+  ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS=3 \
+  PRUNE_FAIL_ON=2
+PID1="${EP_PID}"
+wait_for_log "${LOG1}" "${DAEMON_UP}" 40 || bad "entrypoint never reached the worker-up milestone (see ${LOG1})"
+
+assert_contains "${LOG1}" "workspace prune ENABLED" "prune is on by default (no env set)"
+assert_contains "${LOG1}" "prune[boot]: prune TASK-1-EXAMPLE" "the CLI's per-worktree verdicts land in the boot log"
+assert_contains "${LOG1}" "workspace prune (boot) finished" "the boot pass reports its outcome"
+assert_contains "${LOG1}" "starting the workspace prune loop" "the interval loop is started"
+
+if [ "$(prune_count)" -ge 1 ]; then
+  pass "boot pass invoked the CLI"
+  assert_eq "$(head -1 "${SPY}/prune-argv" | sed 's/ argv=.*//')" "cwd=${WORKSPACE}" \
+    "prune runs from the workspace root (the binding is cwd-based)"
+  assert_eq "$(head -1 "${SPY}/prune-argv" | sed 's/^.* argv=//')" "" \
+    "boot pass passes NO flags when neither knob is set (CLI defaults apply)"
+else
+  bad "boot pass never invoked the CLI"
+fi
+
+# The loop: three passes at 3s ticks, the second of which fails.
+if wait_for_prune_count 3 40; then
+  pass "the interval loop ticks (>=3 passes)"
+  assert_contains "${LOG1}" "workspace prune (interval) exited 3" "a failed interval pass warns"
+  assert_contains "${LOG1}" "prune[interval]:" "interval verdicts are logged too"
+  kill -0 "${PID1}" 2>/dev/null \
+    && pass "the container survives a failed prune" \
+    || bad "the entrypoint died on a failed prune"
+else
+  bad "the interval loop did not tick 3 times within 40s (count=$(prune_count))"
+fi
+
+assert_not_contains "${SPY}/prune-argv" "--force" "--force is NEVER passed"
+
+# Teardown: the loop must die with the container, not keep pruning a volume
+# nothing is using.
+stop_entrypoint "${PID1}"
+assert_contains "${LOG1}" "shutting down" "shuts down on SIGTERM"
+AFTER="$(prune_count)"
+sleep 8   # >2 ticks at the 3s override
+assert_eq "$(prune_count)" "${AFTER}" "no prune pass runs after shutdown (the loop is torn down)"
+
+# -----------------------------------------------------------------------------
+info ""
+info "2. ALISSA_WORKSPACE_PRUNE=0 -> the opt-out really is one"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG2="${TMPROOT}/off.log"
+run_entrypoint "${LOG2}" ALISSA_WORKSPACE_PRUNE=0 ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS=3
+PID2="${EP_PID}"
+wait_for_log "${LOG2}" "${DAEMON_UP}" 40 || bad "entrypoint never reached the worker-up milestone (see ${LOG2})"
+assert_contains "${LOG2}" "workspace prune DISABLED" "logs the opt-out"
+assert_not_contains "${LOG2}" "starting the workspace prune loop" "no interval loop when opted out"
+sleep 6
+assert_eq "$(prune_count)" "0" "zero prune invocations when opted out"
+stop_entrypoint "${PID2}"
+
+# -----------------------------------------------------------------------------
+info ""
+info "3. a CLI that predates the subcommand -> ONE loud warning, both hooks skip"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG3="${TMPROOT}/old-cli.log"
+run_entrypoint "${LOG3}" PRUNE_CAPABLE=0 ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS=3
+PID3="${EP_PID}"
+wait_for_log "${LOG3}" "${DAEMON_UP}" 40 || bad "entrypoint never reached the worker-up milestone (see ${LOG3})"
+assert_eq "$(grep -c "predates 'alissa code workspace prune'" "${LOG3}")" "1" \
+  "exactly ONE warning about the missing subcommand"
+assert_contains "${LOG3}" "WARN: this alissa CLI predates" "and it is a WARN, not a whisper"
+assert_not_contains "${LOG3}" "starting the workspace prune loop" "no interval loop on an old CLI"
+assert_not_contains "${LOG3}" "workspace prune ENABLED" "the feature is not reported as enabled"
+sleep 6
+assert_eq "$(prune_count)" "0" "zero prune invocations on an old CLI"
+kill -0 "${PID3}" 2>/dev/null \
+  && pass "the container boots normally on an old CLI" \
+  || bad "an old CLI broke the boot"
+stop_entrypoint "${PID3}"
+
+# -----------------------------------------------------------------------------
+info ""
+info "4. min-age pass-through + a garbage interval"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG4="${TMPROOT}/knobs.log"
+run_entrypoint "${LOG4}" \
+  ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS=48 \
+  ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES=soon
+PID4="${EP_PID}"
+wait_for_log "${LOG4}" "${DAEMON_UP}" 40 || bad "entrypoint never reached the worker-up milestone (see ${LOG4})"
+if [ "$(prune_count)" -ge 1 ]; then
+  assert_eq "$(head -1 "${SPY}/prune-argv" | sed 's/^.* argv=//')" "--min-age-hours 48" \
+    "ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS is passed through as --min-age-hours"
+else
+  bad "no prune invocation to inspect"
+fi
+assert_contains "${LOG4}" "ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES=soon is not a positive whole number" \
+  "a garbage interval warns"
+assert_contains "${LOG4}" "starting the workspace prune loop (every 360 min" \
+  "a garbage interval falls back to 360 (an interval is not a safety knob)"
+stop_entrypoint "${PID4}"
+
+# -----------------------------------------------------------------------------
+info ""
+info "5. a garbage min-age fails CLOSED (the age gate is a safety knob)"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG5="${TMPROOT}/bad-age.log"
+run_entrypoint "${LOG5}" \
+  ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS=48h \
+  ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS=3
+PID5="${EP_PID}"
+wait_for_log "${LOG5}" "${DAEMON_UP}" 40 || bad "entrypoint never reached the worker-up milestone (see ${LOG5})"
+assert_contains "${LOG5}" "ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS=48h is not a whole number of hours" \
+  "a garbage min-age warns"
+assert_not_contains "${LOG5}" "starting the workspace prune loop" "and disables the loop"
+sleep 6
+assert_eq "$(prune_count)" "0" "and runs no pass at all rather than one with a shorter age gate"
+kill -0 "${PID5}" 2>/dev/null \
+  && pass "the container still boots" \
+  || bad "a garbage min-age broke the boot"
+stop_entrypoint "${PID5}"
+
+# -----------------------------------------------------------------------------
+info ""
+info "6. executor role -> boot pass, but no interval loop"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG6="${TMPROOT}/executor.log"
+run_entrypoint "${LOG6}" \
+  CONTAINER_ROLE=executor ALISSA_BRIDGE_EXECUTOR=1 \
+  ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS=3
+PID6="${EP_PID}"
+wait_for_log "${LOG6}" "starting alissa bridge start" 40 \
+  || bad "the executor never reached the bridge (see ${LOG6})"
+assert_eq "$(prune_count)" "1" "the executor prunes once at boot (it grows the same volume)"
+assert_contains "${LOG6}" "executor role runs the boot pass only" "and says why there is no loop"
+assert_not_contains "${LOG6}" "starting the workspace prune loop" "no interval loop in the executor role"
+sleep 8   # >2 ticks at the 3s override: an orphaned loop would show up here
+assert_eq "$(prune_count)" "1" "no loop survived the exec into the bridge"
+stop_entrypoint "${PID6}"
+
+info ""
+if [ "${fail}" = "0" ]; then
+  info "All workspace-prune entrypoint checks passed."
+else
+  info "Some workspace-prune entrypoint checks FAILED." >&2
+fi
+exit "${fail}"

--- a/docker/claude/tests-entrypoint-prune.sh
+++ b/docker/claude/tests-entrypoint-prune.sh
@@ -31,6 +31,10 @@
 #   6. executor role             -> boot pass yes, interval loop no (the role
 #                                   `exec`s the bridge; a loop would outlive the
 #                                   only code that stops it)
+#   7. a HANGING prune           -> `timeout` cuts it, the boot continues to the
+#                                   worker, and the warning names the knob. The
+#                                   boot hook runs BEFORE the worker starts, so
+#                                   an unbounded pass delays every boot
 #
 # Usage: bash docker/claude/tests-entrypoint-prune.sh
 # Needs: bash, python3, jq (the entrypoint's own bootstrap uses both).
@@ -85,7 +89,8 @@ STUB
 # --help` SUCCEEDS on a CLI that has never heard of prune.
 #
 # PRUNE_FAIL_ON=<n> makes the n-th prune invocation fail, so the interval loop's
-# tolerance of a failing pass is exercised rather than assumed.
+# tolerance of a failing pass is exercised rather than assumed. PRUNE_HANG makes
+# it block forever, which is what the boot pass's `timeout` bound exists for.
 cat > "${BIN}/alissa" <<'STUB'
 #!/usr/bin/env bash
 case "${1:-} ${2:-} ${3:-}" in
@@ -126,6 +131,9 @@ HELP
       exit 0
     fi
     printf 'cwd=%s argv=%s\n' "${PWD}" "$*" >> "${SPY_DIR}/prune-argv"
+    # PRUNE_HANG models the slow first sweep (or a prompt on a tty-less
+    # container): the entrypoint's `timeout` is the only thing that ends it.
+    [ -n "${PRUNE_HANG:-}" ] && sleep 120
     n="$(wc -l < "${SPY_DIR}/prune-argv" | tr -d ' ')"
     echo "keep  main (never pruned)"
     echo "prune TASK-1-EXAMPLE (branch merged, PR closed)"
@@ -311,7 +319,8 @@ reset_spies
 LOG4="${TMPROOT}/knobs.log"
 run_entrypoint "${LOG4}" \
   ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS=48 \
-  ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES=soon
+  ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES=soon \
+  ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS=3
 PID4="${EP_PID}"
 wait_for_log "${LOG4}" "${DAEMON_UP}" 40 || bad "entrypoint never reached the worker-up milestone (see ${LOG4})"
 if [ "$(prune_count)" -ge 1 ]; then
@@ -324,6 +333,14 @@ assert_contains "${LOG4}" "ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES=soon is not a
   "a garbage interval warns"
 assert_contains "${LOG4}" "starting the workspace prune loop (every 360 min" \
   "a garbage interval falls back to 360 (an interval is not a safety knob)"
+# The INTERVAL pass must carry the same flags as the boot pass — PRUNE_ARGS is a
+# global the loop's subshell inherits, and nothing else pins that.
+if wait_for_prune_count 2 30; then
+  assert_eq "$(sed -n 2p "${SPY}/prune-argv" | sed 's/^.* argv=//')" "--min-age-hours 48" \
+    "the interval pass inherits --min-age-hours too, not just the boot pass"
+else
+  bad "no interval pass observed within 30s (count=$(prune_count))"
+fi
 stop_entrypoint "${PID4}"
 
 # -----------------------------------------------------------------------------
@@ -360,11 +377,39 @@ PID6="${EP_PID}"
 wait_for_log "${LOG6}" "starting alissa bridge start" 40 \
   || bad "the executor never reached the bridge (see ${LOG6})"
 assert_eq "$(prune_count)" "1" "the executor prunes once at boot (it grows the same volume)"
-assert_contains "${LOG6}" "executor role runs the boot pass only" "and says why there is no loop"
+assert_contains "${LOG6}" "boot pass only (executor role" "the ENABLED line says boot-pass-only for this role"
+assert_contains "${LOG6}" "nothing left here to tear a loop down" "and says why there is no loop"
 assert_not_contains "${LOG6}" "starting the workspace prune loop" "no interval loop in the executor role"
+assert_not_contains "${LOG6}" "then every" "the executor's log announces no cadence it will not run"
 sleep 8   # >2 ticks at the 3s override: an orphaned loop would show up here
 assert_eq "$(prune_count)" "1" "no loop survived the exec into the bridge"
 stop_entrypoint "${PID6}"
+
+# -----------------------------------------------------------------------------
+info ""
+info "7. a HANGING prune cannot hold the boot open"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG7="${TMPROOT}/hang.log"
+# The boot hook runs before the worker starts, so an unbounded pass would delay
+# every boot by however long the CLI takes — and on a never-pruned volume the
+# first `git gc --auto` sweep is exactly that case. PRUNE_HANG makes the stub
+# sleep for two minutes; a 2s timeout must cut it and let the boot continue.
+run_entrypoint "${LOG7}" PRUNE_HANG=1 ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS=2
+PID7="${EP_PID}"
+if wait_for_log "${LOG7}" "${DAEMON_UP}" 40; then
+  pass "the boot reaches the worker even though the prune pass hangs"
+else
+  bad "a hanging prune pass held the boot open (see ${LOG7})"
+fi
+assert_contains "${LOG7}" "workspace prune (boot) TIMED OUT after 2s" \
+  "the timeout is reported as a timeout, not as a bare exit code"
+assert_contains "${LOG7}" "ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS" \
+  "and names the knob that raises the bound"
+kill -0 "${PID7}" 2>/dev/null \
+  && pass "the container is alive after a timed-out pass" \
+  || bad "a timed-out prune killed the container"
+stop_entrypoint "${PID7}"
 
 info ""
 if [ "${fail}" = "0" ]; then


### PR DESCRIPTION
Closes #81

**Tasks:** origin `TASK-1492300589` · implementation `TASK-190865621`

Nothing in this container ever removed anything from the `/workspace` volume. Every
review round materializes a per-PR worktree in a hub, a merged or closed PR left its
worktree in place forever, and the bare `.source` object stores only grew. This wires
the CLI's remediation primitive, `alissa code workspace prune`, into
`docker/claude/entrypoint.sh`:

* **Boot pass** (new section 3c-ii, right after the hub sync, on the path both roles
  share) — best-effort and **bounded** (`timeout` + stdin closed, so a slow first sweep
  cannot hold the boot open), with the CLI's per-worktree verdicts re-logged through
  `redact_token()` so they land in the boot log.
* **Interval loop** (new section 4c, daemon role) — a supervised background subshell
  modelled on the console monitor, `ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES` (default
  360), killed by the existing shutdown handler alongside `UI_MONITOR_PID`/`UI_PID`. A
  failing pass warns and the loop waits for the next tick.
* **Env contract** — `ALISSA_WORKSPACE_PRUNE` default **on** (opt out with `0`),
  `ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES` (360),
  `ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS` passed through to `--min-age-hours`,
  `ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS` (900) bounding one pass.
  **`--force` is never passed and no knob adds it.**
* **Capability gate** — probed once at boot; a CLI without the subcommand gets exactly
  one loud `WARN` and both hooks skip. No version pin.

A prune failure is always a warning, never a dead container.

## Delivery notes

### Judgment calls

* **The capability probe reads the help *output*, not its exit status.** The issue
  suggests "the subcommand's `--help` exits 0". That probe is wrong for this CLI:
  commander answers an *unknown* subcommand by printing the **parent** command's help
  and exiting **0** — verified against the alissa CLI 0.1.0 in this container, where
  `alissa code workspace prune --help` exits 0 and prints the `workspace` help with no
  mention of prune. So the probe requires the output to name the subcommand. I ran the
  issue's version as a counterfactual: with it, case 3 of the new suite fails and an
  old CLI is invoked **3 times** instead of 0. Same acceptance criterion, working
  detection.
* **A garbage `ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS` disables prune for that boot
  rather than falling back.** Min-age is a *safety* knob — larger keeps more — so
  falling back to the CLI's default could prune worktrees *younger* than the operator
  asked to keep, the one error direction that destroys something. The interval, which
  is not a safety knob, does fall back to 360 with a warning.
* **The executor role gets the boot pass but no interval loop.** It boots from the same
  image and grows the same volume, so skipping it entirely would leave half the problem;
  but it `exec`s `alissa bridge start`, which replaces the shell, so a loop started
  there would outlive the only code that stops it. The asymmetry is logged at boot and
  asserted in case 6.
* **Added `ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS`, test-only.** The documented knob's
  smallest value is one minute per tick, which makes "the loop keeps ticking after a
  failed pass" a 3-minute test. This is the same posture as the existing
  `ALISSA_AUTH_RETRY_SECONDS` / `ALISSA_INSTALL_URL` overrides. A deploy leaves it unset.
  **Correction (round 1):** this bullet originally claimed it was "documented in the
  README as test-only". It was not — the only note was the code comment at the
  resolution site. Round 1 caught that; it now has a table row and an
  `ALISSA_INSTALL_URL`-shaped blockquote.
* **Verdicts are captured and re-emitted through `log()`** rather than streamed
  straight through. It costs streaming (a pass logs when it finishes), and buys a
  greppable `[entrypoint] prune[boot|interval]: …` prefix plus an outcome line carrying
  the exit status.
* **The prune pass is bounded, `workspace sync` is not** (round 1). Both run against the
  same hubs at the same point in the boot, and the asymmetry is deliberate: hubs are a
  precondition for reviewing anything, so blocking on sync is correct, while prune is an
  optimization and may not delay a boot. Hence `timeout` + `</dev/null` on the prune
  runner only. The bound is a knob (`ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS`, default
  900) rather than a constant because the legitimate slow case — the first sweep over a
  never-pruned volume — is exactly the one an operator may need to let finish.
* **No flags beyond `--min-age-hours` are invented.** Whether the subcommand needs a
  non-interactive/`--yes` flag in a TTY-less container is not something I can see from
  here — see the gate below.

### Not verified — operator's gate

* [ ] **The prune subcommand itself does not exist yet.** `alissa code workspace prune`
  is CLI task TASK-2059754063 in the studio repo and is absent from the CLI installed
  here (0.1.0). Every prune invocation in this PR was exercised against a **stub**. The
  capability gate is what makes shipping this first safe — it no-ops with one warning
  until the CLI catches up — but the real command's flags, output and exit codes are
  unverified.
* [ ] **`--min-age-hours` is the real flag spelling**, and it takes a bare integer. Taken
  from the issue text; not probed against a real CLI.
* [ ] **The real subcommand is non-interactive in a TTY-less container.** Nothing here
  passes a `--yes`-style flag because none is specified. Since round 1 this can no
  longer hold the boot open — the pass runs with stdin closed and under `timeout` — so
  what remains unverified is only whether a prompt would make it a no-op that logs a
  timeout every 6 h.
* [ ] **No container was booted.** These runners have no docker daemon; the suites boot
  the *real* `entrypoint.sh` with stubbed CLIs, which is this repo's established
  substitute (`docker/claude/tests-entrypoint-*.sh`). The image layers are unchanged by
  this PR, so there is nothing image-level to exercise — but "it ran in the actual
  container" remains unverified by construction.
* [ ] **Real-world pruning behaviour on the live volume** — how much it reclaims, and
  that the live-tmux-session guard protects an in-flight reviewer worktree — can only be
  seen after deploy. Watch the first boot's `prune[boot]:` lines.

### Verification

* `docker/claude/tests-entrypoint-prune.sh` (new, 6 real boots): **34/34 ok**.
* Counterfactuals, each mutating one clause in a throwaway copy: exit-status-only
  capability probe → case 3 fails (5 assertions, 3 prune invocations on an old CLI);
  shutdown handler without the `PRUNE_PID` kill → "no prune pass runs after shutdown"
  fails (3 → 6 invocations). Both assertions are load-bearing.
* All six pre-existing entrypoint suites against the patched entrypoint: `config`,
  `identity`, `chown`, `executor`, `auth`, `ui` — **all pass** (exit 0). Their `alissa`
  stubs return empty output for the probe, so they exercise the skip path incidentally.
* `check-style.sh` (pycodestyle) clean; `check-types.sh` (mypy) "Success: no issues
  found in 29 source files"; `tests-unit.sh` **687 passed**. No Python changed — these
  are regression cover, not evidence about the diff.
* `shellcheck -S warning` (0.10.0, downloaded): `entrypoint.sh` clean. The new suite
  reports one `SC2034` (`for i in $(seq …)`), which every existing entrypoint suite
  reports twice — consistent with the house style, so left alone.
* `bash -n` on both changed shell files.

**Round 2 (after the round-1 fixes):**

* `tests-entrypoint-prune.sh`: **40/40 ok** (7 boots — case 7 is new: a prune stub that
  hangs, a 2s timeout, asserting the boot still reaches the worker and that the warning
  names the knob).
* Third counterfactual, mutating only the new clause: drop `timeout` from the runner
  line and keep everything else → case 7 fails 3/4 (the boot never reaches the worker).
* All six pre-existing entrypoint suites re-run against the patched entrypoint: **pass**.
* `shellcheck -S warning` on `entrypoint.sh`: clean. `bash -n` on both files.
* Style/types/unit unchanged (no Python touched).

### Round 1

Verdict: `request_changes` — 1 major, 3 minor, 2 nits, 1 question; all seven triaged
`[pursue]` except the question (`[answer]`), and all seven landed in `d67e5a9`. The
`[major]` was correct and is the substantive change: the boot pass was unbounded and
blocking, which contradicted this feature's own "can never take the container down"
property.

One process note the thread history will show, recorded here so the validator does not
have to reconstruct it: a separate fix session briefly posted a second set of triage
replies on the same seven threads and made two stray edits to `entrypoint.sh` (a section
label flip). It deleted its replies and reverted both edits; I re-verified independently
before committing — the seven threads carry exactly one reply each (mine), and the label
scheme greps clean as `3a`/`3b`/`3c`/`3c-ii`/`3d`. No code of that session's is in this
branch.

### Scope touched

Declared scope was `docker/claude/*`, `README.md`.

* `docker/claude/entrypoint.sh` — sections 3c-ii (probe, runner, gates, boot pass; the
  block was labelled `3e` before round 1 renamed it) and 4c (interval loop), one line in
  `shutdown()`, one line in the header map. No existing line changed.
* `docker/claude/tests-entrypoint-prune.sh` — new suite.
* `docker/claude/README.md` — three table rows, a "Volume hygiene" subsection with the
  growth diagnosis, a paragraph in Persistence, a step in "What the entrypoint does".
* Round 1 added no files: the same four, plus the new `ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS`
  row and the test-only blockquote in the README.
* **Excursion:** `.github/workflows/check-entrypoint.yaml` — one step so the new suite
  actually runs in CI, plus its comment. Outside the declared scope's letter; a suite no
  workflow calls is not cover. The repo-root `README.md` named in the scope needed no
  change: the container env contract is documented in `docker/claude/README.md`, where
  every sibling knob lives.
