### PR TITLE
TASK-859296697: bump loopwork base pin 0.1.0 → 0.2.0 (tag + index digest)

### DIFF
--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -24,7 +24,10 @@
 # 1000) + /workspace mount point, the system-wide GitHub SSH->HTTPS rewrite with
 # gh as git's credential helper, the workspace ENV skeleton
 # (ALISSA_WORKSPACE_ROOT / TMUX_TMPDIR / CLAUDE_CONFIG_DIR), EXPOSE 8080, and the
-# tini ENTRYPOINT hook at the fixed path /usr/local/bin/entrypoint.sh.
+# tini ENTRYPOINT hook at the fixed path /usr/local/bin/entrypoint.sh. Since base
+# 0.2.0 it is also MULTI-AGENT: the `codex` and `pi` CLIs ship alongside
+# claude-code. This daemon spawns `claude` only, so they are inert here — do not
+# add knobs or config for them.
 #
 # In this LEAF (below): the pip-installed daemon, the entrypoint + its helper
 # scripts (COPYed OVER the base's failing stub at that fixed path), the
@@ -61,7 +64,7 @@
 #     deliberate, reviewable change to this line, and that is the ONLY thing that
 #     advances the shared infrastructure layers;
 #   * the `@sha256:` is the ENFORCING half — a tag is mutable, so without it a
-#     re-push of `0.1.0` is substituted into every build with no diff to review.
+#     re-push of `0.2.0` is substituted into every build with no diff to review.
 #     That matters more here than for an ordinary base: this pin is now the whole
 #     review surface for claude-code, the `curl … | bash` CLI install and the apt
 #     layer, none of which this repo builds any more.
@@ -74,10 +77,10 @@
 # into the reference, so an arm64 base, once published, needs only the ordinary
 # two-value bump. Read the current one back with:
 #
-#   docker buildx imagetools inspect ghcr.io/ali-fhr/alissa-loopwork-base:0.1.0
+#   docker buildx imagetools inspect ghcr.io/ali-fhr/alissa-loopwork-base:0.2.0
 #
 # The base is linux/amd64-ONLY today; see "Base image" in README.md.
-FROM ghcr.io/ali-fhr/alissa-loopwork-base:0.1.0@sha256:b8eeb3df52b1437a02d217523b447fb6066d536b3916222d2b141b7167361845
+FROM ghcr.io/ali-fhr/alissa-loopwork-base:0.2.0@sha256:f46fd1431462392993da6dd209e23c15c3dc8495540469eaa06b40ca5bafda1c
 
 # Version of the daemon to install from PyPI. Bump per release: 0.16.0 is the
 # release this repo publishes on merge (it must match the dist's version file,

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -58,7 +58,7 @@ This Dockerfile is a thin **leaf** on the shared loopwork base image, pinned by
 both an exact tag and a digest:
 
 ```dockerfile
-FROM ghcr.io/ali-fhr/alissa-loopwork-base:0.1.0@sha256:b8eeb3df52b1437a02d217523b447fb6066d536b3916222d2b141b7167361845
+FROM ghcr.io/ali-fhr/alissa-loopwork-base:0.2.0@sha256:f46fd1431462392993da6dd209e23c15c3dc8495540469eaa06b40ca5bafda1c
 ```
 
 The base is **public on GHCR**, so the pull is anonymous — no registry
@@ -72,6 +72,10 @@ to the leaf:**
   (+ `iptables`/`ipset` for the optional egress firewall)
 - **claude-code**, with its first-run gates pre-seeded (`~/.claude.json`,
   `~/.claude/settings.json`) so worker-spawned reviewers start headless
+- since base `0.2.0`, two further agent CLIs — **`codex`** and **`pi`** — which
+  make the base multi-agent for its other leaves. This daemon spawns `claude`
+  only, so both are present and unused here; that is expected, not a defect, and
+  it is not a reason to add knobs or config for them
 - the **alissa CLI** on the `alissa` user's `PATH`
 - the non-root **`alissa` user (uid 1000)** and the `/workspace` mount point
 - the system-wide GitHub **SSH→HTTPS rewrite** with `gh` as git's credential
@@ -91,6 +95,13 @@ PR. That is how claude-code, the alissa CLI and the system packages advance for
 this image — never by re-adding a layer here. Base repo and its leaf contract:
 <https://github.com/ali-fhr/alissa-loopwork>.
 
+The bump to `0.2.0` (base PR `ali-fhr/alissa-loopwork#2`) is the multi-agent one:
+it adds `codex` and `pi` next to claude-code, and that is the whole of it — the
+claude-code version is unchanged across the bump, and so is everything this leaf
+builds on top. What it costs is **size**: the base's compressed amd64 layers go
+from ~270 MB to ~430 MB (≈840 MB → ≈1.31 GB unpacked), and this image inherits
+all of it. Expect a slower cold pull; nothing else about the runtime changes.
+
 #### How the pin is written
 
 Never `:latest`, and never a bare tag either. The reference carries **two values
@@ -98,8 +109,8 @@ that do different jobs**, and a bump changes both together:
 
 | half | job |
 | --- | --- |
-| `:0.1.0` — exact semver | the **readable** half. It is what makes a bump a reviewable one-line change and what tells a reader which base this is. |
-| `@sha256:b8eeb3df…` — digest | the **enforcing** half. A tag is mutable; without the digest, a re-push of `0.1.0` is substituted into every build with no diff to review. |
+| `:0.2.0` — exact semver | the **readable** half. It is what makes a bump a reviewable one-line change and what tells a reader which base this is. |
+| `@sha256:f46fd143…` — digest | the **enforcing** half. A tag is mutable; without the digest, a re-push of `0.2.0` is substituted into every build with no diff to review. |
 
 The digest matters more here than for an ordinary base image. This one line is now
 the *entire* review surface for claude-code, a `curl … | bash` CLI install and
@@ -107,19 +118,19 @@ the whole apt layer — none of which this repo builds, or sees, any more. A sil
 substitution should be a build failure, not a successful build of something else.
 
 The pinned digest is the **index** digest (what the registry returns as
-`Docker-Content-Digest` for the tag `0.1.0`), not the digest of the amd64 child
-manifest it currently selects (`sha256:8434c474…`). Pinning the index keeps
+`Docker-Content-Digest` for the tag `0.2.0`), not the digest of the amd64 child
+manifest it currently selects (`sha256:ba2f9b7b…`). Pinning the index keeps
 platform selection a build-time choice, so when the base gains arm64 this stays an
 ordinary two-value bump instead of a reference that can only ever resolve to
 amd64. Read the current values back with:
 
 ```sh
-docker buildx imagetools inspect ghcr.io/ali-fhr/alissa-loopwork-base:0.1.0
+docker buildx imagetools inspect ghcr.io/ali-fhr/alissa-loopwork-base:0.2.0
 ```
 
 #### Platform: amd64 only
 
-**The base publishes `linux/amd64` and nothing else.** Its `0.1.0` index contains
+**The base publishes `linux/amd64` and nothing else.** Its `0.2.0` index contains
 exactly one platform manifest plus an attestation manifest — no `arm64`, no
 `arm/v7`. The `python:3.12-slim-bookworm` this image used to build from shipped
 five architectures, so this is a real narrowing and it is worth knowing before you

--- a/docker/claude/tests-image-contract.sh
+++ b/docker/claude/tests-image-contract.sh
@@ -23,8 +23,11 @@
 # eye:
 #
 #   1. the build itself succeeds
-#   2. `alissa-revloop`, `alissa-revloop-ui`, `claude`, `alissa`, `gh`, `tmux`
-#      all resolvable on PATH
+#   2. `alissa-revloop`, `alissa-revloop-ui`, `claude`, `alissa`, `gh`, `tmux`,
+#      `codex`, `pi` all resolvable on PATH. The last two are base-contract only:
+#      this daemon never spawns them (base 0.2.0 made the base multi-agent), and
+#      they are asserted precisely BECAUSE nothing here would notice them going
+#      missing — which is the same reason every other inherited item is listed.
 #   3. `alissa` is uid 1000 / gid 1000
 #   4. BOTH GitHub SSH->HTTPS rewrites, the gh credential helper, and
 #      advice.detachedHead=false are present system-wide
@@ -121,7 +124,10 @@ eq()  { # eq <label> <expected> <actual>
 }
 
 # --- console scripts + inherited CLIs ---
-for b in alissa-revloop alissa-revloop-ui claude alissa gh tmux; do
+# `codex` and `pi` arrived with base 0.2.0 and are unused by this daemon; they
+# are here as BASE-CONTRACT assertions, not because anything in the leaf calls
+# them.
+for b in alissa-revloop alissa-revloop-ui claude alissa gh tmux codex pi; do
   p="$(command -v "$b" 2>/dev/null)"
   if [ -n "$p" ]; then ok "command -v $b -> $p"; else no "command -v $b -> NOT FOUND"; fi
 done


### PR DESCRIPTION
Closes #102

- Origin task: **TASK-981626946**
- Implementation task: **TASK-859296697** (soft-linked downstream of the origin)
- Review task (CR2): **TASK-1871873396**

## What changed

Re-pins `docker/claude/Dockerfile`'s base `FROM` from `0.1.0` to `0.2.0`, keeping the tag + **index digest** convention PR #96 established:

```dockerfile
FROM ghcr.io/ali-fhr/alissa-loopwork-base:0.2.0@sha256:f46fd1431462392993da6dd209e23c15c3dc8495540469eaa06b40ca5bafda1c
```

Three files, nothing else:

| file | change |
| --- | --- |
| `docker/claude/Dockerfile` | the `FROM` line, plus the three comment spots that spell out `0.1.0` and a note that the base is multi-agent since `0.2.0` |
| `docker/claude/README.md` | the `FROM` block, the "How the pin is written" table (`:0.2.0` / `@sha256:f46fd143…`), the index-vs-child-digest note (`sha256:ba2f9b7b…`), the `imagetools inspect` example, the amd64-only paragraph; a base-owned bullet for `codex`/`pi` and a paragraph on what the bump costs |
| `docker/claude/tests-image-contract.sh` | the optional two: `codex` and `pi` added to the PATH-resolution loop as base-contract assertions |

`entrypoint.sh`, `revloop-config.sh`, `init-firewall.sh` and `agents.yaml` are **byte-identical** to `main`; so are all seven `tests-entrypoint-*.sh` suites. `REVLOOP_VERSION` and every ARG→ENV knob default are untouched.

## Digest verification (worker-side)

The digest was resolved from GHCR anonymously, not taken from the issue text, and confirmed two independent ways:

```
GET https://ghcr.io/v2/ali-fhr/alissa-loopwork-base/manifests/0.2.0
  content-type:            application/vnd.oci.image.index.v1+json
  docker-content-digest:   sha256:f46fd1431462392993da6dd209e23c15c3dc8495540469eaa06b40ca5bafda1c
  sha256sum(response body) f46fd1431462392993da6dd209e23c15c3dc8495540469eaa06b40ca5bafda1c
```

Both agree with each other and with the value issue #102 names. The `0.2.0` index holds exactly one platform manifest (`linux/amd64`, `sha256:ba2f9b7b18…`) plus an attestation manifest — the same shape as `0.1.0`, so the amd64-only paragraph in the README stays true and only its digests moved. The check-image job's "Resolve the pinned base reference" step logs the same resolution on this PR.

## Base 0.2.0, pre-verified without a docker daemon

These runners have no docker binary, so the build itself is CI's job (below). What *could* be checked here was checked: the base's amd64 layer blobs and image config were pulled straight from GHCR and inspected, which covers every in-image assertion that depends on the base rather than on this leaf.

Image config (contract item 9 — the leaf re-declares none of it):

```
Entrypoint  [/usr/bin/tini -- /usr/local/bin/entrypoint.sh]
Cmd         (none)
User        root
WorkingDir  /workspace
Exposed     8080/tcp
Env         ALISSA_WORKSPACE_ROOT=/workspace  TMUX_TMPDIR=/home/alissa/.tmux
            CLAUDE_CONFIG_DIR=/workspace/.claude-config
```

Filesystem, from the layer tars (38 210 entries):

- on PATH: `/usr/bin/claude`, `/home/alissa/.local/bin/alissa`, `/usr/bin/gh`, `/usr/bin/tmux`, `/usr/bin/tini`, `/usr/sbin/gosu`, `/usr/bin/jq`, `/usr/bin/git`, `/usr/local/bin/python3` — **and `/usr/bin/codex` + `/usr/bin/pi`**, which is what makes the two new assertions safe rather than a guess
- `/usr/local/bin/entrypoint.sh` (the base stub this leaf COPYs over) is still at the fixed path
- `/home/alissa/.claude.json` carries `hasCompletedOnboarding: true`; `/home/alissa/.claude/settings.json` present
- `/etc/gitconfig` carries both `insteadOf` rewrites, `credential."https://github.com".helper = !gh auth git-credential`, and `advice.detachedHead = false`

Versions in the base, read from the npm package manifests — exactly what issue #102 predicts:

| CLI | 0.1.0 | 0.2.0 |
| --- | --- | --- |
| `@anthropic-ai/claude-code` | 2.1.241 | **2.1.241 (unchanged)** |
| `@openai/codex` | — | 0.149.1 |
| `@mariozechner/pi-coding-agent` | — | 0.73.1 |

Size, measured as compressed amd64 layer bytes: **270 MB → 430 MB** (15 layers either way). That is consistent with the ≈840 MB → ≈1.31 GB unpacked figure the issue quotes, at the ~3.1× ratio these layers compress at.

## Verification

| check | result |
| --- | --- |
| all 7 `docker/claude/tests-entrypoint-*.sh` | **PASS**, unedited (`auth`, `chown`, `config`, `executor`, `identity`, `prune`, `ui`) |
| `docker/claude/tests-image-contract.sh` | **SKIP** — no docker binary on this runner; it takes its documented no-daemon path and exits 0. `bash -n` clean. CI runs it with `REQUIRE_DOCKER=1` |
| `bash check-style.sh alissa-tools-github-revloop` | **PASS** (exit 0) |
| `bash check-types.sh alissa-tools-github-revloop` | **PASS** — "Success: no issues found in 30 source files" |
| `PYTHONPATH=src/main bash tests-unit.sh alissa-tools-github-revloop` | **PASS** — 823 passed in 64.41s |
| **all 7 checks on this PR** | **GREEN** — image contract 53s, entrypoint config renderer 2m49s, style, types, unit, wheel, version bump |

### check-image on this PR — GREEN

**Run:** <https://github.com/fahera-mx/alissa-github-review-daemon/actions/runs/33178252819/job/98872435935> — `Image contract (build + in-image assertions)`, **pass in 53s**.

- **Assertion count: 42 `ok`, 0 `FAIL`** — the harness printed `ALL PASS`.
- The build really built: `1. docker build --platform linux/amd64 …/docker/claude` → `Successfully installed alissa-tools-github-revloop-0.16.14` → `writing image sha256:7bf86e71…` → `naming to docker.io/library/alissa-review-daemon:contract-test`.
- The resolve step logged the pin agreeing with the digest resolved here:
  ```
  Dockerfile pins: ghcr.io/ali-fhr/alissa-loopwork-base:0.2.0@sha256:f46fd143…bafda1c
  Digest:    sha256:f46fd1431462392993da6dd209e23c15c3dc8495540469eaa06b40ca5bafda1c
    Name:    …@sha256:ba2f9b7b186db169caef45dfb1b94b41b82abbe4176d8083e6e4e7a00020849c   Platform: linux/amd64
  ```
- The two new assertions passed on their first execution: `ok command -v codex -> /usr/bin/codex`, `ok command -v pi -> /usr/bin/pi`.
- Leaf-side assertions that no local check could reach also passed in-image: `installed alissa-tools-github-revloop = 0.16.14`, the four sha256 COPY equalities, the knob defaults, and the git author identity read as `alissa`.

## Merge-time note — please paste the commit trailer

Round 1's `[minor]` 1: the single commit `69edd43b` was authored without the `Co-Authored-By` trailer that every recent non-merge commit on `main` carries. It cannot be fixed on this branch — amending would force-push off the approved, reviewed-green sha — so the remedy the reviewer proposed, and which I have taken, is to carry it in the **squash-merge message**:

```
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
```

Nothing else about the merge changes.

## Round 1 review — approve

`alissa-app` approved at `69edd43b3dfaaacb695425c3b2500f7ad1ef4a16` (the current head) with **0 blocker, 0 major, 2 minor, 1 nit**. Triage is posted on the PR: the trailer minor is answered by the merge-time note above; the stale `:0.1.0` comment in `.github/workflows/check-image.yaml:50` is deferred out of scope and carried by **TASK-736966448**; the nit needs no action and is answered on its inline thread. No code change and no follow-up PR resulted, so this branch is terminal at `69edd43b`.

## Delivery notes

**Judgment calls**

- Took the optional `tests-image-contract.sh` extension. `codex`/`pi` are exactly the kind of inherited thing that harness exists to catch, and their presence on PATH was confirmed against the real 0.2.0 layers first, so the assertions cannot turn CI red on a guess.
- Updated the three *comment* occurrences of `0.1.0` inside the Dockerfile (the mutable-tag warning, the `imagetools inspect` example) as well as the `FROM` line. The issue asks only for the `FROM`, but a bump that leaves the surrounding prose naming the old tag is the stale-doc failure this file's own comments warn about.
- Added two things to the README beyond a find-and-replace: a base-owned bullet for `codex`/`pi` saying they are present-and-unused here, and a short paragraph on the size cost. Both are stated in the issue as expected consequences; putting them where a reader of the pin will find them seemed better than leaving the fact only in this PR.
- Wrote the README's size figures as measured compressed layer bytes with the issue's unpacked numbers alongside, rather than repeating the unpacked numbers alone — I could measure the former here and not the latter.
- Left `.github/workflows/check-image.yaml` alone even though a comment there says "Records what `:0.1.0` resolved to". Workflow changes are explicitly out of scope for issue #102, and the step reads the tag out of the Dockerfile so it behaved correctly on this run — only the prose is stale. Flagged under the gate below rather than fixed here.
- Wrote the base's own PR reference in the README as `ali-fhr/alissa-loopwork#2`, fully qualified, so GitHub does not render it as a link to this repo's #2.

**Not verified — operator's gate**

Everything docker-shaped is now settled by CI rather than by me — `docker build` never ran on this runner (no docker binary at all: no daemon, no root, no user namespaces), so the check-image job linked above is the evidence for it, not a local run. What is left for the operator:

- [ ] **Nothing about the image was proven locally.** The base-side facts below the "pre-verified without a docker daemon" heading come from reading GHCR layer tars and the image config — evidence about the *base*, not about the assembled leaf. Trust the check-image run (42 ok / 0 FAIL, `ALL PASS`) for the assembled artifact, and re-read it if this branch is rebased.
- [ ] **Runtime cost of the bigger image is unobserved.** Cold-pull time on Railway and disk headroom on the deployed volume cannot be measured from here; the base's compressed layers grew roughly 1.6× (270 MB → 430 MB). Nothing else about the runtime changes.
- [ ] **`codex`/`pi` staying present-and-unused is a policy call, not a check.** No knob or config was added for them, per the issue. If the operator would rather they were absent, that is a change to the base repo, not to this leaf.
- [ ] **Non-amd64 local builds were not exercised.** The `0.2.0` index still ships exactly one platform manifest plus an attestation, so the amd64-only caveat in the README is unchanged — but nobody built this under emulation on Apple Silicon to confirm it.
- [ ] **`.github/workflows/check-image.yaml` carries a now-stale comment** ("Records what `:0.1.0` resolved to"). The step itself reads the tag out of the Dockerfile and logged `0.2.0` correctly on this run; only the prose is stale. Workflow files are out of scope for issue #102, so it was left alone deliberately — the operator may want a one-line follow-up.

**Verification**

- **Locally:** 7/7 `tests-entrypoint-*.sh` suites pass unedited; `check-style.sh` exit 0; `check-types.sh` "no issues found in 30 source files"; `tests-unit.sh` 823 passed. `tests-image-contract.sh` took its documented no-daemon SKIP (exit 0) and is `bash -n` clean. No failures anywhere.
- **On the PR:** all seven checks green. `Image contract` built the image FROM `0.2.0@sha256:f46fd143…` and printed `ALL PASS` — **42 ok, 0 FAIL**, including the two `codex`/`pi` lines this PR adds.
- Digest resolution and the base filesystem/config inspection were done live against GHCR during this session, not read from the issue text — and CI's independent `imagetools inspect` agreed with both.

**Scope touched**

- Declared scope is `docker/claude/**`. Three files modified, all inside it: `Dockerfile`, `README.md`, `tests-image-contract.sh`.
- No excursion. No python, no workflow, no entrypoint or helper script, no `agents.yaml`, no knob or version default. The develop-daemon repo and TASK-1002153074 (the dead `deb.nodesource.com` allowlist entry) were not touched.
