### PR TITLE
TASK-145014812: refuse a model pin that smuggles flags into the reviewer spawn (follow-up to #117)

### DIFF
--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -316,7 +316,13 @@ for `effective reviewer command:`).
 | `default` *or* empty | `claude …` (no `--model` — restores account default) |
 
 The value passes through **verbatim** — both aliases (`opus`, `sonnet`) and full
-ids (`claude-opus-4-8`) are valid; there is no allowlist.
+ids (`claude-opus-4-8`) are valid; there is no allowlist. There is a **shape
+rule**, though: the value must be one bare token, with no whitespace and no
+leading dash, and the entrypoint refuses to boot otherwise. Because the pin is
+appended verbatim, anything else would smuggle extra flags into the reviewer
+spawn — and an explicit `--permission-mode` there overrides
+`--dangerously-skip-permissions` and brings back the permission prompts that
+wedge headless sessions (issue #116). Pin models with this knob, never flags.
 
 **Precedence.** The entrypoint only rewrites the **baked default** profile, which
 it recognizes by an `alissa-managed:` marker comment. A custom `agents.yaml`

--- a/docker/claude/README.md
+++ b/docker/claude/README.md
@@ -317,12 +317,15 @@ for `effective reviewer command:`).
 
 The value passes through **verbatim** — both aliases (`opus`, `sonnet`) and full
 ids (`claude-opus-4-8`) are valid; there is no allowlist. There is a **shape
-rule**, though: the value must be one bare token, with no whitespace and no
-leading dash, and the entrypoint refuses to boot otherwise. Because the pin is
-appended verbatim, anything else would smuggle extra flags into the reviewer
-spawn — and an explicit `--permission-mode` there overrides
-`--dangerously-skip-permissions` and brings back the permission prompts that
-wedge headless sessions (issue #116). Pin models with this knob, never flags.
+rule**, though: the value must be one bare token of letters, digits, dot,
+underscore or dash (`[A-Za-z0-9._-]`, the same rule the CLI applies to every
+value it puts on this launch line) that does not start with a dash, and the
+entrypoint refuses to boot otherwise. The rendered command is typed into the agent's shell, so any other
+character would smuggle flags or commands into the reviewer spawn — and an
+explicit `--permission-mode` there overrides `--dangerously-skip-permissions`
+and brings back the permission prompts that wedge headless sessions (issue
+#116). Leading and trailing whitespace is trimmed, so a padded paste still
+boots. Pin models with this knob, never flags.
 
 **Precedence.** The entrypoint only rewrites the **baked default** profile, which
 it recognizes by an `alissa-managed:` marker comment. A custom `agents.yaml`

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -597,6 +597,13 @@ AGENTS_YAML="${HOME}/.config/alissa/agents.yaml"
 # Default `claude-fable-5-1` only when UNSET (use `-`, not `:-`): an explicitly
 # empty value is a valid opt-out and must NOT be re-defaulted back to the pin.
 AGENT_MODEL="${ALISSA_AGENT_MODEL-claude-fable-5-1}"
+# Trim leading/trailing whitespace first: a padded `opus ` pasted out of a
+# platform env editor is a working configuration at base (the shell drops the
+# padding when it splits the command line) and must not become a boot refusal
+# at the next redeploy. Interior whitespace is NOT trimmed — it is a smuggling
+# shape and the shape check below refuses it.
+AGENT_MODEL="${AGENT_MODEL#"${AGENT_MODEL%%[![:space:]]*}"}"
+AGENT_MODEL="${AGENT_MODEL%"${AGENT_MODEL##*[![:space:]]}"}"
 if [ ! -f "${AGENTS_YAML}" ]; then
   log "WARN: ${AGENTS_YAML} not found — skipping model pin (worker will fall back to a bare claude)"
 elif ! grep -q 'alissa-managed:' "${AGENTS_YAML}"; then
@@ -607,17 +614,23 @@ else
     CLAUDE_CMD="${BASE_CMD}"
     log "reviewer model: account default (ALISSA_AGENT_MODEL='${AGENT_MODEL}') — no --model flag"
   else
-    # The pin is appended VERBATIM (no model allowlist, by design), which makes
-    # it a route for smuggling extra flags into the reviewer spawn: a value of
-    # `opus --permission-mode acceptEdits` renders a command whose explicit mode
-    # overrides --dangerously-skip-permissions and re-enables the hard prompts
-    # that wedge headless sessions (issue #116, PR #117 round-1 finding). A
-    # model alias or id is one bare token, so refuse anything with whitespace
-    # or a leading dash — same posture as the executor-id validation above:
-    # a mis-set knob is fatal at boot with a message that names the fix.
+    # The pin is appended VERBATIM (no model allowlist, by design) to a command
+    # line that the CLI later TYPES into the agent's tmux pane (`send-keys -l`
+    # + Enter), so the pane's shell splits and expands it. That makes the pin a
+    # shell-metacharacter surface, not just a flag surface: `opus --permission-
+    # mode acceptEdits`, `opus${IFS}--permission-mode${IFS}acceptEdits` and
+    # `opus;<cmd>` all reach the shell intact and the first two rebuild the
+    # exact argv that wedged issue #116 (PR #117 / PR #118 round-1 findings).
+    # So the check is POSITIVE, like the executor-id validation above: a model
+    # alias or id is one bare token of letters, digits, dot, underscore or dash
+    # — the CLI's own ENV_VALUE_RE for values it interpolates into this same
+    # launch string — and it does not START with a dash (that class admits
+    # `-`, so a bare `--permission-mode` would otherwise pass and render as
+    # `--model --permission-mode`). Anything else is fatal at boot with a
+    # message naming the fix. A shape rule, not an allowlist on model names.
     case "${AGENT_MODEL}" in
-      -*|*[[:space:]]*)
-        die "ALISSA_AGENT_MODEL='${AGENT_MODEL}' is not a model alias or id — it must be one bare token (no whitespace, no leading dash). The value is appended verbatim to the claude command as '--model <value>', so anything else smuggles extra flags into the reviewer spawn; an explicit --permission-mode there overrides --dangerously-skip-permissions and re-enables the permission prompts that wedge headless sessions (issue #116). Use an alias or id such as 'opus' or 'claude-fable-5-1', or 'default' / empty to inherit the account default." ;;
+      -*|*[!A-Za-z0-9._-]*)
+        die "ALISSA_AGENT_MODEL='${AGENT_MODEL}' is not a model alias or id — it must be one bare token of letters, digits, dot, underscore or dash, not starting with a dash. The value is appended verbatim to the claude command as '--model <value>' and that command is typed into the agent's shell, so any other character smuggles flags or commands into the reviewer spawn; an explicit --permission-mode there overrides --dangerously-skip-permissions and re-enables the permission prompts that wedge headless sessions (issue #116). Use an alias or id such as 'opus' or 'claude-fable-5-1', or 'default' / empty to inherit the account default." ;;
     esac
     CLAUDE_CMD="${BASE_CMD} --model ${AGENT_MODEL}"
     log "reviewer model: ${AGENT_MODEL} (ALISSA_AGENT_MODEL)"

--- a/docker/claude/entrypoint.sh
+++ b/docker/claude/entrypoint.sh
@@ -607,6 +607,18 @@ else
     CLAUDE_CMD="${BASE_CMD}"
     log "reviewer model: account default (ALISSA_AGENT_MODEL='${AGENT_MODEL}') — no --model flag"
   else
+    # The pin is appended VERBATIM (no model allowlist, by design), which makes
+    # it a route for smuggling extra flags into the reviewer spawn: a value of
+    # `opus --permission-mode acceptEdits` renders a command whose explicit mode
+    # overrides --dangerously-skip-permissions and re-enables the hard prompts
+    # that wedge headless sessions (issue #116, PR #117 round-1 finding). A
+    # model alias or id is one bare token, so refuse anything with whitespace
+    # or a leading dash — same posture as the executor-id validation above:
+    # a mis-set knob is fatal at boot with a message that names the fix.
+    case "${AGENT_MODEL}" in
+      -*|*[[:space:]]*)
+        die "ALISSA_AGENT_MODEL='${AGENT_MODEL}' is not a model alias or id — it must be one bare token (no whitespace, no leading dash). The value is appended verbatim to the claude command as '--model <value>', so anything else smuggles extra flags into the reviewer spawn; an explicit --permission-mode there overrides --dangerously-skip-permissions and re-enables the permission prompts that wedge headless sessions (issue #116). Use an alias or id such as 'opus' or 'claude-fable-5-1', or 'default' / empty to inherit the account default." ;;
+    esac
     CLAUDE_CMD="${BASE_CMD} --model ${AGENT_MODEL}"
     log "reviewer model: ${AGENT_MODEL} (ALISSA_AGENT_MODEL)"
   fi

--- a/docker/claude/tests-entrypoint-executor.sh
+++ b/docker/claude/tests-entrypoint-executor.sh
@@ -331,6 +331,33 @@ assert_eq "$(profile_cmd)" "${BASE_CMD}" \
 assert_contains "${LOG2E}" "reviewer model: account default (ALISSA_AGENT_MODEL='')" \
   "...and the log says so"
 
+# Verbatim pass-through is the feature, but it is also a second route back into
+# issue #116: a pin carrying flags renders them straight into the spawn, and the
+# rendered-command assertions never see it because every value above is a bare
+# token. A model alias or id has no whitespace and no leading dash, so those two
+# shapes are refused at boot (PR #117 round-1 finding).
+LOG2F="${TMPROOT}/model-smuggled-flag.log"
+model_boot "${LOG2F}" "ALISSA_AGENT_MODEL=opus --permission-mode acceptEdits"
+[ "${BOOT_STATUS}" != "0" ] && pass "a model pin carrying whitespace (smuggled flags) is fatal at BOOT" \
+  || bad "a pin of 'opus --permission-mode acceptEdits' should not have booted"
+assert_contains "${LOG2F}" "is not a model alias or id" \
+  "the refusal names the shape rule"
+assert_contains "${LOG2F}" "overrides --dangerously-skip-permissions" \
+  "...and why a smuggled flag is the hazard"
+assert_no_file "${SPY}/bridge-argv" "nothing registers on a refused pin"
+case "$(profile_cmd)" in
+  *--permission-mode*) bad "the rendered command must never carry the smuggled flag" ;;
+  *) pass "the rendered command never carried the smuggled flag" ;;
+esac
+
+LOG2G="${TMPROOT}/model-leading-dash.log"
+model_boot "${LOG2G}" "ALISSA_AGENT_MODEL=--permission-mode"
+[ "${BOOT_STATUS}" != "0" ] && pass "a model pin with a leading dash (a bare flag) is fatal at BOOT" \
+  || bad "a pin of '--permission-mode' should not have booted"
+assert_contains "${LOG2G}" "is not a model alias or id" \
+  "the refusal names the shape rule"
+assert_no_file "${SPY}/bridge-argv" "nothing registers on a refused pin"
+
 # -----------------------------------------------------------------------------
 info ""
 info "3. the executor id is required and validated"

--- a/docker/claude/tests-entrypoint-executor.sh
+++ b/docker/claude/tests-entrypoint-executor.sh
@@ -332,31 +332,53 @@ assert_contains "${LOG2E}" "reviewer model: account default (ALISSA_AGENT_MODEL=
   "...and the log says so"
 
 # Verbatim pass-through is the feature, but it is also a second route back into
-# issue #116: a pin carrying flags renders them straight into the spawn, and the
+# issue #116: the rendered command is TYPED into the agent's tmux pane, so the
+# pane's shell splits and expands whatever the pin carries, and the
 # rendered-command assertions never see it because every value above is a bare
-# token. A model alias or id has no whitespace and no leading dash, so those two
-# shapes are refused at boot (PR #117 round-1 finding).
-LOG2F="${TMPROOT}/model-smuggled-flag.log"
-model_boot "${LOG2F}" "ALISSA_AGENT_MODEL=opus --permission-mode acceptEdits"
-[ "${BOOT_STATUS}" != "0" ] && pass "a model pin carrying whitespace (smuggled flags) is fatal at BOOT" \
-  || bad "a pin of 'opus --permission-mode acceptEdits' should not have booted"
-assert_contains "${LOG2F}" "is not a model alias or id" \
-  "the refusal names the shape rule"
-assert_contains "${LOG2F}" "overrides --dangerously-skip-permissions" \
-  "...and why a smuggled flag is the hazard"
-assert_no_file "${SPY}/bridge-argv" "nothing registers on a refused pin"
-case "$(profile_cmd)" in
-  *--permission-mode*) bad "the rendered command must never carry the smuggled flag" ;;
-  *) pass "the rendered command never carried the smuggled flag" ;;
-esac
+# token. The entrypoint therefore checks the shape POSITIVELY — one bare token
+# of [A-Za-z0-9._-], the CLI's own ENV_VALUE_RE, not starting with a dash (the
+# class admits `-`, so a bare flag needs its own arm) — and refuses the rest at
+# boot (PR #117 / PR #118 round-1 findings). A refused pin dies in step 2e, BEFORE
+# 2e-ii copies the profile, so the strongest true assertion is "no profile was
+# rendered at all", not a match against an empty read.
+refused_pin() {  # <log> <value> <label>
+  model_boot "$1" "ALISSA_AGENT_MODEL=$2"
+  [ "${BOOT_STATUS}" != "0" ] && pass "$3 is fatal at BOOT" \
+    || bad "a pin of '$2' should not have booted"
+  assert_contains "$1" "is not a model alias or id" \
+    "...the refusal names the shape rule"
+  assert_no_file "${SPY}/bridge-argv" "...nothing registers on a refused pin"
+  assert_no_file "${WORKSPACE}/.alissa-config/agents.yaml" \
+    "...and a refused pin renders no profile at all"
+}
+refused_pin "${TMPROOT}/model-smuggled-flag.log" 'opus --permission-mode acceptEdits' \
+  "a model pin carrying whitespace (smuggled flags)"
+assert_contains "${TMPROOT}/model-smuggled-flag.log" "overrides --dangerously-skip-permissions" \
+  "...and the refusal says why a smuggled flag is the hazard"
+refused_pin "${TMPROOT}/model-leading-dash.log" '--permission-mode' \
+  "a model pin that is a bare flag"
+# No literal whitespace, no leading dash — the pane's shell expands ${IFS} back
+# into the issue #116 argv. This is the case a deny-list on those two shapes
+# let through (PR #118 round 1); the positive class refuses the `$`, `{`, `}`.
+refused_pin "${TMPROOT}/model-ifs.log" 'opus${IFS}--permission-mode${IFS}acceptEdits' \
+  "a model pin rebuilding the flag through \${IFS}"
+refused_pin "${TMPROOT}/model-semicolon.log" 'opus;id' \
+  "a model pin carrying a shell command separator"
 
-LOG2G="${TMPROOT}/model-leading-dash.log"
-model_boot "${LOG2G}" "ALISSA_AGENT_MODEL=--permission-mode"
-[ "${BOOT_STATUS}" != "0" ] && pass "a model pin with a leading dash (a bare flag) is fatal at BOOT" \
-  || bad "a pin of '--permission-mode' should not have booted"
-assert_contains "${LOG2G}" "is not a model alias or id" \
-  "the refusal names the shape rule"
-assert_no_file "${SPY}/bridge-argv" "nothing registers on a refused pin"
+# Padding is NOT smuggling: a copy-pasted `opus ` boots at base (the shell drops
+# the padding) and must keep booting — trimmed, pinned, and logged as `opus`.
+# The same trim makes `default ` take the no-`--model` path instead of being
+# pinned as a model literally named "default ".
+LOG2H="${TMPROOT}/model-padded.log"
+model_boot "${LOG2H}" "ALISSA_AGENT_MODEL= opus "
+assert_eq "$(profile_cmd)" "${BASE_CMD} --model opus" \
+  "a padded pin (' opus ') is trimmed and pinned as opus, not refused"
+assert_contains "${LOG2H}" "reviewer model: opus (ALISSA_AGENT_MODEL)" \
+  "...and the log names the trimmed value"
+LOG2I="${TMPROOT}/model-padded-default.log"
+model_boot "${LOG2I}" "ALISSA_AGENT_MODEL=default "
+assert_eq "$(profile_cmd)" "${BASE_CMD}" \
+  "a padded 'default ' still omits --model"
 
 # -----------------------------------------------------------------------------
 info ""


### PR DESCRIPTION
Follow-up to PR #117 (issue #116), round-1 review by alissa-app, finding `[minor]` on `docker/claude/entrypoint.sh` ("`ALISSA_AGENT_MODEL` is a second route back into #116, and the new guards cannot see it"), triaged `[triage:pursue]`.

**Alissa tasks:** origin `TASK-834798535` · implementation `TASK-145014812`.

Follow-up-To: #117

## What changed

`ALISSA_AGENT_MODEL` is appended verbatim to the claude command with no model allowlist, by design. That made it a route for smuggling flags into the reviewer spawn: a pin of `opus --permission-mode acceptEdits` rendered `claude --dangerously-skip-permissions --model opus --permission-mode acceptEdits` and reproduced the wedge in issue 116 while every command-line assertion in PR #117 stayed green, because the suite only ever renders bare-token values.

- `docker/claude/entrypoint.sh` — step 2e trims leading/trailing whitespace, then refuses (`die`, the same posture as the executor-id validation) any pin that is not one bare token of `[A-Za-z0-9._-]` not starting with a dash, at the point where the value is consumed. The rendered command is typed into the agent's shell, so the check is a positive class (the CLI's own `ENV_VALUE_RE`), not a list of bad shapes. `default` / empty are untouched.
- `docker/claude/tests-entrypoint-executor.sh` — four refusal cases at the end of section 2b (whitespace, bare flag, `${IFS}` reconstitution, `;` separator) sharing one helper that asserts the boot is fatal, the message names the rule, nothing registers, and no profile was rendered; plus two padding cases (` opus ` pins `opus`, `default ` omits `--model`).
- `docker/claude/README.md` — "Pinning the reviewer model" gains the shape rule next to the "no allowlist" sentence.

**Merge order.** This branch is cut from `main` and based on `main`, not on PR #117's approved branch, which must not move. It does not depend on PR #117 for correctness and merges cleanly with it in either order (verified with `git merge-tree` on both branches: no conflicts, both step-2e changes present in the merged tree). Until PR #117 merges, the entrypoint on this branch still composes the two-flag `BASE_CMD`; the guard closes the injection route independently of which base command it protects.

No version bump: only `docker/` files changed.

## Delivery notes

### Judgment calls
- **Refuse rather than strip-and-warn.** The reviewer offered both. A silently stripped flag hides an operator mistake behind a WARN nobody reads; every other mis-set knob in this entrypoint (role, executor id, reviewer identity) is fatal at boot with a message naming the fix, so the pin follows that posture.
- **Positive shape class instead of a `--permission-mode` string match or a deny-list.** Round 1 showed a deny-list on two shapes is the wrong tool in front of a shell-typed value (`${IFS}` rebuilt the argv). `[A-Za-z0-9._-]`, not starting with a dash, is what a model alias or id actually is, and it keeps the deliberate no-allowlist contract on model names intact.
- **Guard placed inside the branch that appends the pin**, not at variable resolution, so a custom-mounted agents.yaml (which ignores the pin) is not killed by a value that would never be used.

### Not verified — operator's gate
- [ ] Live container boot with a malformed pin (no docker here). The refusal is proven only through the stubbed-CLI entrypoint harness the suite uses.
- [ ] `check-image.yaml` (docker build + in-image contract): CI-only.

### Verification
- `bash docker/claude/tests-entrypoint-executor.sh` at `0b27880`: 94 ok, 0 FAIL.
- Counterfactual (round 1 head): `case` guard deleted → 8 FAILs in the refusal cases. Counterfactual (round-1 fix): deny-list restored in place of the positive class → exactly the `${IFS}` and `;` cases fail (8 assertions), padding cases still pass. Restored from the fixed copy each time.
- `git merge-tree --write-tree` of this branch with PR #117's branch: exit 0, merged tree carries the single-flag `BASE_CMD`, PR #117's two assertions and this guard together.
- `bash -n` on both edited shell files. Python check scripts not run: no `.py` changed.

### Scope touched
- `docker/claude/entrypoint.sh` — the trim after the default is resolved and the shape check inside step 2e.
- `docker/claude/tests-entrypoint-executor.sh` — six cases and one helper appended to section 2b.
- `docker/claude/README.md` — one paragraph extended.
- No files outside `docker/claude/`. The `[nit]` from the same round (vacuous guard on an empty read) is deliberately NOT in this PR: it edits a block PR #117 introduces and is registered as TASK-345477539, sequenced after that merge.

## Review round 1 — request_changes (alissa-app, head 83f00e2) → fixed in 0b27880

- `[major]` deny-list bypassed via `${IFS}` (command is typed into a tmux shell) → `[triage:pursue]` → positive class + leading-dash arm, `${IFS}` and `;` refusal cases.
- `[minor]` padded pin becomes a boot refusal → `[triage:pursue]` → leading/trailing trim before the default test; two padding cases.
- `[minor]` the implementation task's DoD sentence "grep returns nothing" contradicts criterion 2 → `[triage:pursue]` → DoD on TASK-145014812 re-scoped in place to composing lines only, with a validator comment on the task.
- `[nit]` vacuous empty-read match in the refusal cases → `[triage:pursue]` → `assert_no_file` on the rendered profile.

## Review round 2 — approve (alissa-app, head 0b27880)

All four round-1 findings verified fixed by the reviewer. One `[nit]` (README line wrap) → `[triage:later]` → folded into TASK-345477539, the post-merge cleanup already registered from PR #117 round 1. This branch is terminal; nothing further is pushed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVn2ixtkReYSttFSdiU4Qu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fahera-mx/codesmith/alissa-github-review-daemon/pr/118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791053032&installation_model_id=434695&pr_number=118&repository=fahera-mx%2Falissa-github-review-daemon&return_to=https%3A%2F%2Fgithub.com%2Ffahera-mx%2Falissa-github-review-daemon%2Fpull%2F118&signature=702f3e92572cd67b2db0e522dab890be701f0c39f1c953f83a5b5590629f7b4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

