### PR TITLE
TASK-495451465: default reviewer model opus → claude-fable-5 when ALISSA_AGENT_MODEL is unset (issue #110)

### DIFF
--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -285,9 +285,11 @@ ARG ALISSA_TASK_LIST_SELF_SCOPE=""
 ARG ALISSA_AGENT_PROFILE="claude"
 # Reviewer model pinned into the agents.yaml claude command at boot (the reviewer
 # is the quality gate, so it must not silently fall back to a smaller model on a
-# usage-throttled account). Alias (`opus`/`sonnet`) or full id (`claude-opus-4-8`);
+# usage-throttled account). Default `claude-fable-5`: the most capable generally
+# available Claude model, one tier above Opus (operator decision 2026-08-30).
+# Alias (`opus`/`sonnet`) or full id (`claude-opus-4-8`) pass through verbatim;
 # `default` or empty omits the --model flag. See the entrypoint (step 2e) + README.
-ARG ALISSA_AGENT_MODEL="opus"
+ARG ALISSA_AGENT_MODEL="claude-fable-5"
 ARG ALISSA_ON_MISSING_HUB="add"
 # Worker reconcile tick, seconds.
 ARG ALISSA_WORKER_INTERVAL="2"

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -300,7 +300,9 @@ downstream notices. The baked [`agents.yaml`](./agents.yaml) pins no model, so a
 reviewer inherits whatever the persisted `claude /login` account defaults to —
 and on plan-based accounts that default can **silently fall back to a smaller
 model** once a usage threshold is hit. `ALISSA_AGENT_MODEL` makes the model an
-explicit boot-time decision instead of a rebuild-time one.
+explicit boot-time decision instead of a rebuild-time one. The unset default is
+`claude-fable-5` — the most capable generally-available Claude model, one tier
+above Opus — because the reviewer is the pipeline's quality gate.
 
 At container boot the entrypoint appends `--model "$ALISSA_AGENT_MODEL"` to the
 claude profile's `command:` and logs the effective command (grep the startup log
@@ -308,7 +310,7 @@ for `effective reviewer command:`).
 
 | `ALISSA_AGENT_MODEL` | reviewer `command:` becomes |
 | --- | --- |
-| *(unset)* → default `opus` | `claude … --model opus` |
+| *(unset)* → default `claude-fable-5` | `claude … --model claude-fable-5` |
 | `claude-opus-4-8` (any alias or full id) | `claude … --model claude-opus-4-8` |
 | `default` *or* empty | `claude …` (no `--model` — restores account default) |
 
@@ -352,7 +354,7 @@ automatically; locally pass `--build-arg`):
 | `ALISSA_REVIEW_TASK_MISS_TTL_POLLS` | *daemon default* (currently 10) | how many polls a PR with **no** Alissa review task is taken on trust before the daemon searches the actor's task corpus for one again. That search is the widest read the daemon makes and the PR→task mapping can only cache an answer that exists, so an unmapped PR used to pay the whole corpus every poll, indefinitely. Trades **latency** for reads: a review task created inside the window is picked up at the re-arm, not the next poll. Floor `1` — there is no value that disables it, and `0` is refused at config load. **pass-through** — unset ⇒ library default. Needs `REVLOOP_VERSION >= 0.18.0` |
 | `ALISSA_TASK_LIST_SELF_SCOPE` | *(unset ⇒ library default `false`)* | `1`/`true`/`yes`/`on` narrows `alissa task list` to this actor's own rows (`--self`), dropping the sponsor's corpus; `0`/`false`/`no`/`off` is the explicit opposite and **anything else is refused** rather than rendered as `false`. Off by default on measured evidence: it saves ~4% of the payload, and a small minority of review tasks on the live fleet are owned by another actor — one the list cannot see is a round the daemon cannot count. Set it only where every review task is created by this daemon's own reviewer sessions. The other narrowings (status filter, digest view) are probed from the installed CLI and need no variable. **pass-through** — unset ⇒ library default. Needs `REVLOOP_VERSION >= 0.18.0` |
 | `ALISSA_AGENT_PROFILE` | `claude` | agent the worker launches (must name a profile in `agents.yaml`) |
-| `ALISSA_AGENT_MODEL` | `opus` | model pinned into the reviewer's claude command (see [Pinning the reviewer model](#pinning-the-reviewer-model)); `default` or empty omits the pin |
+| `ALISSA_AGENT_MODEL` | `claude-fable-5` | model pinned into the reviewer's claude command (see [Pinning the reviewer model](#pinning-the-reviewer-model)); `default` or empty omits the pin |
 | `ALISSA_ON_MISSING_HUB` | `add` | `add` hub-ifies on demand; `skip` to require a mounted workspace |
 | `ALISSA_WORKER_INTERVAL` | `2` | worker reconcile tick (seconds) |
 | `ALISSA_ENABLE_FIREWALL` | `0` | `1` raises the egress firewall (needs `--cap-add=NET_ADMIN`) |
@@ -801,8 +803,8 @@ the rest only mean anything on a service that already set those two.
 | `ALISSA_BRIDGE_POLL_SECONDS` | *(CLI default: 15)* | seconds between queue polls; maps to the CLI's `--interval`; **pass-through** |
 
 The model pin works exactly as it does for the daemon: `ALISSA_AGENT_MODEL`
-(default `opus`) is rewritten into the `claude` profile's `command:` at boot, and
-job sessions inherit it. The profile deliberately carries **no**
+(default `claude-fable-5`) is rewritten into the `claude` profile's `command:` at
+boot, and job sessions inherit it. The profile deliberately carries **no**
 `disable_alissa_code`, which is what makes the CLI launch it via `alissa code -y
 --handoff claude` — that wrapper is what registers the codeSession and its
 10-minute log checkpoints. Adding the flag would launch a bare `claude` and lose

--- a/docker/claude/agents.yaml
+++ b/docker/claude/agents.yaml
@@ -9,10 +9,11 @@
 # root) — the image runs as uid 1000, which satisfies it. Reviewer posture (CR6:
 # reviewers never write) is enforced by the round directive, not by this profile.
 #
-# To pin the reviewer model, set the ALISSA_AGENT_MODEL env var (default: opus) —
-# the entrypoint rewrites the `command:` below with `--model "$ALISSA_AGENT_MODEL"`
-# at container boot (set it to `default` or empty to omit the flag and inherit the
-# account default). To change flags instead, mount your own agents.yaml over this
+# To pin the reviewer model, set the ALISSA_AGENT_MODEL env var (default:
+# claude-fable-5) — the entrypoint rewrites the `command:` below with
+# `--model "$ALISSA_AGENT_MODEL"` at container boot (set it to `default` or empty
+# to omit the flag and inherit the account default). To change flags instead,
+# mount your own agents.yaml over this
 # path at runtime; a mounted file lacks the `alissa-managed:` marker below and is
 # used verbatim, so ALISSA_AGENT_MODEL does not touch it (your command wins).
 #

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -580,7 +580,8 @@ fi
 # The reviewer is the pipeline's quality gate, but the baked claude profile pins
 # no model — so it inherits the persisted /login account's default, which can
 # silently fall back to a smaller model when a plan hits its usage threshold. We
-# pin it explicitly at boot: ALISSA_AGENT_MODEL (default `opus`) is appended to
+# pin it explicitly at boot: ALISSA_AGENT_MODEL (default `claude-fable-5`, the
+# most capable generally-available model, one tier above Opus) is appended to
 # the profile's `command:` as `--model <value>`. The value passes through
 # verbatim — aliases (`opus`, `sonnet`) and full ids (`claude-opus-4-8`) are both
 # valid, no allowlist. `default` or an empty value omits the flag entirely,
@@ -593,9 +594,9 @@ fi
 # it is pristine on every boot and this rewrite is idempotent.
 # -----------------------------------------------------------------------------
 AGENTS_YAML="${HOME}/.config/alissa/agents.yaml"
-# Default `opus` only when UNSET (use `-`, not `:-`): an explicitly empty value is
-# a valid opt-out and must NOT be re-defaulted back to opus.
-AGENT_MODEL="${ALISSA_AGENT_MODEL-opus}"
+# Default `claude-fable-5` only when UNSET (use `-`, not `:-`): an explicitly
+# empty value is a valid opt-out and must NOT be re-defaulted back to the pin.
+AGENT_MODEL="${ALISSA_AGENT_MODEL-claude-fable-5}"
 if [ ! -f "${AGENTS_YAML}" ]; then
   log "WARN: ${AGENTS_YAML} not found — skipping model pin (worker will fall back to a bare claude)"
 elif ! grep -q 'alissa-managed:' "${AGENTS_YAML}"; then

--- a/docker/claude/tests-entrypoint-executor.sh
+++ b/docker/claude/tests-entrypoint-executor.sh
@@ -17,6 +17,12 @@
 #                                            structural flags; no worker, no
 #                                            daemon, no revloop.config.json;
 #                                            identity + agent profile on the volume
+#                                            (model pin = the baked default, since
+#                                            the boot env carries no
+#                                            ALISSA_AGENT_MODEL)
+#   2b. the model pin is a DEFAULT        -> an explicit alias / full id lands
+#                                            verbatim; `default` and empty omit
+#                                            the flag instead of re-defaulting
 #   3. executor id required + validated   -> empty dies, bad slug dies
 #   4. the pass-through knobs             -> label / concurrency / interval only
 #                                            appear when they are set
@@ -200,6 +206,16 @@ wait_boot() {
 }
 
 EXECUTOR_UP="starting alissa bridge start"
+
+# The claude profile's rendered `command:` line from the executor's copy of
+# agents.yaml, value only. BASE_CMD mirrors the entrypoint's step-2e constant:
+# a model pin is exactly BASE_CMD plus `--model <value>`, and no pin is exactly
+# BASE_CMD — so every model assertion compares the WHOLE line.
+BASE_CMD="claude --dangerously-skip-permissions --permission-mode acceptEdits"
+profile_cmd() {
+  sed -n -E 's/^[[:space:]]*command:[[:space:]]*//p' \
+    "${WORKSPACE}/.alissa-config/agents.yaml" 2>/dev/null | head -n 1
+}
 DAEMON_UP="alissa worker is running"
 
 # -----------------------------------------------------------------------------
@@ -265,10 +281,55 @@ assert_contains "${LOG2}" "identity file ${WORKSPACE}/.alissa-config/bridge-exec
   "the executor identity file is placed on the volume"
 assert_file "${WORKSPACE}/.alissa-config/agents.yaml" \
   "the resolved agents.yaml is copied to the executor's config dir"
-assert_contains "${WORKSPACE}/.alissa-config/agents.yaml" "--model opus" \
-  "...with the model pin applied, exactly as the daemon role gets it"
+# start_boot runs under `env -i` with no ALISSA_AGENT_MODEL, so this is the
+# UNSET path: the pin must be the baked default, not an alias.
+assert_eq "$(profile_cmd)" "${BASE_CMD} --model claude-fable-5" \
+  "...with the model pin applied (unset -> default claude-fable-5), exactly as the daemon role gets it"
+assert_contains "${LOG2}" "reviewer model: claude-fable-5 (ALISSA_AGENT_MODEL)" \
+  "...and the boot log names the default"
 assert_not_contains "${WORKSPACE}/.alissa-config/agents.yaml" "disable_alissa_code" \
   "...and WITHOUT disable_alissa_code, so job sessions still launch via alissa code"
+
+# -----------------------------------------------------------------------------
+info ""
+info "2b. the model pin is a DEFAULT, not a constant -> explicit values pass through"
+# -----------------------------------------------------------------------------
+# Case 2 proved the baked default on the unset path. A default is only worth
+# having if the operator can still override it, so each boot below sets
+# ALISSA_AGENT_MODEL explicitly and reads back the rendered `command:` line
+# (only that line — the agents.yaml header comment itself mentions `--model` and
+# the default, so a whole-file grep would pass vacuously).
+model_boot() {  # <log> <ALISSA_AGENT_MODEL assignment>
+  reset_spies
+  start_boot "$1" CONTAINER_ROLE=executor ALISSA_BRIDGE_EXECUTOR=1 "$2"
+  wait_boot "$1" 30 "${EXECUTOR_UP}"
+}
+
+LOG2B="${TMPROOT}/model-alias.log"
+model_boot "${LOG2B}" ALISSA_AGENT_MODEL=opus
+assert_eq "$(profile_cmd)" "${BASE_CMD} --model opus" \
+  "an explicit alias (opus) is pinned verbatim, not re-defaulted"
+assert_contains "${LOG2B}" "reviewer model: opus (ALISSA_AGENT_MODEL)" \
+  "...and the log names the explicit value"
+
+LOG2C="${TMPROOT}/model-fullid.log"
+model_boot "${LOG2C}" ALISSA_AGENT_MODEL=claude-opus-4-8
+assert_eq "$(profile_cmd)" "${BASE_CMD} --model claude-opus-4-8" \
+  "a full model id passes through unchanged (no allowlist)"
+
+LOG2D="${TMPROOT}/model-default.log"
+model_boot "${LOG2D}" ALISSA_AGENT_MODEL=default
+assert_eq "$(profile_cmd)" "${BASE_CMD}" \
+  "ALISSA_AGENT_MODEL=default omits --model (account default)"
+assert_contains "${LOG2D}" "reviewer model: account default (ALISSA_AGENT_MODEL='default')" \
+  "...and the log says so"
+
+LOG2E="${TMPROOT}/model-empty.log"
+model_boot "${LOG2E}" ALISSA_AGENT_MODEL=
+assert_eq "$(profile_cmd)" "${BASE_CMD}" \
+  "an explicitly EMPTY value is an opt-out: --model omitted, NOT re-defaulted"
+assert_contains "${LOG2E}" "reviewer model: account default (ALISSA_AGENT_MODEL='')" \
+  "...and the log says so"
 
 # -----------------------------------------------------------------------------
 info ""

--- a/docker/claude/tests-image-contract.sh
+++ b/docker/claude/tests-image-contract.sh
@@ -172,7 +172,7 @@ fi
 
 # --- baked ARG->ENV knob defaults ---
 eq "ALISSA_AGENT_PROFILE"   "claude"     "${ALISSA_AGENT_PROFILE-<unset>}"
-eq "ALISSA_AGENT_MODEL"     "opus"       "${ALISSA_AGENT_MODEL-<unset>}"
+eq "ALISSA_AGENT_MODEL"     "claude-fable-5" "${ALISSA_AGENT_MODEL-<unset>}"
 eq "ALISSA_ON_MISSING_HUB"  "add"        "${ALISSA_ON_MISSING_HUB-<unset>}"
 eq "ALISSA_WORKER_INTERVAL" "2"          "${ALISSA_WORKER_INTERVAL-<unset>}"
 eq "ALISSA_WORKSPACE_ROOT"  "/workspace" "${ALISSA_WORKSPACE_ROOT-<unset>}"


### PR DESCRIPTION
Closes #110

Origin task: TASK-172658489 · Implementation task: TASK-495451465

## What

Flip the `ALISSA_AGENT_MODEL` **unset** default from `opus` to `claude-fable-5` at every site the default is defined, documented or asserted — all under `docker/claude/`. Value change only; everything else about the knob is untouched:

- the fallback stays `${ALISSA_AGENT_MODEL-…}` (`-`, never `:-`) — an explicitly empty value is still an opt-out;
- `default` / empty still omit `--model`; any other value still passes through verbatim (alias or full id, no allowlist);
- a custom `agents.yaml` (no `alissa-managed:` marker) still wins verbatim.

| site | change |
| --- | --- |
| `Dockerfile` | `ARG ALISSA_AGENT_MODEL="claude-fable-5"`; comment block keeps the "must not silently fall back to a smaller model" rationale, names the new default and why |
| `entrypoint.sh` step 2e | `AGENT_MODEL="${ALISSA_AGENT_MODEL-claude-fable-5}"`; the two "default `opus`" comments updated |
| `agents.yaml` | header comment `(default: claude-fable-5)` |
| `README.md` | pinning table row (`*(unset)* → default \`claude-fable-5\`` → `claude … --model claude-fable-5`), one rationale sentence above it, env-var table default column, executor-role paragraph |
| `tests-image-contract.sh` | baked ARG→ENV default asserted as `claude-fable-5` |
| `tests-entrypoint-executor.sh` | case 2 boots under `env -i` with no `ALISSA_AGENT_MODEL`, i.e. it **was** the unset path — it now asserts the rendered `command:` line is exactly `BASE_CMD --model claude-fable-5` and that the boot log says `reviewer model: claude-fable-5 (ALISSA_AGENT_MODEL)`. New **case 2b** boots with `ALISSA_AGENT_MODEL=opus`, `=claude-opus-4-8`, `=default` and `=` (empty) and compares the whole rendered `command:` line each time, proving explicit values and both opt-outs are untouched by the default change |

`revloop-config.sh` carries no model default (only the profile name `claude`) — left alone, as the issue says. No version bump: `check-version-bump.yaml` guards the `alissa-tools-github-revloop/` dist directory only and this PR touches nothing under it.

## Surviving `opus` occurrences (`grep -rn -i opus`, every hit justified)

| file:line | text | why it stays |
| --- | --- | --- |
| `Dockerfile:289` | `one tier above Opus (operator decision …)` | rationale prose — names the tier the default moved past |
| `Dockerfile:290` | ``Alias (`opus`/`sonnet`) or full id (`claude-opus-4-8`)`` | alias / full-id examples (issue: may keep) |
| `entrypoint.sh:584` | `one tier above Opus` | rationale prose |
| `entrypoint.sh:586` | ``aliases (`opus`, `sonnet`) and full ids (`claude-opus-4-8`)`` | alias / full-id examples |
| `README.md:305` | `above Opus — because the reviewer is the pipeline's quality gate` | rationale prose |
| `README.md:314` | ``| `claude-opus-4-8` (any alias or full id) | `claude … --model claude-opus-4-8` |`` | explicit-value table row (full-id example) |
| `README.md:317–318` | ``both aliases (`opus`, `sonnet`) and full ids (`claude-opus-4-8`) are valid`` | the alias/full-id sentence the issue says stays |
| `tests-entrypoint-executor.sh:309–312` | `ALISSA_AGENT_MODEL=opus` … `--model opus` … `reviewer model: opus` | explicit-value pass-through assertion (case 2b) |
| `tests-entrypoint-executor.sh:316–317` | `ALISSA_AGENT_MODEL=claude-opus-4-8` … `--model claude-opus-4-8` | full-id pass-through assertion (case 2b) |

No hit is a *default* any more.

## Delivery notes

### Judgment calls

- The executor suite's `--model opus` assertion (old L268) was **the unset-default path** — `start_boot` uses `env -i` and never sets `ALISSA_AGENT_MODEL` — so it was flipped to `claude-fable-5`, not left as an explicit-value test. Since no suite covered explicit pass-through at all, case 2b was added (alias, full id, `default`, empty), per the issue's "add one assertion … if no such test exists" — four boots rather than one, because the issue's acceptance criteria list all four behaviours.
- Case 2/2b assert on the **rendered `command:` line only** (a `profile_cmd` helper + a `BASE_CMD` constant mirroring the entrypoint's), not a whole-file grep: after this change the agents.yaml header comment itself mentions both `--model` and `claude-fable-5`, so a file-wide `grep -F` would pass vacuously for the "no `--model`" and "no default leak" cases.
- Comment/prose sites gained a one-clause rationale ("the most capable generally-available Claude model, one tier above Opus") next to the new value, where the old comment had none — the issue asked to keep the existing rationale and change the value; the extra clause is the *why* behind the operator decision, so a future reader is not left guessing why an alias became a full id.
- Commit trailer is `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` (the model this session actually runs on) rather than the `Claude Opus 5` seen on recent `main` commits — truthful attribution over pattern-matching.
- The develop-daemon mirror of the README wording is out of scope per the issue; the sentence added here ("The unset default is `claude-fable-5` …") is written so it can be mirrored verbatim there.

### Not verified — operator's gate

- [ ] `tests-image-contract.sh` (check-image) was **not run locally** — this runner has no docker. The change to it is a one-string assertion; the ARG→ENV chain it reads (`ARG ALISSA_AGENT_MODEL` L292 → `ENV … ALISSA_AGENT_MODEL=${ALISSA_AGENT_MODEL}` L324) was verified by reading the Dockerfile, and `EXPECT_AGENTS_SHA` is computed from the repo's `agents.yaml` at run time (L104), so the header-comment edit cannot break the sha pin. CI's `check-image` job is the proof.
- [ ] The Railway runtime: after merge + redeploy the boot log must show `reviewer model: claude-fable-5 (ALISSA_AGENT_MODEL)` and the next round must start without a model-access error from the reviewer's claude login — and a runtime `ALISSA_AGENT_MODEL` set in the dashboard shadows this default. Operator step, as the issue says.
- [ ] That `claude-fable-5` is accepted by the reviewer account's `claude` login (model access is an account property; nothing in this repo can assert it).
- [ ] Round-1 `[nit]` (agents.yaml header: `# mount your own agents.yaml over this` orphaned at ~45 columns by the reflow) is `[triage:later]` → **TASK-1385697915**, sequenced after this PR merges: the rewrap touches the lines this PR changes, so a follow-up off `main` cut before the merge conflicts with it, and the approved branch is not pushed again. Exact patch staged as evidence on TASK-495451465.

### Verification

- `bash docker/claude/tests-entrypoint-executor.sh` — **PASS** (all cases incl. new 2b; 21s).
- Counterfactual mutants, each run against the suite then reverted: fallback `claude-fable-5` → `opus` ⇒ **FAIL** on exactly case 2's two new assertions (rendered line + log); `-` → `:-` ⇒ **FAIL** on exactly the empty-opt-out assertions of case 2b. Both mutants die on the intended clause and nothing else.
- The other six entrypoint suites (`tests-entrypoint-config/identity/auth/chown/prune/ui.sh`), since `entrypoint.sh` changed — **all PASS**, 0 FAIL lines.
- `bash check-style.sh alissa-tools-github-revloop` — exit 0; `bash check-types.sh …` — `Success: no issues found in 30 source files`; `PYTHONPATH=src/main bash tests-unit.sh …` — **920 passed** in 26.5s (the dist is untouched by this PR; run because CI runs them). `pycodestyle`/`mypy`/`coverage` had to be `pip install --user`ed on this runner first.
- CI on this PR at handoff: image contract, style, types, unit tests, wheel and version-bump **SUCCESS**; the entrypoint check result is whatever the rollup shows on the head `1da7703`.
- `grep -rn -i opus` over the repo: 9 sites, all enumerated above.

### Scope touched

- `docker/claude/Dockerfile`, `entrypoint.sh`, `agents.yaml`, `README.md`, `tests-image-contract.sh`, `tests-entrypoint-executor.sh` — all inside the issue's declared scope.
- `alissa-tools-github-revloop/…/version` — in the declared scope but **not** touched (bump not triggered, see above).
- No excursions.
