### PR TITLE
TASK-1443304265: default reviewer model claude-fable-5 → claude-fable-5-1 when ALISSA_AGENT_MODEL is unset (issue #114)

### DIFF
--- a/docker/claude/Dockerfile
+++ b/docker/claude/Dockerfile
@@ -297,11 +297,12 @@ ARG ALISSA_REV_LOOP_EVENTS_ENABLED=""
 ARG ALISSA_AGENT_PROFILE="claude"
 # Reviewer model pinned into the agents.yaml claude command at boot (the reviewer
 # is the quality gate, so it must not silently fall back to a smaller model on a
-# usage-throttled account). Default `claude-fable-5`: the most capable generally
-# available Claude model, one tier above Opus (operator decision 2026-08-30).
+# usage-throttled account). Default `claude-fable-5-1`: the latest and most
+# capable generally available Claude model, one tier above Opus (operator
+# decision 2026-09-01).
 # Alias (`opus`/`sonnet`) or full id (`claude-opus-4-8`) pass through verbatim;
 # `default` or empty omits the --model flag. See the entrypoint (step 2e) + README.
-ARG ALISSA_AGENT_MODEL="claude-fable-5"
+ARG ALISSA_AGENT_MODEL="claude-fable-5-1"
 ARG ALISSA_ON_MISSING_HUB="add"
 # Worker reconcile tick, seconds.
 ARG ALISSA_WORKER_INTERVAL="2"

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -301,8 +301,9 @@ reviewer inherits whatever the persisted `claude /login` account defaults to —
 and on plan-based accounts that default can **silently fall back to a smaller
 model** once a usage threshold is hit. `ALISSA_AGENT_MODEL` makes the model an
 explicit boot-time decision instead of a rebuild-time one. The unset default is
-`claude-fable-5` — the most capable generally-available Claude model, one tier
-above Opus — because the reviewer is the pipeline's quality gate.
+`claude-fable-5-1` — the latest and most capable generally-available Claude
+model, one tier above Opus — because the reviewer is the pipeline's quality
+gate.
 
 At container boot the entrypoint appends `--model "$ALISSA_AGENT_MODEL"` to the
 claude profile's `command:` and logs the effective command (grep the startup log
@@ -310,7 +311,7 @@ for `effective reviewer command:`).
 
 | `ALISSA_AGENT_MODEL` | reviewer `command:` becomes |
 | --- | --- |
-| *(unset)* → default `claude-fable-5` | `claude … --model claude-fable-5` |
+| *(unset)* → default `claude-fable-5-1` | `claude … --model claude-fable-5-1` |
 | `claude-opus-4-8` (any alias or full id) | `claude … --model claude-opus-4-8` |
 | `default` *or* empty | `claude …` (no `--model` — restores account default) |
 
@@ -355,7 +356,7 @@ automatically; locally pass `--build-arg`):
 | `ALISSA_TASK_LIST_SELF_SCOPE` | *(unset ⇒ library default `false`)* | `1`/`true`/`yes`/`on` narrows `alissa task list` to this actor's own rows (`--self`), dropping the sponsor's corpus; `0`/`false`/`no`/`off` is the explicit opposite and **anything else is refused** rather than rendered as `false`. Off by default on measured evidence: it saves ~4% of the payload, and a small minority of review tasks on the live fleet are owned by another actor — one the list cannot see is a round the daemon cannot count. Set it only where every review task is created by this daemon's own reviewer sessions. The other narrowings (status filter, digest view) are probed from the installed CLI and need no variable. **pass-through** — unset ⇒ library default. Needs `REVLOOP_VERSION >= 0.18.0` |
 | `ALISSA_REV_LOOP_EVENTS_ENABLED` | *(unset ⇒ library default `false`)* | `1`/`true`/`yes`/`on` makes the daemon push loop telemetry (rounds spawned, verdicts posted, cap-outs, stability holds, stalls, checks holds, grants, reaps) to Studio's `POST /v1/loop-events` once per poll pass — one idempotent, ledger-derived batch, best-effort and never fatal, authenticated with the container's existing `ALISSA_API_TOKEN`; `0`/`false`/`no`/`off` is the explicit opposite and **anything else is refused** rather than rendered as `false`. The daemon library also reads this exact variable directly and it **wins over the rendered config and the CLI flags**, so the render can never contradict the env. Off by default: telemetry is an outbound write and an image upgrade must not start posting on its own. **pass-through** — unset ⇒ library default. Needs `REVLOOP_VERSION >= 0.28.0` |
 | `ALISSA_AGENT_PROFILE` | `claude` | agent the worker launches (must name a profile in `agents.yaml`) |
-| `ALISSA_AGENT_MODEL` | `claude-fable-5` | model pinned into the reviewer's claude command (see [Pinning the reviewer model](#pinning-the-reviewer-model)); `default` or empty omits the pin |
+| `ALISSA_AGENT_MODEL` | `claude-fable-5-1` | model pinned into the reviewer's claude command (see [Pinning the reviewer model](#pinning-the-reviewer-model)); `default` or empty omits the pin |
 | `ALISSA_ON_MISSING_HUB` | `add` | `add` hub-ifies on demand; `skip` to require a mounted workspace |
 | `ALISSA_WORKER_INTERVAL` | `2` | worker reconcile tick (seconds) |
 | `ALISSA_ENABLE_FIREWALL` | `0` | `1` raises the egress firewall (needs `--cap-add=NET_ADMIN`) |
@@ -805,8 +806,8 @@ the rest only mean anything on a service that already set those two.
 | `ALISSA_BRIDGE_POLL_SECONDS` | *(CLI default: 15)* | seconds between queue polls; maps to the CLI's `--interval`; **pass-through** |
 
 The model pin works exactly as it does for the daemon: `ALISSA_AGENT_MODEL`
-(default `claude-fable-5`) is rewritten into the `claude` profile's `command:` at
-boot, and job sessions inherit it. The profile deliberately carries **no**
+(default `claude-fable-5-1`) is rewritten into the `claude` profile's `command:`
+at boot, and job sessions inherit it. The profile deliberately carries **no**
 `disable_alissa_code`, which is what makes the CLI launch it via `alissa code -y
 --handoff claude` — that wrapper is what registers the codeSession and its
 10-minute log checkpoints. Adding the flag would launch a bare `claude` and lose

--- a/docker/claude/agents.yaml
+++ b/docker/claude/agents.yaml
@@ -10,12 +10,12 @@
 # reviewers never write) is enforced by the round directive, not by this profile.
 #
 # To pin the reviewer model, set the ALISSA_AGENT_MODEL env var (default:
-# claude-fable-5) — the entrypoint rewrites the `command:` below with
+# claude-fable-5-1) — the entrypoint rewrites the `command:` below with
 # `--model "$ALISSA_AGENT_MODEL"` at container boot (set it to `default` or empty
 # to omit the flag and inherit the account default). To change flags instead,
-# mount your own agents.yaml over this
-# path at runtime; a mounted file lacks the `alissa-managed:` marker below and is
-# used verbatim, so ALISSA_AGENT_MODEL does not touch it (your command wins).
+# mount your own agents.yaml over this path at runtime; a mounted file lacks the
+# `alissa-managed:` marker below and is used verbatim, so ALISSA_AGENT_MODEL
+# does not touch it (your command wins).
 #
 # alissa-managed: the entrypoint regenerates the `command:` line of this default
 # profile at boot from ALISSA_AGENT_MODEL — do not remove this marker line, it is

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -580,12 +580,12 @@ fi
 # The reviewer is the pipeline's quality gate, but the baked claude profile pins
 # no model — so it inherits the persisted /login account's default, which can
 # silently fall back to a smaller model when a plan hits its usage threshold. We
-# pin it explicitly at boot: ALISSA_AGENT_MODEL (default `claude-fable-5`, the
-# most capable generally-available model, one tier above Opus) is appended to
-# the profile's `command:` as `--model <value>`. The value passes through
-# verbatim — aliases (`opus`, `sonnet`) and full ids (`claude-opus-4-8`) are both
-# valid, no allowlist. `default` or an empty value omits the flag entirely,
-# restoring the account-default behavior.
+# pin it explicitly at boot: ALISSA_AGENT_MODEL (default `claude-fable-5-1`, the
+# latest and most capable generally-available model, one tier above Opus) is
+# appended to the profile's `command:` as `--model <value>`. The value passes
+# through verbatim — aliases (`opus`, `sonnet`) and full ids (`claude-opus-4-8`)
+# are both valid, no allowlist. `default` or an empty value omits the flag
+# entirely, restoring the account-default behavior.
 #
 # Precedence: we only rewrite the BAKED default (identified by its `alissa-managed:`
 # marker). A custom agents.yaml mounted over this path carries no marker, so it is
@@ -594,9 +594,9 @@ fi
 # it is pristine on every boot and this rewrite is idempotent.
 # -----------------------------------------------------------------------------
 AGENTS_YAML="${HOME}/.config/alissa/agents.yaml"
-# Default `claude-fable-5` only when UNSET (use `-`, not `:-`): an explicitly
+# Default `claude-fable-5-1` only when UNSET (use `-`, not `:-`): an explicitly
 # empty value is a valid opt-out and must NOT be re-defaulted back to the pin.
-AGENT_MODEL="${ALISSA_AGENT_MODEL-claude-fable-5}"
+AGENT_MODEL="${ALISSA_AGENT_MODEL-claude-fable-5-1}"
 if [ ! -f "${AGENTS_YAML}" ]; then
   log "WARN: ${AGENTS_YAML} not found — skipping model pin (worker will fall back to a bare claude)"
 elif ! grep -q 'alissa-managed:' "${AGENTS_YAML}"; then

--- a/docker/claude/tests-entrypoint-executor.sh
+++ b/docker/claude/tests-entrypoint-executor.sh
@@ -283,9 +283,9 @@ assert_file "${WORKSPACE}/.alissa-config/agents.yaml" \
   "the resolved agents.yaml is copied to the executor's config dir"
 # start_boot runs under `env -i` with no ALISSA_AGENT_MODEL, so this is the
 # UNSET path: the pin must be the baked default, not an alias.
-assert_eq "$(profile_cmd)" "${BASE_CMD} --model claude-fable-5" \
-  "...with the model pin applied (unset -> default claude-fable-5), exactly as the daemon role gets it"
-assert_contains "${LOG2}" "reviewer model: claude-fable-5 (ALISSA_AGENT_MODEL)" \
+assert_eq "$(profile_cmd)" "${BASE_CMD} --model claude-fable-5-1" \
+  "...with the model pin applied (unset -> default claude-fable-5-1), exactly as the daemon role gets it"
+assert_contains "${LOG2}" "reviewer model: claude-fable-5-1 (ALISSA_AGENT_MODEL)" \
   "...and the boot log names the default"
 assert_not_contains "${WORKSPACE}/.alissa-config/agents.yaml" "disable_alissa_code" \
   "...and WITHOUT disable_alissa_code, so job sessions still launch via alissa code"

--- a/docker/claude/tests-image-contract.sh
+++ b/docker/claude/tests-image-contract.sh
@@ -172,7 +172,7 @@ fi
 
 # --- baked ARG->ENV knob defaults ---
 eq "ALISSA_AGENT_PROFILE"   "claude"     "${ALISSA_AGENT_PROFILE-<unset>}"
-eq "ALISSA_AGENT_MODEL"     "claude-fable-5" "${ALISSA_AGENT_MODEL-<unset>}"
+eq "ALISSA_AGENT_MODEL"     "claude-fable-5-1" "${ALISSA_AGENT_MODEL-<unset>}"
 eq "ALISSA_ON_MISSING_HUB"  "add"        "${ALISSA_ON_MISSING_HUB-<unset>}"
 eq "ALISSA_WORKER_INTERVAL" "2"          "${ALISSA_WORKER_INTERVAL-<unset>}"
 eq "ALISSA_WORKSPACE_ROOT"  "/workspace" "${ALISSA_WORKSPACE_ROOT-<unset>}"


### PR DESCRIPTION
Closes #114

Value-only repeat of PR #111 one generation up: the `ALISSA_AGENT_MODEL` unset-default moves from `claude-fable-5` to `claude-fable-5-1` at every site PR #111 touched. No knob semantics change: `${ALISSA_AGENT_MODEL-…}` keeps `-` (explicitly-empty stays a valid opt-out), `default`/empty still omit `--model`, explicit aliases and full ids still pass through verbatim, and a mounted agents.yaml without the `alissa-managed:` marker still wins.

**Alissa tasks:** origin TASK-1565634514 · implementation TASK-1443304265 · absorbed TASK-1385697915 (the round-1 `[nit]` from PR #111 — the agents.yaml header comment left orphaned at ~45 columns by that PR's reflow — is rewrapped here, since this PR touches those exact lines).

## Sites

| site | change |
| --- | --- |
| `docker/claude/Dockerfile` | `ARG ALISSA_AGENT_MODEL="claude-fable-5-1"`; rationale comment reworded (operator decision 2026-09-01) |
| `docker/claude/entrypoint.sh` | step-2e fallback `${ALISSA_AGENT_MODEL-claude-fable-5-1}`; step-2e comments; the paragraph is reflowed so the longer id does not leave the same orphan the nit was about |
| `docker/claude/agents.yaml` | header comment default + TASK-1385697915 rewrap |
| `docker/claude/README.md` | "Pinning the reviewer model" prose + `*(unset)*` table row, env-var table default column, executor-role paragraph |
| `docker/claude/tests-image-contract.sh` | `eq "ALISSA_AGENT_MODEL" "claude-fable-5-1"` |
| `docker/claude/tests-entrypoint-executor.sh` | case 2 rendered command line + `reviewer model:` log line → `claude-fable-5-1`; case 2b untouched |

**Surviving bare `claude-fable-5` occurrences:** none. Anchored `grep -rnE 'claude-fable-5([^-]|$)' docker/` on this branch returns nothing; case 2b's explicit-value literals are `opus` and `claude-opus-4-8`, so it never carried the fable id. `grep -rn fable docker/claude/` shows 14 lines, all `claude-fable-5-1`.

**Version bump:** none. `docker/` is a repo-level path outside the dist directory and check-version-bump documents it as never requiring a bump (same as PR #111).

## Delivery notes

### Judgment calls
- The Dockerfile / entrypoint / README rationale text now reads "the latest and most capable generally-available Claude model" with the operator decision dated 2026-09-01 (the issue's date), replacing the 2026-08-30 date PR #111 carried. The issue asked to keep the rationale; the date is part of it and the old one would be misleading.
- The entrypoint step-2e comment paragraph was reflowed (not only the value swapped): the longer id pushed "appended to" onto a line of its own, the exact orphan shape TASK-1385697915 exists for, so I fixed it in the same edit rather than shipping a new instance of the nit.
- TASK-1385697915's staged patch (evidence on TASK-495451465) is not readable from this actor (the evidence endpoint 404s), so the agents.yaml rewrap is my own three-line reflow of the same paragraph. The intent (no orphaned ~45-column line) is met; the bytes may differ from the staged patch.
- No Python is touched, so style/types/unit suites are unaffected by the diff; they were still run locally (see Verification) because the acceptance criteria name them.

### Not verified — operator's gate
- [ ] `tests-image-contract.sh` (check-image): needs a docker daemon; this runner has none, the harness reports SKIPPED / exit 0. CI's "Image contract" job is the only real run of the flipped `eq` assertion — it passed on b4816ab.
- [ ] That `claude-fable-5-1` is accepted by the persisted `/login` account inside the deployed image (the pass-through is verbatim; nothing in this repo can prove model access).
- [ ] OPERATOR post-merge (from the issue): Railway runtime `ALISSA_AGENT_MODEL` currently pins `claude-opus-5` and shadows this default; reconcile it, confirm the boot log shows `reviewer model: claude-fable-5-1`, and that the next review round starts without a model-access error.
- [ ] TASK-1385697915 is at `pending_validation` with a comment naming this PR; the `validated` transition is refused until its one criterion is satisfied, which is the validator's call, not mine.

### Verification
- `bash docker/claude/tests-entrypoint-executor.sh`: PASS, 74 ok / 0 fail. Case 2 asserts `--model claude-fable-5-1` on the rendered command line and `reviewer model: claude-fable-5-1 (ALISSA_AGENT_MODEL)` in the boot log; case 2b (opus alias, `claude-opus-4-8`, `default`, empty) all pass unmodified.
- Counterfactual: with only the entrypoint fallback reverted to `claude-fable-5` (tests kept), the same suite FAILS on exactly the two case-2 assertions (rendered command line got `--model claude-fable-5`; log line `reviewer model: claude-fable-5-1` absent) and nothing else — overall FAIL / exit 1. Working tree restored from the commit afterwards.
- `bash docker/claude/tests-entrypoint-config.sh`: ALL PASS.
- `bash docker/claude/tests-image-contract.sh`: SKIPPED (no docker daemon), exit 0 — not a pass.
- `bash -n docker/claude/entrypoint.sh`: ok.
- `check-style.sh alissa-tools-github-revloop`: exit 0. `mypy src/main` (PYTHONPATH=src/main): "no issues found in 19 source files". Unit suite not run locally: no Python changed, CI runs it.
- Anchored grep for bare `claude-fable-5`: zero hits across `docker/`, `README.md`, `.github/`.

### Scope touched
- `docker/claude/Dockerfile`, `docker/claude/entrypoint.sh`, `docker/claude/agents.yaml`, `docker/claude/README.md`, `docker/claude/tests-image-contract.sh`, `docker/claude/tests-entrypoint-executor.sh` — all inside the issue's declared scope.
- `alissa-tools-github-revloop/.../version` (declared in scope): NOT touched, no bump required.
- Excursions: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjGDRdwME9tajEGtCrfNhu
