### PR TITLE
TASK-145014812: drop --permission-mode acceptEdits from the baked claude agent profile (issue #116)

### DIFF
--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -291,7 +291,11 @@ The reviewer's claude launch command lives in [`agents.yaml`](./agents.yaml). To
 pin the model, set `ALISSA_AGENT_MODEL` (see [Pinning the reviewer model](#pinning-the-reviewer-model))
 rather than editing the file; to change flags, mount your own file over
 `/home/alissa/.config/alissa/agents.yaml`. The image runs as a non-root user
-because claude refuses `--dangerously-skip-permissions` as root.
+because claude refuses `--dangerously-skip-permissions` as root. That flag is the
+whole unattended contract: do **not** pair it with an explicit `--permission-mode`
+(a mounted file included) — an explicit mode overrides the bypass and re-enables
+the hard prompts (dangerous `rm`, un-allowlisted Bash) that nothing in a headless
+container answers, so the session wedges at the dialog until it is killed.
 
 ### Pinning the reviewer model
 

--- a/docker/claude/agents.yaml
+++ b/docker/claude/agents.yaml
@@ -4,10 +4,22 @@
 # (default: claude). Without this file the worker falls back to a bare `claude`,
 # which stops on its first-run trust / permission prompt and hangs the reviewer.
 #
-# `--dangerously-skip-permissions --permission-mode acceptEdits` is what makes
-# claude run unattended. It requires a non-root user (claude refuses that flag as
-# root) — the image runs as uid 1000, which satisfies it. Reviewer posture (CR6:
-# reviewers never write) is enforced by the round directive, not by this profile.
+# `--dangerously-skip-permissions` ALONE is what makes claude run unattended: it
+# bypasses every permission prompt, so a headless session never stops to ask.
+# It requires a non-root user (claude refuses that flag as root) — the image runs
+# as uid 1000, which satisfies it. Reviewer posture (CR6: reviewers never write)
+# is enforced by the round directive, not by this profile.
+#
+# Do NOT add an explicit `--permission-mode <mode>` next to the bypass flag. An
+# explicit mode OVERRIDES the bypass: the session runs in that mode instead, and
+# every hard prompt that mode does not auto-approve comes back — Claude Code's
+# dangerous-rm check ("Dangerous rm operation on statically-unresolvable
+# target"), un-allowlisted Bash, and the like. Nothing in a headless container
+# answers those dialogs (the supervisor's `promptPatterns` below only detect and
+# escalate), so each one is a permanent wedge: this profile shipped with
+# `--permission-mode acceptEdits` alongside the bypass until 2026-09-03, and a
+# reviewer sat at exactly that rm prompt for 7+ hours holding its slot while
+# the queue re-delivered the same round (issue #116).
 #
 # To pin the reviewer model, set the ALISSA_AGENT_MODEL env var (default:
 # claude-fable-5-1) — the entrypoint rewrites the `command:` below with
@@ -21,7 +33,7 @@
 # profile at boot from ALISSA_AGENT_MODEL — do not remove this marker line, it is
 # what distinguishes the baked default from a runtime-mounted custom agents.yaml.
 claude:
-  command: claude --dangerously-skip-permissions --permission-mode acceptEdits
+  command: claude --dangerously-skip-permissions
   mode: interactive
   quietSeconds: 30
   promptPatterns:

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -602,7 +602,11 @@ if [ ! -f "${AGENTS_YAML}" ]; then
 elif ! grep -q 'alissa-managed:' "${AGENTS_YAML}"; then
   log "custom agents.yaml in effect (no alissa-managed marker) — using it verbatim, ALISSA_AGENT_MODEL ignored"
 else
-  BASE_CMD="claude --dangerously-skip-permissions --permission-mode acceptEdits"
+  # Single flag by contract (issue #116): an explicit permission-mode flag next
+  # to the bypass overrides it and re-enables hard prompts (dangerous rm,
+  # un-allowlisted Bash) that wedge a headless session. Keep this in step with
+  # the baked agents.yaml and the executor test's mirror constant.
+  BASE_CMD="claude --dangerously-skip-permissions"
   if [ -z "${AGENT_MODEL}" ] || [ "${AGENT_MODEL}" = "default" ]; then
     CLAUDE_CMD="${BASE_CMD}"
     log "reviewer model: account default (ALISSA_AGENT_MODEL='${AGENT_MODEL}') — no --model flag"

--- a/docker/claude/tests-entrypoint-executor.sh
+++ b/docker/claude/tests-entrypoint-executor.sh
@@ -211,7 +211,7 @@ EXECUTOR_UP="starting alissa bridge start"
 # agents.yaml, value only. BASE_CMD mirrors the entrypoint's step-2e constant:
 # a model pin is exactly BASE_CMD plus `--model <value>`, and no pin is exactly
 # BASE_CMD — so every model assertion compares the WHOLE line.
-BASE_CMD="claude --dangerously-skip-permissions --permission-mode acceptEdits"
+BASE_CMD="claude --dangerously-skip-permissions"
 profile_cmd() {
   sed -n -E 's/^[[:space:]]*command:[[:space:]]*//p' \
     "${WORKSPACE}/.alissa-config/agents.yaml" 2>/dev/null | head -n 1
@@ -289,6 +289,17 @@ assert_contains "${LOG2}" "reviewer model: claude-fable-5-1 (ALISSA_AGENT_MODEL)
   "...and the boot log names the default"
 assert_not_contains "${WORKSPACE}/.alissa-config/agents.yaml" "disable_alissa_code" \
   "...and WITHOUT disable_alissa_code, so job sessions still launch via alissa code"
+# Issue #116: the profile shipped `--dangerously-skip-permissions --permission-mode
+# acceptEdits` for a while, and the explicit mode OVERRIDES the bypass — sessions
+# ran in acceptEdits and wedged on hard prompts (dangerous rm) that nothing in a
+# headless container answers. BASE_CMD above already pins the whole line, but the
+# contract deserves its own named check so a re-added mode fails by name. The
+# rendered `command:` value is checked (not the whole file) because the header
+# comment explains the prohibition and so mentions the flag itself.
+case "$(profile_cmd)" in
+  *--permission-mode*) bad "the rendered claude command must NOT carry an explicit --permission-mode (it overrides --dangerously-skip-permissions and re-enables prompts)" ;;
+  *) pass "the rendered claude command carries no --permission-mode (bypass flag is the whole unattended contract)" ;;
+esac
 
 # -----------------------------------------------------------------------------
 info ""

--- a/docker/claude/tests-entrypoint-executor.sh
+++ b/docker/claude/tests-entrypoint-executor.sh
@@ -300,6 +300,12 @@ case "$(profile_cmd)" in
   *--permission-mode*) bad "the rendered claude command must NOT carry an explicit --permission-mode (it overrides --dangerously-skip-permissions and re-enables prompts)" ;;
   *) pass "the rendered claude command carries no --permission-mode (bypass flag is the whole unattended contract)" ;;
 esac
+# The rewrite above composes from the entrypoint's BASE_CMD, so it would mask a
+# mode flag re-added to the CHECKED-IN profile. Pin the source file too: its
+# unrendered `command:` must be exactly BASE_CMD, so the two agree before boot.
+assert_eq "$(sed -n -E 's/^[[:space:]]*command:[[:space:]]*//p' "${HERE}/agents.yaml" | head -n 1)" \
+  "${BASE_CMD}" \
+  "the checked-in agents.yaml command is exactly BASE_CMD (no --permission-mode, no pin)"
 
 # -----------------------------------------------------------------------------
 info ""


### PR DESCRIPTION
Closes #116

**Alissa tasks:** origin `TASK-834798535` · implementation `TASK-145014812` (soft-depends on the origin; the origin is owned by the develop-daemon actor, so a true downstream link 403s `NOT_OWNER`).

## What changed

The baked `claude` profile spawned the CLI with `--dangerously-skip-permissions --permission-mode acceptEdits`. The explicit mode overrides the bypass, so reviewer sessions really ran in acceptEdits and Claude Code's hard prompts (the dangerous-`rm` check, un-allowlisted Bash) still fired. Nothing in a headless container answers those dialogs; the supervisor's `promptPatterns` only detect and escalate. A prod reviewer sat wedged at that prompt for 7+ hours on 2026-09-03 while the queue re-delivered the round.

- `docker/claude/agents.yaml` — profile command is now `claude --dangerously-skip-permissions`; the header comment states the single-flag contract and why an explicit permission-mode must never be re-added next to the bypass.
- `docker/claude/entrypoint.sh` — the step-2e `BASE_CMD` constant the model-pin rewrite composes from drops the mode flag (comment names the contract).
- `docker/claude/tests-entrypoint-executor.sh` — the mirror `BASE_CMD` drops the flag, so all six whole-line model-pin assertions now pin the single-flag form; plus two named guards: the rendered command carries no `--permission-mode`, and the checked-in profile's unrendered `command:` equals `BASE_CMD` exactly.
- `docker/claude/README.md` — the "mount your own agents.yaml to change flags" paragraph now carries the contract so a custom mount does not re-create the conflict.

No version bump: the guard workflow exempts `docker/` and `.github/`, and no packaged file changed.

## Delivery notes

### Judgment calls
- **Criterion 3 read as "no executable spawn/assert line carries the flag", not "the string is absent from the repo".** Criterion 2 requires the comment block to name `--permission-mode` while forbidding it, so a literal zero-hit grep is impossible. After this PR the string appears only in: the agents.yaml header comment (required), one README sentence, and the executor test's negative guard. Every composing/asserting line (`agents.yaml` `command:`, entrypoint `BASE_CMD`, test `BASE_CMD`) is single-flag. The entrypoint's own comment says "permission-mode flag" without the dashes so the spawn script greps clean.
- **Added a static assertion on the checked-in profile, beyond the issue's list.** The entrypoint rewrites `command:` from `BASE_CMD` at boot, so a rendered-command guard alone would mask the flag creeping back into the source file. Verified by counterfactual: reintroducing the flag in agents.yaml only failed just this new assertion.
- **README edit is one paragraph, not a section.** The issue's scope is `docker/claude/*`; the mount-your-own-file paragraph is the one place a reader would re-create the conflict, so it carries the contract and nothing else was reworded.
- **`.github/workflows/check-entrypoint.yaml` was in the declared scope but needed no change.** It contains no command-line assertion; it only runs the test scripts, which are where the assertion lives.

### Not verified — operator's gate
- [ ] That `claude` actually honours `--dangerously-skip-permissions` alone without a hard prompt in the container. The claim comes from the issue's prod observation and Claude Code's flag semantics; this environment has no docker and no live reviewer spawn to reproduce the wedge or its absence.
- [ ] `check-image.yaml` (docker build + in-image `tests-image-contract.sh`, which compares the baked agents.yaml sha to the source). CI-only; no docker on this runner. The sha check reads the source file, so it is expected to pass.
- [ ] That no other repo (devloop, orcloop) is fed from this file. Out of scope per the issue; this PR touches only this repo.

### Verification
- All seven entrypoint suites, run locally from the worktree after the change (each boots the real `entrypoint.sh` against stubbed CLIs): executor 77 ok, ui 30 ok, config 60 ok, identity 12 ok, auth 31 ok, prune 51 ok, chown 23 ok. Zero FAIL lines.
- Counterfactual A: put the flag back in the entrypoint `BASE_CMD` → executor suite exits 1 with all six model-pin `assert_eq`s plus the rendered-command guard failing by name. Restored from HEAD.
- Counterfactual B: put the flag back in the checked-in agents.yaml `command:` only → executor suite exits 1 with exactly the new static assertion failing. Restored from HEAD.
- `bash -n` on the two edited shell files; agents.yaml is comment-only plus the one-token command change (no YAML structure touched; pyyaml is not installed here so it was not parsed).
- Python check scripts (`check-style.sh`, `check-types.sh`, `tests-unit.sh`) not run: no `.py` file changed.

### Scope touched
- `docker/claude/agents.yaml` (in scope) — command line + comment block.
- `docker/claude/entrypoint.sh` (in scope) — one constant + a four-line comment in step 2e.
- `docker/claude/tests-entrypoint-executor.sh` (in scope) — mirror constant + two new assertions.
- `docker/claude/README.md` (in scope, `docker/claude/*`) — one paragraph extended.
- `.github/workflows/check-entrypoint.yaml` (in scope) — read, unchanged.
- No excursions outside `docker/claude/`.

## Review round 1 — approve (alissa-app, head 4b3ec73)

0 blockers, 0 majors, 2 minors, 1 nit. This branch is terminal; nothing further is pushed here.

- `[minor]` `ALISSA_AGENT_MODEL` can smuggle flags into the spawn → `[triage:pursue]` → follow-up PR #118 (cut from `main`, `Follow-up-To: #117`, closes no issue; merges cleanly with this PR in either order).
- `[minor]` sibling images (devloop, orcloop) still carry the flag pair → `[triage:later]` → TASK-912931013.
- `[nit]` the new negative guard passes vacuously on an empty read → `[triage:later]` → TASK-345477539, sequenced after this PR merges because it edits a block this PR introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVn2ixtkReYSttFSdiU4Qu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fahera-mx/codesmith/alissa-github-review-daemon/pr/117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791047706&installation_model_id=434695&pr_number=117&repository=fahera-mx%2Falissa-github-review-daemon&return_to=https%3A%2F%2Fgithub.com%2Ffahera-mx%2Falissa-github-review-daemon%2Fpull%2F117&signature=0756969c3be01cd76d30afc719fa60c571c2246b96526c339c6fbd63ab0f76e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
