### PR TITLE
TASK-190865621: follow-up — make the prune bound actually bind (PR #82 round 2)

### DIFF
--- a/.github/workflows/check-entrypoint.yaml
+++ b/.github/workflows/check-entrypoint.yaml
@@ -17,6 +17,9 @@ on: [pull_request]
 #   * the bridge-executor role (CONTAINER_ROLE / ALISSA_BRIDGE_* gate, executor
 #     identity, and the guarantee that neither role starts the other's
 #     supervisor) — docker/claude/tests-entrypoint-executor.sh;
+#   * the workspace-prune wiring (boot pass + supervised interval loop,
+#     default-on with an opt-out, capability-gated, --force never passed) —
+#     docker/claude/tests-entrypoint-prune.sh;
 #   * the guarded boot-time chown (warm boot skips the volume walk, a root-owned
 #     probe result or ALISSA_FORCE_CHOWN=1 still runs it) —
 #     docker/claude/tests-entrypoint-chown.sh.
@@ -93,6 +96,17 @@ jobs:
         # claim; the last case runs against the real stat and the real tree.
         timeout-minutes: 4
         run: bash docker/claude/tests-entrypoint-chown.sh
+      - name: Execute Entrypoint Workspace-Prune Tests
+        # Boots the entrypoint six times against an `alissa` stub that records
+        # every `code workspace prune` invocation with its argv AND its cwd —
+        # which is what makes "--force is never passed" and "an old CLI runs
+        # nothing" assertions rather than claims. The stub reproduces
+        # commander's real behaviour for an unknown subcommand (parent help,
+        # exit 0), so the capability probe is tested against the trap it exists
+        # for. Two cases wait out several ticks of the test-only seconds
+        # override, hence the headroom.
+        timeout-minutes: 6
+        run: bash docker/claude/tests-entrypoint-prune.sh
       - name: Execute Entrypoint Console Wiring Tests
         # Boots the entrypoint four times (console off / enabled-without-passcode
         # / enabled / sidecar killed under it). No docker needed: the CLIs the

--- a/.github/workflows/check-entrypoint.yaml
+++ b/.github/workflows/check-entrypoint.yaml
@@ -103,8 +103,8 @@ jobs:
         # nothing" assertions rather than claims. The stub reproduces
         # commander's real behaviour for an unknown subcommand (parent help,
         # exit 0), so the capability probe is tested against the trap it exists
-        # for. Two cases wait out several ticks of the test-only seconds
-        # override, hence the headroom.
+        # for. Three cases wait out several ticks of the test-only seconds
+        # override or a real `timeout` firing, hence the headroom.
         timeout-minutes: 6
         run: bash docker/claude/tests-entrypoint-prune.sh
       - name: Execute Entrypoint Console Wiring Tests

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -237,6 +237,7 @@ automatically; locally pass `--build-arg`):
 | `ALISSA_FORCE_CHOWN` | `0` | `1`/`true`/`yes`/`on` forces the root phase's full `chown -R` of the volume for that boot; anything else (incl. unset) leaves the probe in charge. Off by default: the entrypoint probes ownership at depth 1 and walks only when it finds a foreign owner (see [Boot-time ownership](#boot-time-ownership-the-volume-walk-is-guarded)). Set it for **one** boot after a root shell wrote files deeper in the tree |
 | `ALISSA_WORKSPACE_PRUNE` | `1` (**on**) | volume hygiene: `1`/`true`/`yes`/`on` runs `alissa code workspace prune` at boot **and** on an interval; `0` opts out, after which nothing in the container reclaims anything. Default-on because this is the container whose volume grows (see [Volume hygiene](#volume-hygiene-finished-worktrees-are-pruned)). Skipped, with one loud warning, if the installed CLI predates the subcommand |
 | `ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES` | `360` | minutes between prune passes. Daemon role only — the executor gets the boot pass and no loop. A non-numeric or non-positive value warns and falls back to `360` |
+| `ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS` | `900` | how long ONE prune pass may run before it is killed, so a slow first sweep over a never-pruned volume cannot hold the boot open. A timed-out pass warns (exit 124) and changes nothing. Garbage falls back to `900` |
 | `ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS` | *(CLI default)* | passed straight through as `--min-age-hours`; **pass-through** — unset ⇒ the CLI's own age gate. A value that is not a whole number of hours **disables prune for that boot** instead of falling back (the CLI's default gate may be *shorter* than the one you asked for) |
 
 #### Config precedence: env var > daemon library default
@@ -352,6 +353,25 @@ safe to leave on by default:
   gets the boot pass — it grows the same volume the same way — but not the loop:
   that role `exec`s `alissa bridge start`, which replaces the shell, so a loop
   started there would outlive the only code that knows how to stop it.
+
+**A pass cannot hold the boot open.** The boot hook runs before `alissa worker`
+starts, and the first pass after the CLI lands sweeps `git gc --auto` across hubs
+on a volume that has never had anything reclaimed — minutes of work on a large
+object store, and on a platform with a startup health-check window a slow enough
+boot is a *dead* boot. So a pass runs under `timeout`
+(`ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS`, default 900) with **stdin closed**, and
+a pass that hits either bound lands in the same warning path as any other
+failure. The neighbouring `alissa code workspace sync` is deliberately *not*
+bounded this way: hubs are a precondition for reviewing anything, while prune is
+an optimization, and only one of those may delay a boot.
+
+> **`ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS` is test-only — do not set it in a
+> deploy.** `docker/claude/tests-entrypoint-prune.sh` has to watch the loop tick
+> more than once, and the smallest cadence the supported knob can express is a
+> minute. It silently overrides
+> `ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES`, and the boot log then reads
+> `starting the workspace prune loop (every 360 min = 3s)` — which is what you
+> will find first if it is ever set by accident.
 
 If you turn this off (`ALISSA_WORKSPACE_PRUNE=0`), nothing else reclaims the
 volume; plan on pruning by hand.
@@ -783,11 +803,12 @@ volumes:
    daemon's on-demand `alissa code workspace add` no-ops on a repo already listed
    in the manifest, leaving an empty folder and looping forever hub-ifying a hub
    that never completes.
-3b. **`alissa code workspace prune`** — best-effort volume hygiene, on the path
+3c-ii. **`alissa code workspace prune`** — best-effort volume hygiene, on the path
    both roles share: remove finished-branch worktrees (never `main/`, never
    dirty, never an open PR, never `--force`) and run the hub-level git prune/gc.
    Skipped with one loud warning if the CLI predates the subcommand, or if
-   `ALISSA_WORKSPACE_PRUNE=0`. A failure here is a warning, never a dead boot
+   `ALISSA_WORKSPACE_PRUNE=0`, and bounded by `timeout` with stdin closed so a
+   slow or prompting pass cannot hold the boot open. A failure here is a warning, never a dead boot
    ([why](#volume-hygiene-finished-worktrees-are-pruned)).
 3d. **Executor role only, and the end of the shared path**: drop this executor's
    stale lockfile, then `exec alissa bridge

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -235,6 +235,9 @@ automatically; locally pass `--build-arg`):
 | `ALISSA_ENABLE_FIREWALL` | `0` | `1` raises the egress firewall (needs `--cap-add=NET_ADMIN`) |
 | `ALISSA_FIREWALL_EXTRA` | *(empty)* | extra firewall allowlist hosts, space-separated |
 | `ALISSA_FORCE_CHOWN` | `0` | `1`/`true`/`yes`/`on` forces the root phase's full `chown -R` of the volume for that boot; anything else (incl. unset) leaves the probe in charge. Off by default: the entrypoint probes ownership at depth 1 and walks only when it finds a foreign owner (see [Boot-time ownership](#boot-time-ownership-the-volume-walk-is-guarded)). Set it for **one** boot after a root shell wrote files deeper in the tree |
+| `ALISSA_WORKSPACE_PRUNE` | `1` (**on**) | volume hygiene: `1`/`true`/`yes`/`on` runs `alissa code workspace prune` at boot **and** on an interval; `0` opts out, after which nothing in the container reclaims anything. Default-on because this is the container whose volume grows (see [Volume hygiene](#volume-hygiene-finished-worktrees-are-pruned)). Skipped, with one loud warning, if the installed CLI predates the subcommand |
+| `ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES` | `360` | minutes between prune passes. Daemon role only — the executor gets the boot pass and no loop. A non-numeric or non-positive value warns and falls back to `360` |
+| `ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS` | *(CLI default)* | passed straight through as `--min-age-hours`; **pass-through** — unset ⇒ the CLI's own age gate. A value that is not a whole number of hours **disables prune for that boot** instead of falling back (the CLI's default gate may be *shorter* than the one you asked for) |
 
 #### Config precedence: env var > daemon library default
 
@@ -302,6 +305,56 @@ Reclaiming the cache after the fact is not an option on Railway: `/sys/fs/cgroup
 is mounted read-only inside the container, so writing `memory.reclaim` fails with
 `EROFS` even as root (verified 2026-08-09). Avoidance is the only lever, which is
 why the entrypoint has no reclaim call.
+
+#### Volume hygiene: finished worktrees are pruned
+
+**The diagnosis.** Until issue #81 this container removed *nothing*, ever. Every
+review round materializes a per-PR worktree inside a hub (`<repo>/TASK-…`), plus
+whatever a session's build or test run leaves in it; a merged or closed PR left
+its worktree exactly where it was; and the bare `.source` object store behind
+each hub only ever grew, because nothing pruned the remote-tracking refs the
+deleted branches left behind. There was no cleanup path anywhere in the image —
+not at boot, not on merge, not on a timer — so the only bound on the volume was
+the volume's size, and the only remedy was a human with a shell.
+
+**The remediation** is the CLI's own primitive, `alissa code workspace prune`,
+which removes finished-branch worktrees behind its safety rails (never `main/`,
+never a dirty tree without `--force`, an age gate, a live-tmux-session guard,
+never a worktree whose PR is still open, and a lookup failure *keeps* the
+worktree) and then runs the hub-level `git worktree prune` /
+`git remote prune origin` / `git gc --auto` sequence. The entrypoint calls it in
+two places:
+
+- **at boot**, right after the hub sync, best-effort — a failure logs a warning
+  and the boot continues, exactly like the other best-effort boot steps. Prune
+  is an optimization, never a boot precondition;
+- **on an interval** (`ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES`, default 360), as
+  a supervised background loop that the shutdown handler kills alongside the
+  console sidecar. A failing pass warns and the loop waits for the next tick; it
+  never takes the container down.
+
+Three properties are worth stating explicitly, because they are what make this
+safe to leave on by default:
+
+- **`--force` is never passed, and there is no env knob that adds it.** In a
+  review container a dirty worktree is *evidence* — a session that died
+  mid-round with work someone may still want. The rail that keeps it is the one
+  this container needs most.
+- **It is capability-gated, not version-pinned.** The image installs the alissa
+  CLI from its install channel, which may predate the subcommand. The entrypoint
+  probes once at boot and, if the subcommand is missing, logs exactly one loud
+  `WARN: this alissa CLI predates 'alissa code workspace prune' …` and skips
+  *both* hooks. Nothing here needs to change when the CLI catches up. (The probe
+  reads the help *output*, not its exit status: commander answers an unknown
+  subcommand by printing the parent command's help and exiting `0`, so an
+  exit-status probe would call every old CLI capable.)
+- **The interval loop is daemon-only.** The [executor role](#bridge-executor-role-a-second-service-from-this-same-image)
+  gets the boot pass — it grows the same volume the same way — but not the loop:
+  that role `exec`s `alissa bridge start`, which replaces the shell, so a loop
+  started there would outlive the only code that knows how to stop it.
+
+If you turn this off (`ALISSA_WORKSPACE_PRUNE=0`), nothing else reclaims the
+volume; plan on pruning by hand.
 
 ### Reviewer console (runtime env only — `ALISSA_UI_ENABLED`, `ALISSA_UI_PASSCODE`, `PORT`)
 
@@ -462,6 +515,12 @@ ephemeral home and are gone on restart, so a persisted "round N in-flight" would
 otherwise be stale and stall re-enqueue for 90 min. A fresh container has no
 reviewer running by definition, so clearing them is safe and the daemon
 re-enqueues any still-pending round on its first poll.
+
+The volume is also the thing that **grows**: reviewer worktrees accumulate in
+the hubs and nothing used to remove them. The entrypoint now prunes finished-branch
+worktrees at boot and every `ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES` (default
+360) — see [Volume hygiene](#volume-hygiene-finished-worktrees-are-pruned) for the
+rails it runs behind and `ALISSA_WORKSPACE_PRUNE=0` for the opt-out.
 
 Nothing else needs a volume: the gh/alissa/claude auth is re-established from the
 env tokens on every boot, and tmux sockets are deliberately ephemeral.
@@ -724,6 +783,12 @@ volumes:
    daemon's on-demand `alissa code workspace add` no-ops on a repo already listed
    in the manifest, leaving an empty folder and looping forever hub-ifying a hub
    that never completes.
+3b. **`alissa code workspace prune`** — best-effort volume hygiene, on the path
+   both roles share: remove finished-branch worktrees (never `main/`, never
+   dirty, never an open PR, never `--force`) and run the hub-level git prune/gc.
+   Skipped with one loud warning if the CLI predates the subcommand, or if
+   `ALISSA_WORKSPACE_PRUNE=0`. A failure here is a warning, never a dead boot
+   ([why](#volume-hygiene-finished-worktrees-are-pruned)).
 3d. **Executor role only, and the end of the shared path**: drop this executor's
    stale lockfile, then `exec alissa bridge
    start …`. `exec`, so the container's only process is the executor — steps 4

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -237,7 +237,7 @@ automatically; locally pass `--build-arg`):
 | `ALISSA_FORCE_CHOWN` | `0` | `1`/`true`/`yes`/`on` forces the root phase's full `chown -R` of the volume for that boot; anything else (incl. unset) leaves the probe in charge. Off by default: the entrypoint probes ownership at depth 1 and walks only when it finds a foreign owner (see [Boot-time ownership](#boot-time-ownership-the-volume-walk-is-guarded)). Set it for **one** boot after a root shell wrote files deeper in the tree |
 | `ALISSA_WORKSPACE_PRUNE` | `1` (**on**) | volume hygiene: `1`/`true`/`yes`/`on` runs `alissa code workspace prune` at boot **and** on an interval; `0` opts out, after which nothing in the container reclaims anything. Default-on because this is the container whose volume grows (see [Volume hygiene](#volume-hygiene-finished-worktrees-are-pruned)). Skipped, with one loud warning, if the installed CLI predates the subcommand |
 | `ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES` | `360` | minutes between prune passes. Daemon role only — the executor gets the boot pass and no loop. A non-numeric or non-positive value warns and falls back to `360` |
-| `ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS` | `240` | how long ONE prune pass may run before it is killed, so a slow first sweep over a never-pruned volume cannot hold the boot open. The default is chosen to sit inside a 300s health-check window — the pass runs *before* `/healthz` exists (see below). A timed-out pass warns (exit 124) and changes nothing. Garbage falls back to `240` |
+| `ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS` | `240` | how long ONE prune pass may run before it is killed, so a slow first sweep over a never-pruned volume cannot hold the boot open. The default is chosen to sit inside a 300s health-check window — the pass runs *before* `/healthz` exists (see below). A timed-out pass warns (exit 124, or 137 if it had to be killed) and changes nothing. Garbage falls back to `240` |
 | `ALISSA_WORKSPACE_PRUNE_KILL_AFTER_SECONDS` | `30` | grace a `SIGTERM`-trapping prune gets before `SIGKILL` (`timeout -k`). Without it a CLI that traps `TERM` is unbounded again. **Timeout + grace** is what must fit your health-check window |
 | `ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS` | *(CLI default)* | passed straight through as `--min-age-hours`; **pass-through** — unset ⇒ the CLI's own age gate. A value that is not a whole number of hours **disables prune for that boot** instead of falling back (the CLI's default gate may be *shorter* than the one you asked for) |
 
@@ -367,13 +367,21 @@ The default of **240s** is picked against a window, not chosen for roundness. Th
 prune pass runs at step `3c-ii`; the console that serves `/healthz` — the health
 check [the Railway walkthrough above](#the-console-on-railway) tells you to
 configure — does not start until `4b`. The pass therefore sits *in front of* the
-endpoint the platform probes, and Railway's healthcheck timeout defaults to 300s,
-so a larger default would reproduce the restart loop the bound exists to prevent.
+endpoint the platform probes, and Railway's healthcheck timeout defaults to 300s.
 `ALISSA_WORKSPACE_PRUNE_KILL_AFTER_SECONDS` (30) is the grace a `SIGTERM`-trapping
-CLI gets before `SIGKILL`; **it is the sum that must fit the window**, not the
-timeout alone. Raising the timeout for a known-slow first sweep is fine — the
-warning tells you to — as long as timeout + grace stays inside whatever window
-sits in front of this container. The neighbouring `alissa code workspace sync` is deliberately *not*
+CLI gets before `SIGKILL`; **it is the sum that must fit**, not the timeout alone.
+
+**This bounds the prune step, not the boot.** 240 + 30 < 300 says prune alone fits
+the window; it does not say the boot does, and nothing here bounds the total. Two
+unbounded steps run in front of it: `alissa code workspace sync` at `3c` is
+deliberately unbounded (hubs are a precondition — without them the daemon reviews
+nothing, so blocking on it is correct), and the auth retry loop at `2c` backs off
+to a 600s ceiling, which exceeds the whole window on its own. So read 240 as
+prune's *share* of a window other steps also draw on — the reason to prefer it
+over 900 is that 900 gave this one step more than the entire window. If your
+deployment has a health check in front of it, budget across all three, and when
+you raise the timeout for a known-slow first sweep keep timeout + grace inside
+whatever is left. The neighbouring `alissa code workspace sync` is deliberately *not*
 bounded this way: hubs are a precondition for reviewing anything, while prune is
 an optimization, and only one of those may delay a boot.
 

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -237,7 +237,8 @@ automatically; locally pass `--build-arg`):
 | `ALISSA_FORCE_CHOWN` | `0` | `1`/`true`/`yes`/`on` forces the root phase's full `chown -R` of the volume for that boot; anything else (incl. unset) leaves the probe in charge. Off by default: the entrypoint probes ownership at depth 1 and walks only when it finds a foreign owner (see [Boot-time ownership](#boot-time-ownership-the-volume-walk-is-guarded)). Set it for **one** boot after a root shell wrote files deeper in the tree |
 | `ALISSA_WORKSPACE_PRUNE` | `1` (**on**) | volume hygiene: `1`/`true`/`yes`/`on` runs `alissa code workspace prune` at boot **and** on an interval; `0` opts out, after which nothing in the container reclaims anything. Default-on because this is the container whose volume grows (see [Volume hygiene](#volume-hygiene-finished-worktrees-are-pruned)). Skipped, with one loud warning, if the installed CLI predates the subcommand |
 | `ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES` | `360` | minutes between prune passes. Daemon role only — the executor gets the boot pass and no loop. A non-numeric or non-positive value warns and falls back to `360` |
-| `ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS` | `900` | how long ONE prune pass may run before it is killed, so a slow first sweep over a never-pruned volume cannot hold the boot open. A timed-out pass warns (exit 124) and changes nothing. Garbage falls back to `900` |
+| `ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS` | `240` | how long ONE prune pass may run before it is killed, so a slow first sweep over a never-pruned volume cannot hold the boot open. The default is chosen to sit inside a 300s health-check window — the pass runs *before* `/healthz` exists (see below). A timed-out pass warns (exit 124) and changes nothing. Garbage falls back to `240` |
+| `ALISSA_WORKSPACE_PRUNE_KILL_AFTER_SECONDS` | `30` | grace a `SIGTERM`-trapping prune gets before `SIGKILL` (`timeout -k`). Without it a CLI that traps `TERM` is unbounded again. **Timeout + grace** is what must fit your health-check window |
 | `ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS` | *(CLI default)* | passed straight through as `--min-age-hours`; **pass-through** — unset ⇒ the CLI's own age gate. A value that is not a whole number of hours **disables prune for that boot** instead of falling back (the CLI's default gate may be *shorter* than the one you asked for) |
 
 #### Config precedence: env var > daemon library default
@@ -358,10 +359,21 @@ safe to leave on by default:
 starts, and the first pass after the CLI lands sweeps `git gc --auto` across hubs
 on a volume that has never had anything reclaimed — minutes of work on a large
 object store, and on a platform with a startup health-check window a slow enough
-boot is a *dead* boot. So a pass runs under `timeout`
-(`ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS`, default 900) with **stdin closed**, and
+boot is a *dead* boot. So a pass runs under `timeout` with **stdin closed**, and
 a pass that hits either bound lands in the same warning path as any other
-failure. The neighbouring `alissa code workspace sync` is deliberately *not*
+failure.
+
+The default of **240s** is picked against a window, not chosen for roundness. The
+prune pass runs at step `3c-ii`; the console that serves `/healthz` — the health
+check [the Railway walkthrough above](#the-console-on-railway) tells you to
+configure — does not start until `4b`. The pass therefore sits *in front of* the
+endpoint the platform probes, and Railway's healthcheck timeout defaults to 300s,
+so a larger default would reproduce the restart loop the bound exists to prevent.
+`ALISSA_WORKSPACE_PRUNE_KILL_AFTER_SECONDS` (30) is the grace a `SIGTERM`-trapping
+CLI gets before `SIGKILL`; **it is the sum that must fit the window**, not the
+timeout alone. Raising the timeout for a known-slow first sweep is fine — the
+warning tells you to — as long as timeout + grace stays inside whatever window
+sits in front of this container. The neighbouring `alissa code workspace sync` is deliberately *not*
 bounded this way: hubs are a precondition for reviewing anything, while prune is
 an optimization, and only one of those may delay a boot.
 
@@ -807,8 +819,8 @@ volumes:
    both roles share: remove finished-branch worktrees (never `main/`, never
    dirty, never an open PR, never `--force`) and run the hub-level git prune/gc.
    Skipped with one loud warning if the CLI predates the subcommand, or if
-   `ALISSA_WORKSPACE_PRUNE=0`, and bounded by `timeout` with stdin closed so a
-   slow or prompting pass cannot hold the boot open. A failure here is a warning, never a dead boot
+   `ALISSA_WORKSPACE_PRUNE=0`, and bounded by `timeout -k` with stdin closed so a
+   slow, prompting, or `SIGTERM`-trapping pass cannot hold the boot open. A failure here is a warning, never a dead boot
    ([why](#volume-hygiene-finished-worktrees-are-pruned)).
 3d. **Executor role only, and the end of the shared path**: drop this executor's
    stale lockfile, then `exec alissa bridge

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -5,8 +5,8 @@
 #   0. as root: fix the volume-mount ownership (+ firewall), then drop to alissa
 #   1. preflight the identities the loop depends on (gh / alissa / claude)
 #   2. bootstrap the worktree-hub workspace + revloop config from a manifest
-#   2b. prune finished worktrees off the volume, then again on an interval
-#       (`alissa code workspace prune`, capability-gated, best-effort)
+#      …then prune finished worktrees off it (3c-ii), and again on an interval
+#      (`alissa code workspace prune`, capability-gated, bounded, best-effort)
 #   3. start `alissa worker` (backgrounded) and wait until it is up
 #   4. optionally start the `alissa-revloop-ui` console sidecar (ALISSA_UI_ENABLED)
 #   5. run `alissa-revloop` in the foreground, stopping the worker on exit
@@ -873,7 +873,7 @@ if [ -f "${MANIFEST}" ]; then
 fi
 
 # -----------------------------------------------------------------------------
-# 3e. Volume hygiene — `alissa code workspace prune` (issue #81).
+# 3c-ii. Volume hygiene — `alissa code workspace prune` (issue #81).
 #
 # Nothing in this container ever removed anything from the volume. Every review
 # round materializes a per-PR worktree in a hub (plus whatever a session's build
@@ -899,6 +899,17 @@ fi
 #     pin here would go stale on every CLI release. An older CLI gets exactly
 #     one loud warning and both hooks skip.
 #
+# CONCURRENCY WITH LIVE REVIEWER SESSIONS, since the interval loop fires into
+# hubs that may be mid-round: the CLI's live-session guard covers WORKTREE
+# REMOVAL, and for the hub-level tail we rely on git's own guarantee rather than
+# on the sweep being session-aware. `git gc --auto` never deletes a reachable
+# object, keeps unreachable ones for `gc.pruneExpire` (2 weeks by default),
+# publishes rewritten packs by atomic rename, and drops loose objects only after
+# that — so a concurrent checkout/commit in a sibling worktree sees a consistent
+# store throughout. What would NOT be safe is a pruning `gc --prune=now`, which
+# this entrypoint never asks for and has no knob to ask for, exactly like
+# `--force`.
+#
 # The interval loop is DAEMON-ONLY, and deliberately so: the executor role
 # `exec`s `alissa bridge start` a few lines below, which replaces this shell —
 # a loop started here would outlive the only code that knows how to stop it and
@@ -908,6 +919,7 @@ fi
 PRUNE_ENABLED=0
 PRUNE_INTERVAL_MINUTES=360
 PRUNE_INTERVAL_SECONDS=$(( 360 * 60 ))
+PRUNE_TIMEOUT_SECONDS=900
 # Never contains `--force`. See the block comment above; the entrypoint has no
 # knob that adds it, which is the point.
 PRUNE_ARGS=()
@@ -933,20 +945,49 @@ workspace_prune_supported() {
 # carry on", and the interval loop runs under this script's `set -e`, where a
 # non-zero return would silently kill the loop instead of the pass.
 #
+# BOUNDED AND STDIN-CLOSED, and that is the boot pass's whole safety story. A
+# failing pass is harmless — the volume simply keeps what it holds — but a pass
+# that BLOCKS would hold the boot open, and this hook runs before the worker
+# starts. Two ways that happens, both closed here rather than at the call site
+# so the interval pass inherits them too:
+#
+#   * the first pass after the CLI lands runs `git gc --auto` across hubs on a
+#     volume that, by this feature's own diagnosis, has never had anything
+#     reclaimed. On a multi-GB object store that is minutes — and on a platform
+#     with a startup health-check window, a slow enough boot IS a dead
+#     container, which is the one outcome this wiring must never cause.
+#   * command substitution inherits stdin, so a CLI that ever prompts would
+#     wait forever on a container that has no tty.
+#
+# A timed-out pass is just another non-zero exit into the WARN path below (124,
+# named there so the log says "timed out" instead of a bare number). This is
+# deliberately NOT how `workspace sync` above is treated: sync is a
+# precondition — no hubs, no reviews — while prune is an optimization, and only
+# one of those may hold a boot open.
+#
 # The CLI's per-worktree verdicts are captured and re-emitted through log(), so
 # they carry the entrypoint prefix and are greppable in the platform's boot log
-# next to everything else this boot did.
+# next to everything else this boot did. They go through redact_token() first:
+# every other captured-CLI-output path in this file does (see the auth triage),
+# prune shells out to git across every hub, and an https hub cloned by the
+# daemon's own on_missing_hub:add path has a credential helper wired in by
+# `gh auth setup-git` at step 1 — a failing `git remote prune origin` is one of
+# the few places that could echo a URL.
 workspace_prune_run() {
   local label="$1" out line rc=0
   # Run from the workspace root: the workspace binding is cwd-based, exactly as
   # for the `workspace sync` above.
-  out="$( cd "${WORKSPACE_ROOT}" && alissa code workspace prune ${PRUNE_ARGS[@]+"${PRUNE_ARGS[@]}"} 2>&1 )" \
+  out="$( cd "${WORKSPACE_ROOT}" \
+          && timeout "${PRUNE_TIMEOUT_SECONDS}" \
+             alissa code workspace prune ${PRUNE_ARGS[@]+"${PRUNE_ARGS[@]}"} </dev/null 2>&1 )" \
     || rc=$?
   if [ -n "${out}" ]; then
-    while IFS= read -r line; do log "prune[${label}]: ${line}"; done <<<"${out}"
+    while IFS= read -r line; do log "prune[${label}]: $(redact_token "${line}")"; done <<<"${out}"
   fi
   if [ "${rc}" = "0" ]; then
     log "workspace prune (${label}) finished"
+  elif [ "${rc}" = "124" ]; then
+    log "WARN: workspace prune (${label}) TIMED OUT after ${PRUNE_TIMEOUT_SECONDS}s and was killed — the boot was not held open, and nothing was removed. A first pass over a never-pruned volume can legitimately need longer: raise ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS."
   else
     log "WARN: workspace prune (${label}) exited ${rc} — nothing was removed by this pass; the volume keeps what it holds until the next one. Check the verdict lines above."
   fi
@@ -981,37 +1022,57 @@ else
 fi
 
 if [ "${PRUNE_ENABLED}" = "1" ]; then
-  # The interval is not a safety knob — a bad one only changes how often a
-  # best-effort pass runs — so a garbage value falls back to the default with a
-  # warning instead of disabling the feature.
-  PRUNE_INTERVAL_MINUTES="${ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES:-360}"
-  if ! printf '%s' "${PRUNE_INTERVAL_MINUTES}" | grep -qE '^[1-9][0-9]*$'; then
-    log "WARN: ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES=${PRUNE_INTERVAL_MINUTES} is not a positive whole number of minutes — falling back to 360"
-    PRUNE_INTERVAL_MINUTES=360
+  # How long ONE pass may run before it is killed — a bound, not a budget. 900s
+  # is generous for a warm volume and still well inside any platform's startup
+  # window. Both roles resolve it, because both run the boot pass. Garbage falls
+  # back to the default with a warning rather than failing closed: a bound that
+  # is merely wrong is still a bound, and disabling the hygiene over a typo
+  # would trade the smaller problem for the larger one.
+  PRUNE_TIMEOUT_SECONDS="${ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS:-900}"
+  if ! printf '%s' "${PRUNE_TIMEOUT_SECONDS}" | grep -qE '^[1-9][0-9]*$'; then
+    log "WARN: ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS=${PRUNE_TIMEOUT_SECONDS} is not a positive whole number of seconds — falling back to 900"
+    PRUNE_TIMEOUT_SECONDS=900
   fi
-  PRUNE_INTERVAL_SECONDS=$(( PRUNE_INTERVAL_MINUTES * 60 ))
 
-  # ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS is TEST-ONLY, on the same footing as
-  # ALISSA_AUTH_RETRY_SECONDS: tests-entrypoint-prune.sh has to watch the loop
-  # tick more than once, and the smallest value the documented knob can express
-  # is a minute per tick. A deploy leaves it unset.
-  if [ -n "${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS:-}" ]; then
-    if printf '%s' "${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS}" | grep -qE '^[1-9][0-9]*$'; then
-      PRUNE_INTERVAL_SECONDS="${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS}"
-      log "workspace prune: interval overridden to ${PRUNE_INTERVAL_SECONDS}s (ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS — test-only)"
-    else
-      log "WARN: ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS=${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS} is not a positive whole number of seconds — ignoring it"
+  if [ "${CONTAINER_ROLE}" = "executor" ]; then
+    # No interval resolution at all in this role: it never reaches 4c, and
+    # validating, defaulting and ANNOUNCING a cadence it will not run would put
+    # two contradicting lines in its boot log.
+    log "workspace prune ENABLED — boot pass only (executor role; min-age: ${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS:-CLI default}, timeout ${PRUNE_TIMEOUT_SECONDS}s, --force never passed). The interval loop belongs to the daemon's process chain: this role 'exec's the bridge, so there would be nothing left here to tear a loop down."
+  else
+    # The interval is not a safety knob — a bad one only changes how often a
+    # best-effort pass runs — so a garbage value falls back to the default with
+    # a warning instead of disabling the feature.
+    PRUNE_INTERVAL_MINUTES="${ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES:-360}"
+    if ! printf '%s' "${PRUNE_INTERVAL_MINUTES}" | grep -qE '^[1-9][0-9]*$'; then
+      log "WARN: ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES=${PRUNE_INTERVAL_MINUTES} is not a positive whole number of minutes — falling back to 360"
+      PRUNE_INTERVAL_MINUTES=360
     fi
+    PRUNE_INTERVAL_SECONDS=$(( PRUNE_INTERVAL_MINUTES * 60 ))
+
+    # ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS is TEST-ONLY, on the same footing
+    # as ALISSA_AUTH_RETRY_SECONDS and ALISSA_INSTALL_URL — and, like them, it
+    # is documented as test-only in docker/claude/README.md rather than only
+    # here: an override a shipped entrypoint honours but no operator can find is
+    # a footgun. tests-entrypoint-prune.sh has to watch the loop tick more than
+    # once, and the smallest cadence the supported knob can express is a minute.
+    # A deploy leaves it unset.
+    if [ -n "${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS:-}" ]; then
+      if printf '%s' "${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS}" | grep -qE '^[1-9][0-9]*$'; then
+        PRUNE_INTERVAL_SECONDS="${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS}"
+        log "workspace prune: interval overridden to ${PRUNE_INTERVAL_SECONDS}s (ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS — test-only, not for a deploy)"
+      else
+        log "WARN: ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS=${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS} is not a positive whole number of seconds — ignoring it"
+      fi
+    fi
+
+    log "workspace prune ENABLED — boot pass now, then every ${PRUNE_INTERVAL_MINUTES} min (min-age: ${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS:-CLI default}, timeout ${PRUNE_TIMEOUT_SECONDS}s, --force never passed)"
   fi
 
-  log "workspace prune ENABLED — boot pass now, then every ${PRUNE_INTERVAL_MINUTES} min (min-age: ${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS:-CLI default}, --force never passed)"
   # Best-effort, exactly like the other boot steps: prune is an optimization,
   # never a boot precondition. workspace_prune_run already swallows the status;
   # the `|| true` is the belt to that suspenders, and says so at the call site.
   workspace_prune_run boot || true
-  if [ "${CONTAINER_ROLE}" = "executor" ]; then
-    log "workspace prune: executor role runs the boot pass only — the interval loop belongs to the daemon's process chain, and this role 'exec's the bridge, leaving nothing here to tear a loop down"
-  fi
 fi
 
 # -----------------------------------------------------------------------------
@@ -1141,11 +1202,11 @@ if [ "${UI_ENABLED}" = "1" ]; then
 fi
 
 # -----------------------------------------------------------------------------
-# 4c. The periodic workspace prune (daemon role only — see 3e).
+# 4c. The periodic workspace prune (daemon role only — see 3c-ii).
 #
 # Same in-container background pattern as the console monitor above: a subshell
 # child of this entrypoint, so tini reaps it, and a pid the shutdown handler
-# kills. `sleep` FIRST, so the interval measures from the boot pass that 3e
+# kills. `sleep` FIRST, so the interval measures from the boot pass that 3c-ii
 # already ran rather than pruning twice in a row on every restart.
 #
 # The loop cannot die of a prune failure: workspace_prune_run returns 0 always

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -967,18 +967,11 @@ workspace_prune_supported() {
 # a handler that finishes the in-flight git operation before exiting is exactly
 # what a careful implementation would install, so the bound would go missing at
 # the moment the CLI lands and the feature stops being a no-op. `-k` gives such a
-# handler PRUNE_KILL_AFTER_SECONDS to finish and then KILLs it; the exit status
-# stays 124 either way, so the WARN path below does not care which signal did it.
-#
-# `-k` IS PART OF THE BOUND, not a refinement of it. Plain `timeout` sends TERM
-# and then waits indefinitely, so a child that traps TERM is unbounded again —
-# the same boot-held-open failure, one step further along. That is not a
-# hypothetical for this subcommand: `workspace prune` is the destructive one, and
-# a handler that finishes the in-flight git operation before exiting is exactly
-# what a careful implementation would install, so the bound would go missing at
-# the moment the CLI lands and the feature stops being a no-op. `-k` gives such a
-# handler PRUNE_KILL_AFTER_SECONDS to finish and then KILLs it; the exit status
-# stays 124 either way, so the WARN path below does not care which signal did it.
+# handler PRUNE_KILL_AFTER_SECONDS to finish and then KILLs it — and that path
+# reports 137 (128+9), NOT 124, which is why the WARN below has a branch of its
+# own for it. Do not "simplify" the two into one: `timeout` normalises nothing
+# here (measured on coreutils 9.1), so a 124-only branch files the very case `-k`
+# exists for under the generic "exited N" message.
 #
 # A timed-out pass is just another non-zero exit into the WARN path below (124,
 # named there so the log says "timed out" instead of a bare number). This is
@@ -996,6 +989,12 @@ workspace_prune_supported() {
 # the few places that could echo a URL.
 workspace_prune_run() {
   local label="$1" out line rc=0
+  # When the pass started, so the 137 branch below can tell OUR kill from someone
+  # else's. `timeout` reports 128+signal for ANY signal death of the child, so
+  # 137 alone does not mean "we killed it after the grace" — an OOM kill looks
+  # identical, and on a memory-capped container a `git gc --auto` sweep over a
+  # never-pruned object store is the best OOM candidate the boot has (issue #74).
+  local started=${SECONDS}
   # Run from the workspace root: the workspace binding is cwd-based, exactly as
   # for the `workspace sync` above.
   out="$( cd "${WORKSPACE_ROOT}" \
@@ -1009,13 +1008,19 @@ workspace_prune_run() {
     log "workspace prune (${label}) finished"
   elif [ "${rc}" = "124" ]; then
     log "WARN: workspace prune (${label}) TIMED OUT after ${PRUNE_TIMEOUT_SECONDS}s and was terminated — the boot was not held open, and nothing was removed. A first pass over a never-pruned volume can legitimately need longer: raise ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS, but keep it (plus the grace) inside your platform's health-check window."
-  elif [ "${rc}" = "137" ]; then
-    # 124 is `timeout`'s own "I terminated it"; 137 (128+9) is what it reports
-    # when the child had to be KILLED after `-k`. Measured, not assumed: GNU
-    # timeout does NOT normalise the kill path to 124, so a 124-only branch would
-    # file exactly the case `-k` exists for under the generic "exited N" message.
-    # Worth its own line either way — a CLI that ignores SIGTERM is a fact about
-    # the CLI, not about this boot.
+  elif [ "${rc}" = "137" ] && [ $(( SECONDS - started )) -ge "${PRUNE_TIMEOUT_SECONDS}" ]; then
+    # 124 is `timeout`'s own "I terminated it" and needs no corroboration. 137 is
+    # NOT ours to claim: it is 128+9, which `timeout` reports for any SIGKILL
+    # death of the child — `timeout 100 bash -c 'kill -9 $$'` returns 137 with no
+    # `-k` involved at all. The elapsed check is the disambiguator: only a pass
+    # that actually ran out its bound can have been killed by our grace.
+    #
+    # An early 137 therefore falls through to the generic branch below, which
+    # says only what it knows. That matters because the realistic early cause is
+    # the OOM killer, and this branch's remedy — raise the timeout — would make
+    # an OOM strictly worse (the next pass runs longer and allocates more before
+    # dying), while pointing the investigation at the CLI instead of the memory
+    # ceiling.
     log "WARN: workspace prune (${label}) TIMED OUT after ${PRUNE_TIMEOUT_SECONDS}s and did NOT exit on SIGTERM, so it was KILLED after the ${PRUNE_KILL_AFTER_SECONDS}s grace — the boot was not held open, and nothing was removed. Raise ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS (keeping it plus the grace inside your health-check window); if this recurs, the CLI is trapping SIGTERM and the grace may need to be longer."
   else
     log "WARN: workspace prune (${label}) exited ${rc} — nothing was removed by this pass; the volume keeps what it holds until the next one. Check the verdict lines above."
@@ -1056,12 +1061,17 @@ if [ "${PRUNE_ENABLED}" = "1" ]; then
   # 240s, and the number is chosen against a specific window rather than being
   # "generously large": this pass runs at 3c-ii, while the console that serves
   # the documented `/healthz` deployment health check does not start until 4b —
-  # so the pass sits IN FRONT of the endpoint the platform probes. Railway's
-  # healthcheck timeout defaults to 300s (and the README's own Railway walkthrough
-  # tells the operator to point it at `/healthz`), so any default above that
-  # reproduces the restart loop this bound exists to prevent, under the shipped
-  # configuration. A bound whose default permits its own failure mode is not a
-  # bound.
+  # so the pass sits IN FRONT of the endpoint the platform probes, and Railway's
+  # healthcheck timeout defaults to 300s.
+  #
+  # BE PRECISE ABOUT WHAT THIS BUYS, because 240+30 < 300 is easy to misread as a
+  # guarantee that the boot fits the window. It is not one. This bounds the step
+  # this file's prune hook owns; the boot's TOTAL is bounded by nothing here —
+  # `3c` (`workspace sync`) is deliberately unbounded, for the reason argued 80
+  # lines up, and `2c`'s auth retry ceiling is 600s on its own. 240 is prune's
+  # SHARE of a window those steps also draw on, and it is chosen because 900 gave
+  # this one step more than the whole window on the platform the README walks
+  # through.
   #
   # The trade runs one way: a timed-out pass costs a warning and nothing else —
   # the volume simply keeps what it holds until the next tick — while an overrun
@@ -1078,10 +1088,11 @@ if [ "${PRUNE_ENABLED}" = "1" ]; then
     log "WARN: ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS=${PRUNE_TIMEOUT_SECONDS} is not a positive whole number of seconds — falling back to 240"
     PRUNE_TIMEOUT_SECONDS=240
   fi
-  # Grace for a CLI that traps TERM, before KILL. Test-only override; a deploy
-  # leaves it unset. 30s is long enough for an in-flight git operation to finish
-  # and short enough that TIMEOUT+GRACE (270s) still lands inside that 300s
-  # window — the pair is what has to fit, not the timeout alone.
+  # Grace for a CLI that traps TERM, before KILL. Operator-tunable; see the env
+  # table in docker/claude/README.md (this is NOT one of the test-only overrides).
+  # 30s is long enough for an in-flight git operation to finish, and the pair —
+  # timeout PLUS grace — is what has to fit whatever window sits in front of this
+  # container, not the timeout alone.
   PRUNE_KILL_AFTER_SECONDS="${ALISSA_WORKSPACE_PRUNE_KILL_AFTER_SECONDS:-30}"
   if ! printf '%s' "${PRUNE_KILL_AFTER_SECONDS}" | grep -qE '^[1-9][0-9]*$'; then
     log "WARN: ALISSA_WORKSPACE_PRUNE_KILL_AFTER_SECONDS=${PRUNE_KILL_AFTER_SECONDS} is not a positive whole number of seconds — falling back to 30"

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -5,6 +5,8 @@
 #   0. as root: fix the volume-mount ownership (+ firewall), then drop to alissa
 #   1. preflight the identities the loop depends on (gh / alissa / claude)
 #   2. bootstrap the worktree-hub workspace + revloop config from a manifest
+#   2b. prune finished worktrees off the volume, then again on an interval
+#       (`alissa code workspace prune`, capability-gated, best-effort)
 #   3. start `alissa worker` (backgrounded) and wait until it is up
 #   4. optionally start the `alissa-revloop-ui` console sidecar (ALISSA_UI_ENABLED)
 #   5. run `alissa-revloop` in the foreground, stopping the worker on exit
@@ -871,6 +873,148 @@ if [ -f "${MANIFEST}" ]; then
 fi
 
 # -----------------------------------------------------------------------------
+# 3e. Volume hygiene — `alissa code workspace prune` (issue #81).
+#
+# Nothing in this container ever removed anything from the volume. Every review
+# round materializes a per-PR worktree in a hub (plus whatever a session's build
+# leaves behind), merged or closed PRs leave theirs in place forever, and the
+# bare `.source` object store only grows. `alissa code workspace prune` is the
+# remediation primitive: it removes finished-branch worktrees behind the CLI's
+# own safety rails (never `main/`, never a dirty tree without --force, an age
+# gate, a live-tmux-session guard, never a worktree whose PR is still open, and
+# a lookup failure KEEPS the worktree) and then runs the hub-level
+# `git worktree prune` / `git remote prune origin` / `git gc --auto` sequence.
+#
+# Three properties this wiring must have, in order of how much they matter:
+#
+#   * it can never take the container down. Prune is an optimization; a failing
+#     one leaves exactly the disk usage we already had. So: best-effort at boot,
+#     and an interval loop that warns and waits for the next tick.
+#   * `--force` is NEVER passed. In a review container a dirty worktree is
+#     evidence — a session that died mid-round, with uncommitted work someone
+#     may still want. The rail that keeps it is the one this entrypoint most
+#     needs, so the flag that defeats it is not exposed at all.
+#   * it is CAPABILITY-GATED, not version-pinned. The image installs the alissa
+#     CLI from an install channel that may predate the subcommand, and a hard
+#     pin here would go stale on every CLI release. An older CLI gets exactly
+#     one loud warning and both hooks skip.
+#
+# The interval loop is DAEMON-ONLY, and deliberately so: the executor role
+# `exec`s `alissa bridge start` a few lines below, which replaces this shell —
+# a loop started here would outlive the only code that knows how to stop it and
+# would keep pruning against jobs it cannot see being torn down. The executor
+# still gets the boot pass, because it grows the same volume the same way.
+# -----------------------------------------------------------------------------
+PRUNE_ENABLED=0
+PRUNE_INTERVAL_MINUTES=360
+PRUNE_INTERVAL_SECONDS=$(( 360 * 60 ))
+# Never contains `--force`. See the block comment above; the entrypoint has no
+# knob that adds it, which is the point.
+PRUNE_ARGS=()
+
+# Does this CLI ship `alissa code workspace prune`?
+#
+# NOT "does `--help` exit 0". Commander answers an UNKNOWN subcommand by
+# printing the PARENT command's help and exiting 0 — verified against alissa
+# CLI 0.1.0, where `alissa code workspace prune --help` prints the `workspace`
+# help and exits 0 without a word about prune. A probe on the exit status alone
+# would therefore report every old CLI as capable and we would discover the
+# truth one failing prune at a time. So the probe reads the OUTPUT: a real
+# subcommand prints its own `Usage: … workspace prune …`, and a help that lists
+# a `prune` command counts too.
+workspace_prune_supported() {
+  local out
+  out="$(alissa code workspace prune --help 2>&1)" || return 1
+  printf '%s\n' "${out}" \
+    | grep -qE '^[[:space:]]*(Usage:[[:space:]].*workspace[[:space:]]+prune|prune([[:space:]]|$))'
+}
+
+# One prune pass. ALWAYS returns 0: both callers treat a failure as "warn and
+# carry on", and the interval loop runs under this script's `set -e`, where a
+# non-zero return would silently kill the loop instead of the pass.
+#
+# The CLI's per-worktree verdicts are captured and re-emitted through log(), so
+# they carry the entrypoint prefix and are greppable in the platform's boot log
+# next to everything else this boot did.
+workspace_prune_run() {
+  local label="$1" out line rc=0
+  # Run from the workspace root: the workspace binding is cwd-based, exactly as
+  # for the `workspace sync` above.
+  out="$( cd "${WORKSPACE_ROOT}" && alissa code workspace prune ${PRUNE_ARGS[@]+"${PRUNE_ARGS[@]}"} 2>&1 )" \
+    || rc=$?
+  if [ -n "${out}" ]; then
+    while IFS= read -r line; do log "prune[${label}]: ${line}"; done <<<"${out}"
+  fi
+  if [ "${rc}" = "0" ]; then
+    log "workspace prune (${label}) finished"
+  else
+    log "WARN: workspace prune (${label}) exited ${rc} — nothing was removed by this pass; the volume keeps what it holds until the next one. Check the verdict lines above."
+  fi
+  return 0
+}
+
+# Default ON: this container is the one whose volume is growing, so the knob is
+# an opt-OUT. Same truthiness as every other gate here.
+if ! is_truthy "${ALISSA_WORKSPACE_PRUNE:-1}"; then
+  log "workspace prune DISABLED (ALISSA_WORKSPACE_PRUNE=${ALISSA_WORKSPACE_PRUNE:-1}) — nothing in this container reclaims finished worktrees, so the volume grows until someone prunes it by hand"
+elif ! workspace_prune_supported; then
+  # Exactly one warning, and it is loud: this is a silent-growth condition, and
+  # the only signal an operator gets that the hygiene they think is running is
+  # not. Both hooks stay off — see the capability-gate rationale above.
+  log "WARN: this alissa CLI predates 'alissa code workspace prune' — workspace prune is SKIPPED at boot AND on the interval, and the volume WILL grow. Upgrade the CLI in the image's install channel; nothing about this entrypoint needs to change when it lands."
+else
+  PRUNE_ENABLED=1
+
+  # `--min-age-hours` is a SAFETY knob: a larger value keeps MORE worktrees. A
+  # value the CLI would reject therefore must not fall back to the CLI's own
+  # default — that would prune worktrees younger than the operator asked to
+  # keep, which is the one direction of error that destroys something. Fail
+  # closed instead: skip the whole feature for this boot and say why.
+  if [ -n "${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS:-}" ]; then
+    if printf '%s' "${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS}" | grep -qE '^[0-9]+$'; then
+      PRUNE_ARGS+=( --min-age-hours "${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS}" )
+    else
+      PRUNE_ENABLED=0
+      log "WARN: ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS=${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS} is not a whole number of hours — workspace prune is SKIPPED entirely rather than run with the CLI's default age gate, because that gate could be SHORTER than the one you asked for. Fix the value (or unset it to accept the CLI's default) and redeploy."
+    fi
+  fi
+fi
+
+if [ "${PRUNE_ENABLED}" = "1" ]; then
+  # The interval is not a safety knob — a bad one only changes how often a
+  # best-effort pass runs — so a garbage value falls back to the default with a
+  # warning instead of disabling the feature.
+  PRUNE_INTERVAL_MINUTES="${ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES:-360}"
+  if ! printf '%s' "${PRUNE_INTERVAL_MINUTES}" | grep -qE '^[1-9][0-9]*$'; then
+    log "WARN: ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES=${PRUNE_INTERVAL_MINUTES} is not a positive whole number of minutes — falling back to 360"
+    PRUNE_INTERVAL_MINUTES=360
+  fi
+  PRUNE_INTERVAL_SECONDS=$(( PRUNE_INTERVAL_MINUTES * 60 ))
+
+  # ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS is TEST-ONLY, on the same footing as
+  # ALISSA_AUTH_RETRY_SECONDS: tests-entrypoint-prune.sh has to watch the loop
+  # tick more than once, and the smallest value the documented knob can express
+  # is a minute per tick. A deploy leaves it unset.
+  if [ -n "${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS:-}" ]; then
+    if printf '%s' "${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS}" | grep -qE '^[1-9][0-9]*$'; then
+      PRUNE_INTERVAL_SECONDS="${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS}"
+      log "workspace prune: interval overridden to ${PRUNE_INTERVAL_SECONDS}s (ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS — test-only)"
+    else
+      log "WARN: ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS=${ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS} is not a positive whole number of seconds — ignoring it"
+    fi
+  fi
+
+  log "workspace prune ENABLED — boot pass now, then every ${PRUNE_INTERVAL_MINUTES} min (min-age: ${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS:-CLI default}, --force never passed)"
+  # Best-effort, exactly like the other boot steps: prune is an optimization,
+  # never a boot precondition. workspace_prune_run already swallows the status;
+  # the `|| true` is the belt to that suspenders, and says so at the call site.
+  workspace_prune_run boot || true
+  if [ "${CONTAINER_ROLE}" = "executor" ]; then
+    log "workspace prune: executor role runs the boot pass only — the interval loop belongs to the daemon's process chain, and this role 'exec's the bridge, leaving nothing here to tear a loop down"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
 # 3d. EXECUTOR ROLE — hand the container over to `alissa bridge start`.
 #
 # This is the end of the shared path. `exec` replaces this shell, so tini's only
@@ -997,6 +1141,30 @@ if [ "${UI_ENABLED}" = "1" ]; then
 fi
 
 # -----------------------------------------------------------------------------
+# 4c. The periodic workspace prune (daemon role only — see 3e).
+#
+# Same in-container background pattern as the console monitor above: a subshell
+# child of this entrypoint, so tini reaps it, and a pid the shutdown handler
+# kills. `sleep` FIRST, so the interval measures from the boot pass that 3e
+# already ran rather than pruning twice in a row on every restart.
+#
+# The loop cannot die of a prune failure: workspace_prune_run returns 0 always
+# (a non-zero return under `set -e` would end the subshell, turning one failed
+# pass into no more passes until the next redeploy).
+# -----------------------------------------------------------------------------
+PRUNE_PID=""
+if [ "${PRUNE_ENABLED}" = "1" ]; then
+  log "starting the workspace prune loop (every ${PRUNE_INTERVAL_MINUTES} min = ${PRUNE_INTERVAL_SECONDS}s)"
+  (
+    while true; do
+      sleep "${PRUNE_INTERVAL_SECONDS}"
+      workspace_prune_run interval
+    done
+  ) &
+  PRUNE_PID=$!
+fi
+
+# -----------------------------------------------------------------------------
 # 5. Run the daemon in the foreground; stop the worker on shutdown.
 # -----------------------------------------------------------------------------
 DAEMON_PID=""
@@ -1005,6 +1173,10 @@ shutdown() {
   # Silence the console monitor FIRST so tearing the sidecar down below does not
   # trip its "EXITED" alarm during an orderly shutdown.
   [ -n "${UI_MONITOR_PID}" ] && kill "${UI_MONITOR_PID}" 2>/dev/null || true
+  # The prune loop goes down with it, and for the same reason: an orderly
+  # shutdown must not start a pass into a container that is being torn down
+  # (the CLI walks hubs and can run `git gc` — work worth not interrupting).
+  [ -n "${PRUNE_PID}" ] && kill "${PRUNE_PID}" 2>/dev/null || true
   [ -n "${UI_PID}" ] && kill "${UI_PID}" 2>/dev/null || true
   [ -n "${DAEMON_PID}" ] && kill "${DAEMON_PID}" 2>/dev/null || true
   alissa worker stop >/dev/null 2>&1 || true

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -919,7 +919,8 @@ fi
 PRUNE_ENABLED=0
 PRUNE_INTERVAL_MINUTES=360
 PRUNE_INTERVAL_SECONDS=$(( 360 * 60 ))
-PRUNE_TIMEOUT_SECONDS=900
+PRUNE_TIMEOUT_SECONDS=240
+PRUNE_KILL_AFTER_SECONDS=30
 # Never contains `--force`. See the block comment above; the entrypoint has no
 # knob that adds it, which is the point.
 PRUNE_ARGS=()
@@ -959,6 +960,26 @@ workspace_prune_supported() {
 #   * command substitution inherits stdin, so a CLI that ever prompts would
 #     wait forever on a container that has no tty.
 #
+# `-k` IS PART OF THE BOUND, not a refinement of it. Plain `timeout` sends TERM
+# and then waits indefinitely, so a child that traps TERM is unbounded again —
+# the same boot-held-open failure, one step further along. That is not a
+# hypothetical for this subcommand: `workspace prune` is the destructive one, and
+# a handler that finishes the in-flight git operation before exiting is exactly
+# what a careful implementation would install, so the bound would go missing at
+# the moment the CLI lands and the feature stops being a no-op. `-k` gives such a
+# handler PRUNE_KILL_AFTER_SECONDS to finish and then KILLs it; the exit status
+# stays 124 either way, so the WARN path below does not care which signal did it.
+#
+# `-k` IS PART OF THE BOUND, not a refinement of it. Plain `timeout` sends TERM
+# and then waits indefinitely, so a child that traps TERM is unbounded again —
+# the same boot-held-open failure, one step further along. That is not a
+# hypothetical for this subcommand: `workspace prune` is the destructive one, and
+# a handler that finishes the in-flight git operation before exiting is exactly
+# what a careful implementation would install, so the bound would go missing at
+# the moment the CLI lands and the feature stops being a no-op. `-k` gives such a
+# handler PRUNE_KILL_AFTER_SECONDS to finish and then KILLs it; the exit status
+# stays 124 either way, so the WARN path below does not care which signal did it.
+#
 # A timed-out pass is just another non-zero exit into the WARN path below (124,
 # named there so the log says "timed out" instead of a bare number). This is
 # deliberately NOT how `workspace sync` above is treated: sync is a
@@ -978,7 +999,7 @@ workspace_prune_run() {
   # Run from the workspace root: the workspace binding is cwd-based, exactly as
   # for the `workspace sync` above.
   out="$( cd "${WORKSPACE_ROOT}" \
-          && timeout "${PRUNE_TIMEOUT_SECONDS}" \
+          && timeout -k "${PRUNE_KILL_AFTER_SECONDS}" "${PRUNE_TIMEOUT_SECONDS}" \
              alissa code workspace prune ${PRUNE_ARGS[@]+"${PRUNE_ARGS[@]}"} </dev/null 2>&1 )" \
     || rc=$?
   if [ -n "${out}" ]; then
@@ -987,7 +1008,15 @@ workspace_prune_run() {
   if [ "${rc}" = "0" ]; then
     log "workspace prune (${label}) finished"
   elif [ "${rc}" = "124" ]; then
-    log "WARN: workspace prune (${label}) TIMED OUT after ${PRUNE_TIMEOUT_SECONDS}s and was killed — the boot was not held open, and nothing was removed. A first pass over a never-pruned volume can legitimately need longer: raise ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS."
+    log "WARN: workspace prune (${label}) TIMED OUT after ${PRUNE_TIMEOUT_SECONDS}s and was terminated — the boot was not held open, and nothing was removed. A first pass over a never-pruned volume can legitimately need longer: raise ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS, but keep it (plus the grace) inside your platform's health-check window."
+  elif [ "${rc}" = "137" ]; then
+    # 124 is `timeout`'s own "I terminated it"; 137 (128+9) is what it reports
+    # when the child had to be KILLED after `-k`. Measured, not assumed: GNU
+    # timeout does NOT normalise the kill path to 124, so a 124-only branch would
+    # file exactly the case `-k` exists for under the generic "exited N" message.
+    # Worth its own line either way — a CLI that ignores SIGTERM is a fact about
+    # the CLI, not about this boot.
+    log "WARN: workspace prune (${label}) TIMED OUT after ${PRUNE_TIMEOUT_SECONDS}s and did NOT exit on SIGTERM, so it was KILLED after the ${PRUNE_KILL_AFTER_SECONDS}s grace — the boot was not held open, and nothing was removed. Raise ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS (keeping it plus the grace inside your health-check window); if this recurs, the CLI is trapping SIGTERM and the grace may need to be longer."
   else
     log "WARN: workspace prune (${label}) exited ${rc} — nothing was removed by this pass; the volume keeps what it holds until the next one. Check the verdict lines above."
   fi
@@ -1022,23 +1051,48 @@ else
 fi
 
 if [ "${PRUNE_ENABLED}" = "1" ]; then
-  # How long ONE pass may run before it is killed — a bound, not a budget. 900s
-  # is generous for a warm volume and still well inside any platform's startup
-  # window. Both roles resolve it, because both run the boot pass. Garbage falls
-  # back to the default with a warning rather than failing closed: a bound that
-  # is merely wrong is still a bound, and disabling the hygiene over a typo
-  # would trade the smaller problem for the larger one.
-  PRUNE_TIMEOUT_SECONDS="${ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS:-900}"
+  # How long ONE pass may run before it is killed — a bound, not a budget.
+  #
+  # 240s, and the number is chosen against a specific window rather than being
+  # "generously large": this pass runs at 3c-ii, while the console that serves
+  # the documented `/healthz` deployment health check does not start until 4b —
+  # so the pass sits IN FRONT of the endpoint the platform probes. Railway's
+  # healthcheck timeout defaults to 300s (and the README's own Railway walkthrough
+  # tells the operator to point it at `/healthz`), so any default above that
+  # reproduces the restart loop this bound exists to prevent, under the shipped
+  # configuration. A bound whose default permits its own failure mode is not a
+  # bound.
+  #
+  # The trade runs one way: a timed-out pass costs a warning and nothing else —
+  # the volume simply keeps what it holds until the next tick — while an overrun
+  # boot costs the container. So the default protects the boot, and the known
+  # slow case (a first sweep over a never-pruned volume) is served by RAISING the
+  # knob, which is exactly what the timeout WARN tells the operator to do.
+  #
+  # Both roles resolve it, because both run the boot pass. Garbage falls back to
+  # the default with a warning rather than failing closed: a bound that is merely
+  # wrong is still a bound, and disabling the hygiene over a typo would trade the
+  # smaller problem for the larger one.
+  PRUNE_TIMEOUT_SECONDS="${ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS:-240}"
   if ! printf '%s' "${PRUNE_TIMEOUT_SECONDS}" | grep -qE '^[1-9][0-9]*$'; then
-    log "WARN: ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS=${PRUNE_TIMEOUT_SECONDS} is not a positive whole number of seconds — falling back to 900"
-    PRUNE_TIMEOUT_SECONDS=900
+    log "WARN: ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS=${PRUNE_TIMEOUT_SECONDS} is not a positive whole number of seconds — falling back to 240"
+    PRUNE_TIMEOUT_SECONDS=240
+  fi
+  # Grace for a CLI that traps TERM, before KILL. Test-only override; a deploy
+  # leaves it unset. 30s is long enough for an in-flight git operation to finish
+  # and short enough that TIMEOUT+GRACE (270s) still lands inside that 300s
+  # window — the pair is what has to fit, not the timeout alone.
+  PRUNE_KILL_AFTER_SECONDS="${ALISSA_WORKSPACE_PRUNE_KILL_AFTER_SECONDS:-30}"
+  if ! printf '%s' "${PRUNE_KILL_AFTER_SECONDS}" | grep -qE '^[1-9][0-9]*$'; then
+    log "WARN: ALISSA_WORKSPACE_PRUNE_KILL_AFTER_SECONDS=${PRUNE_KILL_AFTER_SECONDS} is not a positive whole number of seconds — falling back to 30"
+    PRUNE_KILL_AFTER_SECONDS=30
   fi
 
   if [ "${CONTAINER_ROLE}" = "executor" ]; then
     # No interval resolution at all in this role: it never reaches 4c, and
     # validating, defaulting and ANNOUNCING a cadence it will not run would put
     # two contradicting lines in its boot log.
-    log "workspace prune ENABLED — boot pass only (executor role; min-age: ${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS:-CLI default}, timeout ${PRUNE_TIMEOUT_SECONDS}s, --force never passed). The interval loop belongs to the daemon's process chain: this role 'exec's the bridge, so there would be nothing left here to tear a loop down."
+    log "workspace prune ENABLED — boot pass only (executor role; min-age: ${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS:-CLI default}, timeout ${PRUNE_TIMEOUT_SECONDS}s+${PRUNE_KILL_AFTER_SECONDS}s, --force never passed). The interval loop belongs to the daemon's process chain: this role 'exec's the bridge, so there would be nothing left here to tear a loop down."
   else
     # The interval is not a safety knob — a bad one only changes how often a
     # best-effort pass runs — so a garbage value falls back to the default with
@@ -1066,7 +1120,7 @@ if [ "${PRUNE_ENABLED}" = "1" ]; then
       fi
     fi
 
-    log "workspace prune ENABLED — boot pass now, then every ${PRUNE_INTERVAL_MINUTES} min (min-age: ${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS:-CLI default}, timeout ${PRUNE_TIMEOUT_SECONDS}s, --force never passed)"
+    log "workspace prune ENABLED — boot pass now, then every ${PRUNE_INTERVAL_MINUTES} min (min-age: ${ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS:-CLI default}, timeout ${PRUNE_TIMEOUT_SECONDS}s+${PRUNE_KILL_AFTER_SECONDS}s, --force never passed)"
   fi
 
   # Best-effort, exactly like the other boot steps: prune is an optimization,

--- a/docker/claude/tests-entrypoint-prune.sh
+++ b/docker/claude/tests-entrypoint-prune.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Tests for the entrypoint's workspace-prune wiring (issue #81).
+#
+# Nothing in this container used to remove anything from the volume, so the
+# entrypoint now runs `alissa code workspace prune` at boot and on a supervised
+# interval. This boots the REAL entrypoint.sh six times with the CLIs it shells
+# out to replaced by stubs (no docker needed — CI has no docker-in-docker, and
+# the image adds layers, not entrypoint behaviour). The `alissa` stub records
+# every prune invocation with its argv AND its cwd, which is what makes the
+# safety properties assertions rather than claims:
+#
+#   1. default ON, capable CLI   -> boot pass runs from the workspace root, the
+#                                   interval loop keeps ticking (a FAILED tick
+#                                   warns and the next one still runs), no
+#                                   --force and no --min-age-hours ever, and
+#                                   SIGTERM stops the loop for good
+#   2. ALISSA_WORKSPACE_PRUNE=0  -> zero invocations, no loop, boot unaffected
+#   3. CLI without the subcommand-> EXACTLY ONE loud warning, zero invocations,
+#                                   and the container still boots. The stub
+#                                   reproduces commander's real behaviour here:
+#                                   an unknown subcommand's `--help` prints the
+#                                   PARENT help and exits 0 (alissa CLI 0.1.0),
+#                                   so a probe reading only the exit status
+#                                   would call this CLI capable
+#   4. min-age + garbage interval-> --min-age-hours passed through verbatim; a
+#                                   non-numeric interval falls back to 360
+#   5. garbage min-age           -> fails CLOSED (prune skipped, loud warning):
+#                                   the CLI's default age gate may be SHORTER
+#                                   than the one that was asked for
+#   6. executor role             -> boot pass yes, interval loop no (the role
+#                                   `exec`s the bridge; a loop would outlive the
+#                                   only code that stops it)
+#
+# Usage: bash docker/claude/tests-entrypoint-prune.sh
+# Needs: bash, python3, jq (the entrypoint's own bootstrap uses both).
+# =============================================================================
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENTRYPOINT="${HERE}/entrypoint.sh"
+
+fail=0
+pass() { printf '  ok   %s\n' "$1"; }
+bad()  { printf '  FAIL %s\n' "$1" >&2; fail=1; }
+info() { printf '%s\n' "$*"; }
+
+assert_contains() {
+  if grep -qF -- "$2" "$1"; then pass "$3"; else bad "$3 (not in $1: $2)"; fi
+}
+assert_not_contains() {
+  if grep -qF -- "$2" "$1"; then bad "$3 (unexpected in $1: $2)"; else pass "$3"; fi
+}
+assert_eq() { if [ "$1" = "$2" ]; then pass "$3"; else bad "$3 (expected '$2', got '$1')"; fi; }
+
+TMPROOT="$(mktemp -d)"
+BIN="${TMPROOT}/bin"; mkdir -p "${BIN}"
+FAKE_HOME="${TMPROOT}/home"; mkdir -p "${FAKE_HOME}/.config/alissa"
+WORKSPACE="${TMPROOT}/workspace"; mkdir -p "${WORKSPACE}"
+SPY="${TMPROOT}/spy"; mkdir -p "${SPY}"
+cp "${HERE}/agents.yaml" "${FAKE_HOME}/.config/alissa/agents.yaml"
+cleanup() { rm -rf "${TMPROOT}"; }
+trap cleanup EXIT
+
+cat > "${BIN}/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  "api user -q .login") echo alissa-app ;;
+esac
+exit 0
+STUB
+
+# The API reachability probe. Always up: the transport classes have their own
+# suite (tests-entrypoint-auth.sh).
+cat > "${BIN}/curl" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+
+# The alissa CLI stub.
+#
+# PRUNE_CAPABLE=0 turns it into a CLI that predates the subcommand — and it
+# models that faithfully, which is the whole point of case 3: commander prints
+# the PARENT command's help and exits 0 for an unknown subcommand, so `prune
+# --help` SUCCEEDS on a CLI that has never heard of prune.
+#
+# PRUNE_FAIL_ON=<n> makes the n-th prune invocation fail, so the interval loop's
+# tolerance of a failing pass is exercised rather than assumed.
+cat > "${BIN}/alissa" <<'STUB'
+#!/usr/bin/env bash
+case "${1:-} ${2:-} ${3:-}" in
+  "code workspace prune")
+    shift 3
+    if [ "${1:-}" = "--help" ]; then
+      if [ "${PRUNE_CAPABLE:-1}" = "1" ]; then
+        cat <<'HELP'
+Usage: alissa code workspace prune [options]
+
+Remove worktrees of finished branches from this workspace's hubs
+
+Options:
+  --min-age-hours <n>  only prune worktrees older than <n> hours
+  --force              prune even a dirty worktree
+  -h, --help           display help for command
+HELP
+        exit 0
+      fi
+      # alissa CLI 0.1.0, verbatim in shape: the `workspace` help, exit 0, no
+      # mention of prune anywhere.
+      cat <<'HELP'
+Usage: alissa code workspace [options] [command]
+
+Create and maintain an Alissa Code Workspace (multi-repo worktree hubs)
+
+Options:
+  -h, --help            display help for command
+
+Commands:
+  init [options] [dir]  Initialize a workspace here (or in <dir>)
+  add [options] <repo>  Hub-ify a repo into this workspace
+  sync [options]        Reconcile the workspace against its manifest
+  status                Show the workspace binding, hubs, and active worktrees
+  doctor                Check workspace invariants
+  help [command]        display help for command
+HELP
+      exit 0
+    fi
+    printf 'cwd=%s argv=%s\n' "${PWD}" "$*" >> "${SPY_DIR}/prune-argv"
+    n="$(wc -l < "${SPY_DIR}/prune-argv" | tr -d ' ')"
+    echo "keep  main (never pruned)"
+    echo "prune TASK-1-EXAMPLE (branch merged, PR closed)"
+    if [ -n "${PRUNE_FAIL_ON:-}" ] && [ "${n}" = "${PRUNE_FAIL_ON}" ]; then
+      echo "error: hub sweep failed" >&2
+      exit 3
+    fi
+    exit 0
+    ;;
+esac
+case "${1:-} ${2:-}" in
+  "auth login")     echo "Authenticated." ;;
+  "worker start")   : > "${SPY_DIR}/worker-started" ;;
+  "worker status")  [ -f "${SPY_DIR}/worker-started" ] && echo "worker is running" || echo "worker not running" ;;
+  "worker stop")    : > "${SPY_DIR}/worker-stopped" ;;
+  "code workspace") ;;
+  "bridge start")
+    : > "${SPY_DIR}/bridge-started"
+    trap 'exit 0' TERM INT
+    sleep 600 &
+    wait $!
+    ;;
+esac
+exit 0
+STUB
+
+# The review daemon: a foreground process the entrypoint backgrounds.
+cat > "${BIN}/alissa-revloop" <<'STUB'
+#!/usr/bin/env bash
+trap 'exit 0' TERM INT
+sleep 600 &
+wait $!
+STUB
+chmod 0755 "${BIN}/gh" "${BIN}/curl" "${BIN}/alissa" "${BIN}/alissa-revloop"
+
+reset_spies() {
+  rm -f "${SPY}"/prune-argv "${SPY}"/worker-started "${SPY}"/worker-stopped \
+        "${SPY}"/bridge-started
+}
+
+prune_count() { [ -f "${SPY}/prune-argv" ] && wc -l < "${SPY}/prune-argv" | tr -d ' ' || echo 0; }
+
+EP_PID=""
+run_entrypoint() {
+  local log="$1"; shift
+  env -i \
+    PATH="${BIN}:/usr/local/bin:/usr/bin:/bin" \
+    HOME="${FAKE_HOME}" \
+    TMUX_TMPDIR="${TMPROOT}/tmux" \
+    ALISSA_WORKSPACE_ROOT="${WORKSPACE}" \
+    GH_TOKEN=stub-gh-token \
+    ALISSA_API_TOKEN=stub-alissa-token \
+    ALISSA_REVIEW_REPOS="fahera-mx/example-repo" \
+    SPY_DIR="${SPY}" \
+    "$@" \
+    bash "${ENTRYPOINT}" > "${log}" 2>&1 &
+  EP_PID=$!
+}
+
+wait_for_log() {
+  local i
+  for i in $(seq 1 "$3"); do
+    grep -qF -- "$2" "$1" && return 0
+    kill -0 "${EP_PID}" 2>/dev/null || { grep -qF -- "$2" "$1" && return 0; return 1; }
+    sleep 1
+  done
+  return 1
+}
+
+# wait_for_prune_count <n> <seconds>
+wait_for_prune_count() {
+  local i
+  for i in $(seq 1 "$2"); do
+    [ "$(prune_count)" -ge "$1" ] && return 0
+    sleep 1
+  done
+  return 1
+}
+
+stop_entrypoint() {
+  local pid="$1" i
+  kill -TERM "${pid}" 2>/dev/null || true
+  for i in $(seq 1 15); do
+    kill -0 "${pid}" 2>/dev/null || return 0
+    sleep 1
+  done
+  kill -KILL "${pid}" 2>/dev/null || true
+}
+
+DAEMON_UP="alissa worker is running"
+
+# -----------------------------------------------------------------------------
+info "1. default ON with a capable CLI -> boot pass + a supervised interval loop"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG1="${TMPROOT}/on.log"
+# 3s ticks via the test-only seconds override, and the SECOND pass fails, so the
+# assertions below cover both "the loop ticks" and "a failed tick is survivable".
+run_entrypoint "${LOG1}" \
+  ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS=3 \
+  PRUNE_FAIL_ON=2
+PID1="${EP_PID}"
+wait_for_log "${LOG1}" "${DAEMON_UP}" 40 || bad "entrypoint never reached the worker-up milestone (see ${LOG1})"
+
+assert_contains "${LOG1}" "workspace prune ENABLED" "prune is on by default (no env set)"
+assert_contains "${LOG1}" "prune[boot]: prune TASK-1-EXAMPLE" "the CLI's per-worktree verdicts land in the boot log"
+assert_contains "${LOG1}" "workspace prune (boot) finished" "the boot pass reports its outcome"
+assert_contains "${LOG1}" "starting the workspace prune loop" "the interval loop is started"
+
+if [ "$(prune_count)" -ge 1 ]; then
+  pass "boot pass invoked the CLI"
+  assert_eq "$(head -1 "${SPY}/prune-argv" | sed 's/ argv=.*//')" "cwd=${WORKSPACE}" \
+    "prune runs from the workspace root (the binding is cwd-based)"
+  assert_eq "$(head -1 "${SPY}/prune-argv" | sed 's/^.* argv=//')" "" \
+    "boot pass passes NO flags when neither knob is set (CLI defaults apply)"
+else
+  bad "boot pass never invoked the CLI"
+fi
+
+# The loop: three passes at 3s ticks, the second of which fails.
+if wait_for_prune_count 3 40; then
+  pass "the interval loop ticks (>=3 passes)"
+  assert_contains "${LOG1}" "workspace prune (interval) exited 3" "a failed interval pass warns"
+  assert_contains "${LOG1}" "prune[interval]:" "interval verdicts are logged too"
+  kill -0 "${PID1}" 2>/dev/null \
+    && pass "the container survives a failed prune" \
+    || bad "the entrypoint died on a failed prune"
+else
+  bad "the interval loop did not tick 3 times within 40s (count=$(prune_count))"
+fi
+
+assert_not_contains "${SPY}/prune-argv" "--force" "--force is NEVER passed"
+
+# Teardown: the loop must die with the container, not keep pruning a volume
+# nothing is using.
+stop_entrypoint "${PID1}"
+assert_contains "${LOG1}" "shutting down" "shuts down on SIGTERM"
+AFTER="$(prune_count)"
+sleep 8   # >2 ticks at the 3s override
+assert_eq "$(prune_count)" "${AFTER}" "no prune pass runs after shutdown (the loop is torn down)"
+
+# -----------------------------------------------------------------------------
+info ""
+info "2. ALISSA_WORKSPACE_PRUNE=0 -> the opt-out really is one"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG2="${TMPROOT}/off.log"
+run_entrypoint "${LOG2}" ALISSA_WORKSPACE_PRUNE=0 ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS=3
+PID2="${EP_PID}"
+wait_for_log "${LOG2}" "${DAEMON_UP}" 40 || bad "entrypoint never reached the worker-up milestone (see ${LOG2})"
+assert_contains "${LOG2}" "workspace prune DISABLED" "logs the opt-out"
+assert_not_contains "${LOG2}" "starting the workspace prune loop" "no interval loop when opted out"
+sleep 6
+assert_eq "$(prune_count)" "0" "zero prune invocations when opted out"
+stop_entrypoint "${PID2}"
+
+# -----------------------------------------------------------------------------
+info ""
+info "3. a CLI that predates the subcommand -> ONE loud warning, both hooks skip"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG3="${TMPROOT}/old-cli.log"
+run_entrypoint "${LOG3}" PRUNE_CAPABLE=0 ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS=3
+PID3="${EP_PID}"
+wait_for_log "${LOG3}" "${DAEMON_UP}" 40 || bad "entrypoint never reached the worker-up milestone (see ${LOG3})"
+assert_eq "$(grep -c "predates 'alissa code workspace prune'" "${LOG3}")" "1" \
+  "exactly ONE warning about the missing subcommand"
+assert_contains "${LOG3}" "WARN: this alissa CLI predates" "and it is a WARN, not a whisper"
+assert_not_contains "${LOG3}" "starting the workspace prune loop" "no interval loop on an old CLI"
+assert_not_contains "${LOG3}" "workspace prune ENABLED" "the feature is not reported as enabled"
+sleep 6
+assert_eq "$(prune_count)" "0" "zero prune invocations on an old CLI"
+kill -0 "${PID3}" 2>/dev/null \
+  && pass "the container boots normally on an old CLI" \
+  || bad "an old CLI broke the boot"
+stop_entrypoint "${PID3}"
+
+# -----------------------------------------------------------------------------
+info ""
+info "4. min-age pass-through + a garbage interval"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG4="${TMPROOT}/knobs.log"
+run_entrypoint "${LOG4}" \
+  ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS=48 \
+  ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES=soon
+PID4="${EP_PID}"
+wait_for_log "${LOG4}" "${DAEMON_UP}" 40 || bad "entrypoint never reached the worker-up milestone (see ${LOG4})"
+if [ "$(prune_count)" -ge 1 ]; then
+  assert_eq "$(head -1 "${SPY}/prune-argv" | sed 's/^.* argv=//')" "--min-age-hours 48" \
+    "ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS is passed through as --min-age-hours"
+else
+  bad "no prune invocation to inspect"
+fi
+assert_contains "${LOG4}" "ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES=soon is not a positive whole number" \
+  "a garbage interval warns"
+assert_contains "${LOG4}" "starting the workspace prune loop (every 360 min" \
+  "a garbage interval falls back to 360 (an interval is not a safety knob)"
+stop_entrypoint "${PID4}"
+
+# -----------------------------------------------------------------------------
+info ""
+info "5. a garbage min-age fails CLOSED (the age gate is a safety knob)"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG5="${TMPROOT}/bad-age.log"
+run_entrypoint "${LOG5}" \
+  ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS=48h \
+  ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS=3
+PID5="${EP_PID}"
+wait_for_log "${LOG5}" "${DAEMON_UP}" 40 || bad "entrypoint never reached the worker-up milestone (see ${LOG5})"
+assert_contains "${LOG5}" "ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS=48h is not a whole number of hours" \
+  "a garbage min-age warns"
+assert_not_contains "${LOG5}" "starting the workspace prune loop" "and disables the loop"
+sleep 6
+assert_eq "$(prune_count)" "0" "and runs no pass at all rather than one with a shorter age gate"
+kill -0 "${PID5}" 2>/dev/null \
+  && pass "the container still boots" \
+  || bad "a garbage min-age broke the boot"
+stop_entrypoint "${PID5}"
+
+# -----------------------------------------------------------------------------
+info ""
+info "6. executor role -> boot pass, but no interval loop"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG6="${TMPROOT}/executor.log"
+run_entrypoint "${LOG6}" \
+  CONTAINER_ROLE=executor ALISSA_BRIDGE_EXECUTOR=1 \
+  ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS=3
+PID6="${EP_PID}"
+wait_for_log "${LOG6}" "starting alissa bridge start" 40 \
+  || bad "the executor never reached the bridge (see ${LOG6})"
+assert_eq "$(prune_count)" "1" "the executor prunes once at boot (it grows the same volume)"
+assert_contains "${LOG6}" "executor role runs the boot pass only" "and says why there is no loop"
+assert_not_contains "${LOG6}" "starting the workspace prune loop" "no interval loop in the executor role"
+sleep 8   # >2 ticks at the 3s override: an orphaned loop would show up here
+assert_eq "$(prune_count)" "1" "no loop survived the exec into the bridge"
+stop_entrypoint "${PID6}"
+
+info ""
+if [ "${fail}" = "0" ]; then
+  info "All workspace-prune entrypoint checks passed."
+else
+  info "Some workspace-prune entrypoint checks FAILED." >&2
+fi
+exit "${fail}"

--- a/docker/claude/tests-entrypoint-prune.sh
+++ b/docker/claude/tests-entrypoint-prune.sh
@@ -45,6 +45,10 @@
 #  10. a prune that ECHOES A TOKEN -> the boot log carries the redacted marker and
 #                                   NOT the raw token (a one-sided assertion
 #                                   would pass on a log containing both)
+#  11. an EARLY external SIGKILL -> reported as a plain exit 137, NOT as our
+#                                   kill-after-grace: `timeout` returns 128+signal
+#                                   for any signal death, and an OOM kill is the
+#                                   realistic early cause
 #
 # Usage: bash docker/claude/tests-entrypoint-prune.sh
 # Needs: bash, python3, jq (the entrypoint's own bootstrap uses both).
@@ -73,7 +77,14 @@ FAKE_HOME="${TMPROOT}/home"; mkdir -p "${FAKE_HOME}/.config/alissa"
 WORKSPACE="${TMPROOT}/workspace"; mkdir -p "${WORKSPACE}"
 SPY="${TMPROOT}/spy"; mkdir -p "${SPY}"
 cp "${HERE}/agents.yaml" "${FAKE_HOME}/.config/alissa/agents.yaml"
-cleanup() { rm -rf "${TMPROOT}"; }
+# FIFO_HOLDER is case 9's blocking-stdin writer (see there). Reaped in cleanup so
+# an early `bad` or a `set -e` abort between its start and its kill cannot leave a
+# stray `sleep` behind — the success-path kill alone would not cover those.
+FIFO_HOLDER=""
+cleanup() {
+  [ -n "${FIFO_HOLDER}" ] && kill "${FIFO_HOLDER}" 2>/dev/null || true
+  rm -rf "${TMPROOT}"
+}
 trap cleanup EXIT
 
 cat > "${BIN}/gh" <<'STUB'
@@ -154,6 +165,10 @@ HELP
     # PRUNE_READ_STDIN models a CLI that prompts. With stdin closed it reads EOF
     # and carries on; with stdin inherited from the entrypoint it blocks.
     [ -n "${PRUNE_READ_STDIN:-}" ] && read -r _
+    # PRUNE_SIGKILL_SELF models an EXTERNAL SIGKILL arriving early — the OOM
+    # killer being the realistic one. `timeout` reports 137 for it exactly as it
+    # does for its own -k kill, which is why the entrypoint checks elapsed time.
+    [ -n "${PRUNE_SIGKILL_SELF:-}" ] && kill -9 $$
     # PRUNE_ECHO_TOKEN models `git remote prune origin` echoing an https remote
     # that carries a credential — the case redact_token() exists for.
     [ -n "${PRUNE_ECHO_TOKEN:-}" ] && echo "error: failed to fetch https://x-access-token:${PRUNE_ECHO_TOKEN}@github.com/fahera-mx/example-repo"
@@ -516,6 +531,29 @@ assert_contains "${LOG10}" "***REDACTED***" "the token is redacted in the re-emi
 # satisfy the assertion above on its own.
 assert_not_contains "${LOG10}" "stub-alissa-token" "and the raw token appears nowhere in the boot log"
 stop_entrypoint "${PID10}"
+
+# -----------------------------------------------------------------------------
+info ""
+info "11. an EARLY 137 is not claimed as our timeout kill"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG11="${TMPROOT}/oom.log"
+# `timeout` reports 128+signal for ANY signal death of the child, so 137 does not
+# mean "killed by our -k grace" — an OOM kill of the prune pass looks identical,
+# and on this container that is the realistic cause (a `git gc --auto` sweep over
+# a never-pruned object store, under a memory cap). Reporting it as a timeout
+# would assert a duration that never elapsed and advise RAISING the timeout,
+# which makes an OOM worse. The elapsed check is what separates them.
+run_entrypoint "${LOG11}" PRUNE_SIGKILL_SELF=1 ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS=20
+PID11="${EP_PID}"
+wait_for_log "${LOG11}" "${DAEMON_UP}" 40 || bad "entrypoint never reached the worker-up milestone (see ${LOG11})"
+assert_contains "${LOG11}" "workspace prune (boot) exited 137" \
+  "an early SIGKILL falls through to the generic branch, which claims only what it knows"
+assert_not_contains "${LOG11}" "did NOT exit on SIGTERM" \
+  "and is NOT reported as our kill-after-grace (no SIGTERM was ever sent)"
+assert_not_contains "${LOG11}" "TIMED OUT after 20s" \
+  "nor as a 20s timeout that never elapsed"
+stop_entrypoint "${PID11}"
 
 info ""
 if [ "${fail}" = "0" ]; then

--- a/docker/claude/tests-entrypoint-prune.sh
+++ b/docker/claude/tests-entrypoint-prune.sh
@@ -31,6 +31,10 @@
 #   6. executor role             -> boot pass yes, interval loop no (the role
 #                                   `exec`s the bridge; a loop would outlive the
 #                                   only code that stops it)
+#   7. a HANGING prune           -> `timeout` cuts it, the boot continues to the
+#                                   worker, and the warning names the knob. The
+#                                   boot hook runs BEFORE the worker starts, so
+#                                   an unbounded pass delays every boot
 #
 # Usage: bash docker/claude/tests-entrypoint-prune.sh
 # Needs: bash, python3, jq (the entrypoint's own bootstrap uses both).
@@ -85,7 +89,8 @@ STUB
 # --help` SUCCEEDS on a CLI that has never heard of prune.
 #
 # PRUNE_FAIL_ON=<n> makes the n-th prune invocation fail, so the interval loop's
-# tolerance of a failing pass is exercised rather than assumed.
+# tolerance of a failing pass is exercised rather than assumed. PRUNE_HANG makes
+# it block forever, which is what the boot pass's `timeout` bound exists for.
 cat > "${BIN}/alissa" <<'STUB'
 #!/usr/bin/env bash
 case "${1:-} ${2:-} ${3:-}" in
@@ -126,6 +131,9 @@ HELP
       exit 0
     fi
     printf 'cwd=%s argv=%s\n' "${PWD}" "$*" >> "${SPY_DIR}/prune-argv"
+    # PRUNE_HANG models the slow first sweep (or a prompt on a tty-less
+    # container): the entrypoint's `timeout` is the only thing that ends it.
+    [ -n "${PRUNE_HANG:-}" ] && sleep 120
     n="$(wc -l < "${SPY_DIR}/prune-argv" | tr -d ' ')"
     echo "keep  main (never pruned)"
     echo "prune TASK-1-EXAMPLE (branch merged, PR closed)"
@@ -311,7 +319,8 @@ reset_spies
 LOG4="${TMPROOT}/knobs.log"
 run_entrypoint "${LOG4}" \
   ALISSA_WORKSPACE_PRUNE_MIN_AGE_HOURS=48 \
-  ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES=soon
+  ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES=soon \
+  ALISSA_WORKSPACE_PRUNE_INTERVAL_SECONDS=3
 PID4="${EP_PID}"
 wait_for_log "${LOG4}" "${DAEMON_UP}" 40 || bad "entrypoint never reached the worker-up milestone (see ${LOG4})"
 if [ "$(prune_count)" -ge 1 ]; then
@@ -324,6 +333,14 @@ assert_contains "${LOG4}" "ALISSA_WORKSPACE_PRUNE_INTERVAL_MINUTES=soon is not a
   "a garbage interval warns"
 assert_contains "${LOG4}" "starting the workspace prune loop (every 360 min" \
   "a garbage interval falls back to 360 (an interval is not a safety knob)"
+# The INTERVAL pass must carry the same flags as the boot pass — PRUNE_ARGS is a
+# global the loop's subshell inherits, and nothing else pins that.
+if wait_for_prune_count 2 30; then
+  assert_eq "$(sed -n 2p "${SPY}/prune-argv" | sed 's/^.* argv=//')" "--min-age-hours 48" \
+    "the interval pass inherits --min-age-hours too, not just the boot pass"
+else
+  bad "no interval pass observed within 30s (count=$(prune_count))"
+fi
 stop_entrypoint "${PID4}"
 
 # -----------------------------------------------------------------------------
@@ -360,11 +377,39 @@ PID6="${EP_PID}"
 wait_for_log "${LOG6}" "starting alissa bridge start" 40 \
   || bad "the executor never reached the bridge (see ${LOG6})"
 assert_eq "$(prune_count)" "1" "the executor prunes once at boot (it grows the same volume)"
-assert_contains "${LOG6}" "executor role runs the boot pass only" "and says why there is no loop"
+assert_contains "${LOG6}" "boot pass only (executor role" "the ENABLED line says boot-pass-only for this role"
+assert_contains "${LOG6}" "nothing left here to tear a loop down" "and says why there is no loop"
 assert_not_contains "${LOG6}" "starting the workspace prune loop" "no interval loop in the executor role"
+assert_not_contains "${LOG6}" "then every" "the executor's log announces no cadence it will not run"
 sleep 8   # >2 ticks at the 3s override: an orphaned loop would show up here
 assert_eq "$(prune_count)" "1" "no loop survived the exec into the bridge"
 stop_entrypoint "${PID6}"
+
+# -----------------------------------------------------------------------------
+info ""
+info "7. a HANGING prune cannot hold the boot open"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG7="${TMPROOT}/hang.log"
+# The boot hook runs before the worker starts, so an unbounded pass would delay
+# every boot by however long the CLI takes — and on a never-pruned volume the
+# first `git gc --auto` sweep is exactly that case. PRUNE_HANG makes the stub
+# sleep for two minutes; a 2s timeout must cut it and let the boot continue.
+run_entrypoint "${LOG7}" PRUNE_HANG=1 ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS=2
+PID7="${EP_PID}"
+if wait_for_log "${LOG7}" "${DAEMON_UP}" 40; then
+  pass "the boot reaches the worker even though the prune pass hangs"
+else
+  bad "a hanging prune pass held the boot open (see ${LOG7})"
+fi
+assert_contains "${LOG7}" "workspace prune (boot) TIMED OUT after 2s" \
+  "the timeout is reported as a timeout, not as a bare exit code"
+assert_contains "${LOG7}" "ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS" \
+  "and names the knob that raises the bound"
+kill -0 "${PID7}" 2>/dev/null \
+  && pass "the container is alive after a timed-out pass" \
+  || bad "a timed-out prune killed the container"
+stop_entrypoint "${PID7}"
 
 info ""
 if [ "${fail}" = "0" ]; then

--- a/docker/claude/tests-entrypoint-prune.sh
+++ b/docker/claude/tests-entrypoint-prune.sh
@@ -35,6 +35,16 @@
 #                                   worker, and the warning names the knob. The
 #                                   boot hook runs BEFORE the worker starts, so
 #                                   an unbounded pass delays every boot
+#   8. a TERM-TRAPPING prune     -> `-k` KILLs it. Plain `timeout` waits forever
+#                                   on a child that traps TERM, so without the
+#                                   grace flag case 7's bound is not a bound
+#   9. a prune that READS STDIN  -> `</dev/null` gives it EOF and the pass
+#                                   SUCCEEDS; without it the pass would sit until
+#                                   the timeout, so the success line is what
+#                                   distinguishes the two
+#  10. a prune that ECHOES A TOKEN -> the boot log carries the redacted marker and
+#                                   NOT the raw token (a one-sided assertion
+#                                   would pass on a log containing both)
 #
 # Usage: bash docker/claude/tests-entrypoint-prune.sh
 # Needs: bash, python3, jq (the entrypoint's own bootstrap uses both).
@@ -131,9 +141,23 @@ HELP
       exit 0
     fi
     printf 'cwd=%s argv=%s\n' "${PWD}" "$*" >> "${SPY_DIR}/prune-argv"
-    # PRUNE_HANG models the slow first sweep (or a prompt on a tty-less
-    # container): the entrypoint's `timeout` is the only thing that ends it.
+    # PRUNE_HANG models the slow first sweep: the entrypoint's `timeout` is the
+    # only thing that ends it.
     [ -n "${PRUNE_HANG:-}" ] && sleep 120
+    # PRUNE_TRAP_TERM models a CLI that handles SIGTERM gracefully — finishing
+    # the in-flight git operation instead of dying. Plain `timeout` would wait
+    # for it forever; only `-k` ends this.
+    if [ -n "${PRUNE_TRAP_TERM:-}" ]; then
+      trap 'echo "caught TERM, still finishing" >&2' TERM
+      end=$((SECONDS+120)); while [ "${SECONDS}" -lt "${end}" ]; do sleep 1; done
+    fi
+    # PRUNE_READ_STDIN models a CLI that prompts. With stdin closed it reads EOF
+    # and carries on; with stdin inherited from the entrypoint it blocks.
+    [ -n "${PRUNE_READ_STDIN:-}" ] && read -r _
+    # PRUNE_ECHO_TOKEN models `git remote prune origin` echoing an https remote
+    # that carries a credential — the case redact_token() exists for.
+    [ -n "${PRUNE_ECHO_TOKEN:-}" ] && echo "error: failed to fetch https://x-access-token:${PRUNE_ECHO_TOKEN}@github.com/fahera-mx/example-repo"
+    :
     n="$(wc -l < "${SPY_DIR}/prune-argv" | tr -d ' ')"
     echo "keep  main (never pruned)"
     echo "prune TASK-1-EXAMPLE (branch merged, PR closed)"
@@ -176,6 +200,12 @@ reset_spies() {
 
 prune_count() { [ -f "${SPY}/prune-argv" ] && wc -l < "${SPY}/prune-argv" | tr -d ' ' || echo 0; }
 
+# What the entrypoint's own stdin is. Defaults to /dev/null, which is also what a
+# backgrounded job gets for free — and that is exactly why case 9 overrides it: a
+# harness whose stdin is already EOF cannot tell `</dev/null` on the prune runner
+# from its absence. Case 9 points this at a FIFO held open by a writer that never
+# writes, so an inherited stdin BLOCKS and the missing redirect becomes visible.
+EP_STDIN="/dev/null"
 EP_PID=""
 run_entrypoint() {
   local log="$1"; shift
@@ -189,7 +219,7 @@ run_entrypoint() {
     ALISSA_REVIEW_REPOS="fahera-mx/example-repo" \
     SPY_DIR="${SPY}" \
     "$@" \
-    bash "${ENTRYPOINT}" > "${log}" 2>&1 &
+    bash "${ENTRYPOINT}" < "${EP_STDIN}" > "${log}" 2>&1 &
   EP_PID=$!
 }
 
@@ -410,6 +440,82 @@ kill -0 "${PID7}" 2>/dev/null \
   && pass "the container is alive after a timed-out pass" \
   || bad "a timed-out prune killed the container"
 stop_entrypoint "${PID7}"
+
+# -----------------------------------------------------------------------------
+info ""
+info "8. a TERM-TRAPPING prune is KILLED, not waited on"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG8="${TMPROOT}/trap.log"
+# `timeout` without -k sends TERM and then waits INDEFINITELY, so a CLI that
+# traps TERM is unbounded again — the same held-open boot case 7 covers, one step
+# further along. `workspace prune` is the destructive subcommand in the set, and
+# a handler that finishes the in-flight git operation is exactly what it would
+# plausibly install, so this is the bound that has to survive the CLI landing.
+run_entrypoint "${LOG8}" PRUNE_TRAP_TERM=1 \
+  ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS=2 ALISSA_WORKSPACE_PRUNE_KILL_AFTER_SECONDS=2
+PID8="${EP_PID}"
+if wait_for_log "${LOG8}" "${DAEMON_UP}" 40; then
+  pass "the boot reaches the worker even though the prune pass ignores SIGTERM"
+else
+  bad "a TERM-trapping prune pass held the boot open — is -k missing? (see ${LOG8})"
+fi
+# GNU `timeout` reports 137 (128+9), NOT 124, when the child had to be KILLED
+# after -k — measured on this harness, and the reason the entrypoint has a
+# separate branch for it. Assert the KILL wording specifically: a 124-only branch
+# would file this case under the generic "exited N" message, which is precisely
+# the case -k exists for.
+assert_contains "${LOG8}" "did NOT exit on SIGTERM, so it was KILLED after the 2s grace" \
+  "the kill path is reported as a timeout+kill, not as a generic non-zero exit"
+assert_not_contains "${LOG8}" "workspace prune (boot) exited 137" \
+  "and does not fall through to the generic exit-code branch"
+stop_entrypoint "${PID8}"
+
+# -----------------------------------------------------------------------------
+info ""
+info "9. a prune that reads stdin gets EOF, not the entrypoint's stdin"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG9="${TMPROOT}/stdin.log"
+# Command substitution inherits stdin, so without `</dev/null` a prompting CLI
+# would sit until the timeout fires. The assertion is therefore the SUCCESS line,
+# not the timeout WARN: both leave the boot alive, and only the success line
+# distinguishes "got EOF and carried on" from "was cut off".
+STDIN_FIFO="${TMPROOT}/blocking-stdin.fifo"
+mkfifo "${STDIN_FIFO}"
+# A writer that never writes: opening the read end then yields no data and no
+# EOF, so a child inheriting it blocks. Backgrounded because opening a FIFO for
+# writing blocks until a reader arrives.
+sleep 120 > "${STDIN_FIFO}" &
+FIFO_HOLDER=$!
+EP_STDIN="${STDIN_FIFO}"
+run_entrypoint "${LOG9}" PRUNE_READ_STDIN=1 ALISSA_WORKSPACE_PRUNE_TIMEOUT_SECONDS=20
+PID9="${EP_PID}"
+EP_STDIN="/dev/null"
+wait_for_log "${LOG9}" "${DAEMON_UP}" 40 || bad "entrypoint never reached the worker-up milestone (see ${LOG9})"
+assert_contains "${LOG9}" "workspace prune (boot) finished" \
+  "the pass completes promptly on EOF (stdin is closed, not inherited)"
+assert_not_contains "${LOG9}" "TIMED OUT" "and is not merely cut off by the bound"
+stop_entrypoint "${PID9}"
+kill "${FIFO_HOLDER}" 2>/dev/null || true
+
+# -----------------------------------------------------------------------------
+info ""
+info "10. a token echoed by prune is REDACTED in the boot log"
+# -----------------------------------------------------------------------------
+reset_spies
+LOG10="${TMPROOT}/redact.log"
+# Modelled on the real shape: `git remote prune origin` failing and echoing an
+# https remote, on a hub whose credential helper `gh auth setup-git` wired in at
+# step 1. The stub echoes the API token the sandbox injects.
+run_entrypoint "${LOG10}" PRUNE_ECHO_TOKEN=stub-alissa-token
+PID10="${EP_PID}"
+wait_for_log "${LOG10}" "${DAEMON_UP}" 40 || bad "entrypoint never reached the worker-up milestone (see ${LOG10})"
+assert_contains "${LOG10}" "***REDACTED***" "the token is redacted in the re-emitted prune output"
+# Two-sided on purpose: a log containing BOTH the marker and the raw token would
+# satisfy the assertion above on its own.
+assert_not_contains "${LOG10}" "stub-alissa-token" "and the raw token appears nowhere in the boot log"
+stop_entrypoint "${PID10}"
 
 info ""
 if [ "${fail}" = "0" ]; then


### PR DESCRIPTION
Follow-up to PR #82 round 2 (`approve`), carrying its three `[minor]` findings. No issue is closed here — #82 carries that claim.

**Tasks:** origin `TASK-1492300589` · implementation `TASK-190865621`

Follow-up-To: #82

## Merge order

**Merge #82 first.** This branch is cut from #82's approved head `d67e5a9`, because every line it touches is code #82 introduces — none of it exists on `main` yet. It is based on `main` so it lands there on its own, but merging it *before* #82 would squash #82's entire delta into `main` under this PR's commit message and leave #82 resolving as empty, losing its history and the issue-closing claim it carries for issue #81. The review surface here is `d67e5a9..HEAD` — one commit — even though GitHub's diff against `main` shows #82's changes too until #82 merges.

## What it does

| round-2 finding | fix |
| --- | --- |
| `[minor]` `timeout` without `-k` does not bind a `SIGTERM`-trapping child | `timeout -k "${PRUNE_KILL_AFTER_SECONDS}"`, new `ALISSA_WORKSPACE_PRUNE_KILL_AFTER_SECONDS` (30) |
| `[minor]` the 900s default sits outside the health-check window the README documents | default → **240s**, and the comment now derives the number from that window instead of asserting roominess |
| `[minor]` the `</dev/null` and `redact_token()` fixes ship with no regression cover | new suite cases 9 and 10, each counterfactually verified |

## Delivery notes

### Judgment calls

* **`timeout -k` reports 137, not 124 — so the "one flag" fix needed a second branch.** The finding's patch says "the exit code stays 124 either way". Measured here, it does not: GNU `timeout` exits `124` when its own `TERM` ends the child, and `137` (128+9) when `-k` had to `KILL` it. A 124-only branch therefore files the exact case `-k` exists for under the generic *"exited N"* message. The entrypoint now has a distinct `137` branch saying the CLI did not exit on `SIGTERM` and was killed after the grace — which is a fact about the CLI worth surfacing, not just about this boot. Case 8 asserts the kill wording *and* asserts the generic branch was not taken.
* **Took the finding's first option (lower the default), not the second (keep 900, soften the comment).** The reviewer said either was acceptable and preferred the second. The ordering argument decides it: the pass runs at `3c-ii` and `/healthz` does not exist until `4b`, so with Railway's 300s default a 400–899s pass reproduces the restart loop the bound exists to prevent — using the shipped configuration. A default that permits its own failure mode is not a bound. The trade is one-directional: a timed-out pass costs a warning, an overrun boot costs the container.
* **240 + 30 is chosen as a pair.** `-k` grace is spent *after* the timeout, so what has to fit the window is timeout + grace (270s), not the timeout alone. Both the comment and the README say so, because raising only the timeout to "just under 300" would silently exceed it.
* **The stdin case needed a harness change to be load-bearing at all.** My first version passed against a mutant with `</dev/null` removed — a backgrounded job already gets `/dev/null` as stdin, so the harness had nothing to distinguish. Case 9 now runs the entrypoint with its stdin on a FIFO held open by a writer that never writes: inherited stdin blocks, closed stdin gets EOF. This is the finding's point made twice over — the fix was untested, and so was the first test of it.
* **`ALISSA_WORKSPACE_PRUNE_KILL_AFTER_SECONDS` is a documented knob, not a test-only one**, unlike the interval-seconds override. It changes production behaviour (how long a wedged CLI is tolerated), and an operator who raises the timeout needs it to keep the pair inside their window.
* **Round 1: `137` is now claimed only when the elapsed time supports it.** The branch originally read any `137` as "our `-k` killed it". It is not ours to claim — `timeout` reports 128+signal for *any* signal death, and the realistic early cause on this container is the OOM killer. The branch now also requires `elapsed >= PRUNE_TIMEOUT_SECONDS`; an early `137` falls through to the generic `exited N` WARN. This matters beyond wording: the kill-after-grace message advises *raising* the timeout, which for an OOM means the next pass runs longer and allocates more before dying.
* **Round 1: the 240s derivation no longer implies a boot-wide guarantee.** `240 + 30 < 300` shows prune alone fits the window; it does not show the boot does, and two unbounded steps run in front of it (`3c` `workspace sync` by design, `2c`'s auth backoff at a 600s ceiling). The comment and README now frame 240 as prune's *share* of a shared window — which is still the argument against 900, without the false guarantee.
* **Round 1: the merge-ordering `[minor]` is the one finding declined** (`[triage:ignore]`, reasoned on the PR thread). Retargeting this PR's base at `TASK-190865621-WORKSPACE-PRUNE` would let GitHub enforce the order, but a PR based on a sibling branch is auto-retargeted when the parent squash-merges, and the retargeted diff can resolve to empty while GitHub reports a successful merge — silent and unrecoverable, versus a wrong merge order that is at least visible at review time. The gate stays prose, first section, bold.

### Not verified — operator's gate

* [ ] **Whether the real CLI traps `SIGTERM`.** The whole `-k` path is exercised against a stub that traps it deliberately. If TASK-2059754063 ships a graceful handler, 30s is a guess at how long an in-flight git operation needs; the `137` WARN is what will say so, and the knob is what raises it.
* [ ] **Whether 240s is enough for a real first sweep** on the production volume. It is deliberately not: the design assumes the first pass may time out, warn, and reclaim nothing until an operator raises the knob. If that reads as too conservative once real numbers exist, the knob is the lever — not a code change.
* [ ] **Railway's healthcheck timeout is 300s by default**, taken from the platform's documented default and this repo's own README walkthrough, not from an observed deploy. If this service configures a different window, the default should be re-derived against it.
* [ ] **Still no container and still no real subcommand** — same two gates as #82, unchanged by this PR.
* [ ] **The `137` elapsed guard assumes the kill lands at or after the bound.** If a platform's own supervisor SIGKILLs a *long-running* pass for an unrelated reason, it will still be reported as our kill-after-grace. The guard removes the early-kill misdiagnosis, which is the OOM case; it cannot separate two late kills.

### Verification

* `docker/claude/tests-entrypoint-prune.sh`: **51/51 ok**, eleven boots (cases 8, 9, 10 new at open; case 11 added in round 1).
* Counterfactuals, each mutating exactly one clause in a throwaway copy of `docker/claude/`:
  * drop `-k` → case 8 fails 2/3 ("a TERM-trapping prune pass held the boot open");
  * drop `</dev/null` → case 9 fails 2/2 (the pass is cut off by the bound instead of finishing);
  * drop `redact_token()` → case 10 fails 2/2 (marker absent, raw token present).
* All six pre-existing entrypoint suites re-run against the patched entrypoint: `config`, `identity`, `chown`, `executor`, `auth`, `ui` — all pass.
* `shellcheck -S warning` on `entrypoint.sh`: clean. `bash -n` on both changed shell files.
* Measured rather than assumed: `timeout -k 2 2 bash -c '<traps TERM>'` → exit **137**, and plain `timeout 25 bash -c 'timeout 2 <traps TERM>'` → the inner bound never returns and the outer one fires at 25s. That measurement is what produced the `137` branch above.
* No Python touched, so the style/type/unit suites carry no information about this diff; they were green on #82's head.

**Round 1 fixes (`3e6213f`):**

* Fourth counterfactual, mutating only the new clause: drop the `elapsed >= bound` condition from the `137` branch and case 11 fails 3/3 — an early SIGKILL is announced as a 20s timeout that never elapsed.
* Suite back to **51/51**; all six pre-existing entrypoint suites re-run and pass; `shellcheck -S warning` clean; `grep -c` confirms the duplicated comment block appears exactly once.
* Worth recording how the duplication happened, since `bash -n`, `shellcheck` and the suite are all blind to it: the patch script that applied this change aborted partway on an unrelated anchor, and the "already applied" guard added for the re-run tests whether the OLD text is still present — for this hunk the new text contained the old as a prefix, so the guard read "not yet applied" and appended a second copy. A comment-only duplication has no runtime signal at all; only review caught it.

### Round 2 — approve, three nits deferred

Round 2 returned `approve` on `3e6213f` with 0 blockers/majors/minors and three `[nit]`s. All three are triaged `[triage:later]` against **TASK-2093688770** (soft-linked to TASK-190865621), not pushed here:

* the generic non-zero WARN branch — the landing spot for an early `137` — logs the raw number without naming the signal or pointing an early kill at the memory ceiling;
* case 9 kills `FIFO_HOLDER` but never clears it, so the new `EXIT` trap can fire a second `kill` at a recycled PID (a defect this round introduced);
* the README's volume-hygiene paragraph now states "sync at `3c` is unbounded" twice, four lines apart.

Deferred rather than pushed because an approve is terminal for this branch, and a third stacked PR would force the operator into a strict #82 → #83 → #84 merge order — a worse trade than three registered diagnostic nits. The task is written to be opened as a plain PR against `main` once both merge, at which point nothing needs stacking.

### Scope touched

Same three files as #82, all within its declared scope (`docker/claude/*`):

* `docker/claude/entrypoint.sh` — the runner's `timeout -k`, the `137` branch, the two knob resolutions, the two ENABLED log lines.
* `docker/claude/tests-entrypoint-prune.sh` — cases 8/9/10, four stub modes, and the `EP_STDIN` hook.
* `docker/claude/README.md` — the timeout row rewritten, a `KILL_AFTER` row, and the window derivation.
* No workflow change needed: `check-entrypoint.yaml` already runs this suite (added by #82).
